### PR TITLE
feat: WiredCalendarDatePicker

### DIFF
--- a/apps/skribble_storybook/lib/pages/data_display_page.dart
+++ b/apps/skribble_storybook/lib/pages/data_display_page.dart
@@ -37,6 +37,26 @@ class DataDisplayPage extends HookWidget {
             ],
           ),
           ShowcaseSection(
+            title: 'WiredCalendarDatePicker',
+            children: [
+              ComponentShowcase(
+                title: 'Calendar Date Picker (M3)',
+                description:
+                    'Flutter CalendarDatePicker with hand-drawn border.',
+                child: SizedBox(
+                  width: 340,
+                  height: 360,
+                  child: WiredCalendarDatePicker(
+                    initialDate: DateTime.now(),
+                    firstDate: DateTime(2020),
+                    lastDate: DateTime(2030),
+                    onDateChanged: (_) {},
+                  ),
+                ),
+              ),
+            ],
+          ),
+          ShowcaseSection(
             title: 'WiredDatePicker',
             children: [
               ComponentShowcase(
@@ -117,21 +137,15 @@ class DataDisplayPage extends HookWidget {
                     WiredDataColumn(label: Text('Score')),
                   ],
                   rows: const [
-                    WiredDataRow(cells: [
-                      Text('Alice'),
-                      Text('Engineer'),
-                      Text('95'),
-                    ]),
-                    WiredDataRow(cells: [
-                      Text('Bob'),
-                      Text('Designer'),
-                      Text('88'),
-                    ]),
-                    WiredDataRow(cells: [
-                      Text('Carol'),
-                      Text('Manager'),
-                      Text('92'),
-                    ]),
+                    WiredDataRow(
+                      cells: [Text('Alice'), Text('Engineer'), Text('95')],
+                    ),
+                    WiredDataRow(
+                      cells: [Text('Bob'), Text('Designer'), Text('88')],
+                    ),
+                    WiredDataRow(
+                      cells: [Text('Carol'), Text('Manager'), Text('92')],
+                    ),
                   ],
                 ),
               ),

--- a/packages/skribble/lib/skribble.dart
+++ b/packages/skribble/lib/skribble.dart
@@ -14,6 +14,7 @@ export 'src/wired_bottom_nav.dart';
 export 'src/wired_bottom_sheet.dart';
 export 'src/wired_button.dart';
 export 'src/wired_calendar.dart';
+export 'src/wired_calendar_date_picker.dart';
 export 'src/wired_card.dart';
 export 'src/wired_checkbox.dart';
 export 'src/wired_checkbox_list_tile.dart';

--- a/packages/skribble/lib/src/wired_calendar_date_picker.dart
+++ b/packages/skribble/lib/src/wired_calendar_date_picker.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+import 'canvas/wired_canvas.dart';
+import 'rough/skribble_rough.dart';
+import 'wired_base.dart';
+
+/// A hand-drawn calendar date picker that wraps Flutter's
+/// [CalendarDatePicker] for full API parity.
+///
+/// Provides the same parameters as [CalendarDatePicker] while adding
+/// a sketchy rounded-rectangle border around the picker.
+class WiredCalendarDatePicker extends HookWidget {
+  /// The initially selected date.
+  final DateTime initialDate;
+
+  /// The earliest selectable date.
+  final DateTime firstDate;
+
+  /// The latest selectable date.
+  final DateTime lastDate;
+
+  /// Called when the user selects a date.
+  final ValueChanged<DateTime> onDateChanged;
+
+  /// Called when the displayed month changes.
+  final ValueChanged<DateTime>? onDisplayedMonthChanged;
+
+  /// The initial calendar mode (day or year).
+  final DatePickerMode initialCalendarMode;
+
+  /// Optional predicate to control which dates are selectable.
+  final bool Function(DateTime)? selectableDayPredicate;
+
+  const WiredCalendarDatePicker({
+    super.key,
+    required this.initialDate,
+    required this.firstDate,
+    required this.lastDate,
+    required this.onDateChanged,
+    this.onDisplayedMonthChanged,
+    this.initialCalendarMode = DatePickerMode.day,
+    this.selectableDayPredicate,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return buildWiredElement(
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: WiredCanvas(
+              painter: WiredRoundedRectangleBase(
+                borderRadius: BorderRadius.circular(16),
+              ),
+              fillerType: RoughFilter.noFiller,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: CalendarDatePicker(
+              initialDate: initialDate,
+              firstDate: firstDate,
+              lastDate: lastDate,
+              onDateChanged: onDateChanged,
+              onDisplayedMonthChanged: onDisplayedMonthChanged,
+              initialCalendarMode: initialCalendarMode,
+              selectableDayPredicate: selectableDayPredicate,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/skribble/test/widgets/wired_calendar_date_picker_test.dart
+++ b/packages/skribble/test/widgets/wired_calendar_date_picker_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:skribble/skribble.dart';
+
+void main() {
+  group('WiredCalendarDatePicker', () {
+    testWidgets('renders without error', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: WiredCalendarDatePicker(
+              initialDate: DateTime(2025, 6, 15),
+              firstDate: DateTime(2020),
+              lastDate: DateTime(2030),
+              onDateChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(WiredCalendarDatePicker), findsOneWidget);
+      expect(find.byType(CalendarDatePicker), findsOneWidget);
+      expect(find.byType(RepaintBoundary), findsWidgets);
+    });
+
+    testWidgets('calls onDateChanged when day tapped', (tester) async {
+      DateTime? selected;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: WiredCalendarDatePicker(
+              initialDate: DateTime(2025, 6, 15),
+              firstDate: DateTime(2020),
+              lastDate: DateTime(2030),
+              onDateChanged: (d) => selected = d,
+            ),
+          ),
+        ),
+      );
+
+      // Tap a visible day number
+      await tester.tap(find.text('20'));
+      await tester.pumpAndSettle();
+
+      expect(selected, isNotNull);
+      expect(selected!.day, 20);
+    });
+
+    testWidgets('respects selectableDayPredicate', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: WiredCalendarDatePicker(
+              initialDate: DateTime(2025, 6, 16),
+              firstDate: DateTime(2020),
+              lastDate: DateTime(2030),
+              onDateChanged: (_) {},
+              selectableDayPredicate: (d) => d.weekday != DateTime.sunday,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(CalendarDatePicker), findsOneWidget);
+    });
+
+    testWidgets('wraps picker in hand-drawn border', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: WiredCalendarDatePicker(
+              initialDate: DateTime(2025, 3, 1),
+              firstDate: DateTime(2020),
+              lastDate: DateTime(2030),
+              onDateChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(WiredCanvas), findsWidgets);
+    });
+  });
+}


### PR DESCRIPTION
Wraps CalendarDatePicker with full API parity + hand-drawn border. Closes CalendarDatePicker partial gap.