### PR TITLE
feat: WiredForm widget

### DIFF
--- a/apps/skribble_storybook/lib/pages/inputs_page.dart
+++ b/apps/skribble_storybook/lib/pages/inputs_page.dart
@@ -15,6 +15,8 @@ class InputsPage extends HookWidget {
     final sliderValue = useState(0.5);
     final comboValue = useState<String?>(null);
     final switchValue = useState(false);
+    final formKey = useMemoized(GlobalKey<FormState>.new);
+    final formStatus = useState('Form not validated yet');
 
     return Scaffold(
       appBar: WiredAppBar(
@@ -30,10 +32,7 @@ class InputsPage extends HookWidget {
               ComponentShowcase(
                 title: 'Text Field',
                 description: 'Single-line text input with hand-drawn border.',
-                child: WiredInput(
-                  hintText: 'Enter text...',
-                  onChanged: (v) {},
-                ),
+                child: WiredInput(hintText: 'Enter text...', onChanged: (v) {}),
               ),
               ComponentShowcase(
                 title: 'With Label',
@@ -62,6 +61,74 @@ class InputsPage extends HookWidget {
                 child: WiredTextArea(
                   hintText: 'Write something...',
                   onChanged: (v) {},
+                ),
+              ),
+            ],
+          ),
+          ShowcaseSection(
+            title: 'WiredForm',
+            children: [
+              ComponentShowcase(
+                title: 'Validated Form',
+                description: 'Hand-drawn form container with validation.',
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    SizedBox(
+                      width: 320,
+                      child: WiredForm(
+                        formKey: formKey,
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            TextFormField(
+                              decoration: const InputDecoration(
+                                labelText: 'Email',
+                              ),
+                              validator: (value) {
+                                if (value == null || value.isEmpty) {
+                                  return 'Email required';
+                                }
+                                if (!value.contains('@')) {
+                                  return 'Enter a valid email';
+                                }
+                                return null;
+                              },
+                            ),
+                            const SizedBox(height: 12),
+                            TextFormField(
+                              decoration: const InputDecoration(
+                                labelText: 'Name',
+                              ),
+                              validator: (value) {
+                                if (value == null || value.isEmpty) {
+                                  return 'Name required';
+                                }
+                                return null;
+                              },
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    Row(
+                      children: [
+                        WiredButton(
+                          onPressed: () {
+                            final isValid =
+                                formKey.currentState?.validate() ?? false;
+                            formStatus.value = isValid
+                                ? 'Form valid'
+                                : 'Form invalid';
+                          },
+                          child: const Text('Validate Form'),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(child: Text(formStatus.value)),
+                      ],
+                    ),
+                  ],
                 ),
               ),
             ],
@@ -183,10 +250,7 @@ class InputsPage extends HookWidget {
               ComponentShowcase(
                 title: 'Search',
                 description: 'Rounded rect input with search icon.',
-                child: WiredSearchBar(
-                  hintText: 'Search...',
-                  onChanged: (v) {},
-                ),
+                child: WiredSearchBar(hintText: 'Search...', onChanged: (v) {}),
               ),
             ],
           ),

--- a/packages/skribble/lib/skribble.dart
+++ b/packages/skribble/lib/skribble.dart
@@ -29,6 +29,7 @@ export 'src/wired_elevated_button.dart';
 export 'src/wired_expansion_tile.dart';
 export 'src/wired_fab.dart';
 export 'src/wired_filter_chip.dart';
+export 'src/wired_form.dart';
 export 'src/wired_icon_button.dart';
 export 'src/wired_input.dart';
 export 'src/wired_list_tile.dart';

--- a/packages/skribble/lib/src/wired_form.dart
+++ b/packages/skribble/lib/src/wired_form.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+import 'canvas/wired_canvas.dart';
+import 'rough/skribble_rough.dart';
+import 'wired_base.dart';
+
+/// A hand-drawn wrapper around Flutter's [Form].
+class WiredForm extends HookWidget {
+  final Widget child;
+  final GlobalKey<FormState>? formKey;
+  final AutovalidateMode autovalidateMode;
+  final VoidCallback? onChanged;
+  final EdgeInsetsGeometry padding;
+  final BorderRadius borderRadius;
+
+  const WiredForm({
+    super.key,
+    required this.child,
+    this.formKey,
+    this.autovalidateMode = AutovalidateMode.disabled,
+    this.onChanged,
+    this.padding = const EdgeInsets.all(16),
+    this.borderRadius = const BorderRadius.all(Radius.circular(16)),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return buildWiredElement(
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: WiredCanvas(
+              painter: WiredRoundedRectangleBase(borderRadius: borderRadius),
+              fillerType: RoughFilter.noFiller,
+            ),
+          ),
+          Padding(
+            padding: padding,
+            child: Form(
+              key: formKey,
+              autovalidateMode: autovalidateMode,
+              onChanged: onChanged,
+              child: child,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/skribble/test/widgets/wired_form_test.dart
+++ b/packages/skribble/test/widgets/wired_form_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:skribble/skribble.dart';
+
+void main() {
+  group('WiredForm', () {
+    testWidgets('renders child content', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 320,
+              child: WiredForm(child: Text('Form body')),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(WiredForm), findsOneWidget);
+      expect(find.text('Form body'), findsOneWidget);
+      expect(find.byType(Form), findsOneWidget);
+      expect(find.byType(RepaintBoundary), findsWidgets);
+    });
+
+    testWidgets('forwards validation through provided form key', (
+      tester,
+    ) async {
+      final formKey = GlobalKey<FormState>();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 320,
+              child: WiredForm(
+                formKey: formKey,
+                child: TextFormField(
+                  validator: (value) =>
+                      value == null || value.isEmpty ? 'Required' : null,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(formKey.currentState!.validate(), isFalse);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Required'), findsOneWidget);
+    });
+
+    testWidgets('calls onChanged when form fields change', (tester) async {
+      var changed = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 320,
+              child: WiredForm(
+                onChanged: () => changed += 1,
+                child: TextFormField(),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextFormField), 'wired');
+      await tester.pumpAndSettle();
+
+      expect(changed, greaterThan(0));
+    });
+
+    testWidgets('supports autovalidate mode', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 320,
+              child: WiredForm(
+                autovalidateMode: AutovalidateMode.always,
+                child: TextFormField(
+                  validator: (value) =>
+                      value == null || value.length < 3 ? 'Too short' : null,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('Too short'), findsOneWidget);
+    });
+
+    testWidgets('applies default padding around form body', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(width: 320, child: WiredForm(child: Placeholder())),
+          ),
+        ),
+      );
+
+      final padding = tester.widget<Padding>(
+        find
+            .descendant(
+              of: find.byType(WiredForm),
+              matching: find.byType(Padding),
+            )
+            .first,
+      );
+
+      expect(padding.padding, const EdgeInsets.all(16));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Adds `WiredForm` — a hand-drawn wrapper around Flutter's `Form` widget.

### Changes
- **`WiredForm`** widget with `WiredRoundedRectangleBase` border
- Supports `formKey`, `autovalidateMode`, `onChanged`, `padding`, `borderRadius`
- Widget tests: rendering, validation, onChanged, autovalidate, default padding
- Storybook showcase with interactive validation demo
- Barrel export in `skribble.dart`

### Parity
Implements **Form** from the missing widgets list.