### PR TITLE
feat: adopt WiredIcon in navigation widgets

### DIFF
--- a/.changeset/wired_icon_navigation_widgets.md
+++ b/.changeset/wired_icon_navigation_widgets.md
@@ -1,0 +1,10 @@
+---
+skribble: patch
+---
+
+# Adopt rough icons in navigation widgets
+
+Updates `WiredNavigationBar`, `WiredBottomNavigationBar`, and
+`WiredNavigationRail` to render destination icons with `WiredIcon`
+instead of `Icon`, keeping icon visuals consistent with the hand-drawn
+style and preserving fallback behavior for unsupported glyphs.

--- a/packages/skribble/lib/src/wired_bottom_nav.dart
+++ b/packages/skribble/lib/src/wired_bottom_nav.dart
@@ -3,6 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'canvas/wired_canvas.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// A bottom navigation bar item.
@@ -94,10 +95,12 @@ class WiredBottomNavigationBar extends HookWidget {
                       fillerType: RoughFilter.noFiller,
                     ),
                   ),
-                Icon(
-                  item.icon,
+                WiredIcon(
+                  icon: item.icon,
                   color: selected ? theme.borderColor : theme.disabledTextColor,
                   size: 24,
+                  fillStyle: WiredIconFillStyle.solid,
+                  strokeWidth: 1.2,
                 ),
               ],
             ),

--- a/packages/skribble/lib/src/wired_navigation_bar.dart
+++ b/packages/skribble/lib/src/wired_navigation_bar.dart
@@ -4,6 +4,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'canvas/wired_canvas.dart';
 import 'rough/skribble_rough.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// A navigation bar destination.
@@ -101,10 +102,12 @@ class WiredNavigationBar extends HookWidget {
                       fillerConfig: FillerConfig.build(hachureGap: 2.0),
                     ),
                   ),
-                Icon(
-                  selected ? (dest.selectedIcon ?? dest.icon) : dest.icon,
+                WiredIcon(
+                  icon: selected ? (dest.selectedIcon ?? dest.icon) : dest.icon,
                   color: selected ? theme.fillColor : theme.disabledTextColor,
                   size: 24,
+                  fillStyle: WiredIconFillStyle.solid,
+                  strokeWidth: 1.2,
                 ),
               ],
             ),

--- a/packages/skribble/lib/src/wired_navigation_rail.dart
+++ b/packages/skribble/lib/src/wired_navigation_rail.dart
@@ -4,6 +4,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'canvas/wired_canvas.dart';
 import 'rough/skribble_rough.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// A destination for the navigation rail.
@@ -119,10 +120,14 @@ class WiredNavigationRail extends HookWidget {
                         fillerConfig: FillerConfig.build(hachureGap: 2.0),
                       ),
                     ),
-                  Icon(
-                    selected ? (dest.selectedIcon ?? dest.icon) : dest.icon,
+                  WiredIcon(
+                    icon: selected
+                        ? (dest.selectedIcon ?? dest.icon)
+                        : dest.icon,
                     color: selected ? theme.fillColor : theme.disabledTextColor,
                     size: 24,
+                    fillStyle: WiredIconFillStyle.solid,
+                    strokeWidth: 1.2,
                   ),
                 ],
               ),

--- a/packages/skribble/test/widgets/wired_bottom_nav_test.dart
+++ b/packages/skribble/test/widgets/wired_bottom_nav_test.dart
@@ -5,6 +5,13 @@ import 'package:skribble/skribble.dart';
 import '../helpers/finders.dart';
 import '../helpers/pump_app.dart';
 
+Finder findWiredIcon(IconData icon) {
+  return find.byWidgetPredicate(
+    (widget) => widget is WiredIcon && widget.icon == icon,
+    description: 'WiredIcon($icon)',
+  );
+}
+
 void main() {
   group('WiredBottomNavigationBar', () {
     const testItems = [
@@ -42,9 +49,10 @@ void main() {
         asBottomNav: true,
       );
 
-      expect(find.byIcon(Icons.home), findsOneWidget);
-      expect(find.byIcon(Icons.search), findsOneWidget);
-      expect(find.byIcon(Icons.person), findsOneWidget);
+      expect(find.byType(WiredIcon), findsNWidgets(3));
+      expect(findWiredIcon(Icons.home), findsOneWidget);
+      expect(findWiredIcon(Icons.search), findsOneWidget);
+      expect(findWiredIcon(Icons.person), findsOneWidget);
     });
 
     testWidgets('default currentIndex is 0', (tester) async {

--- a/packages/skribble/test/widgets/wired_navigation_bar_test.dart
+++ b/packages/skribble/test/widgets/wired_navigation_bar_test.dart
@@ -5,6 +5,13 @@ import 'package:skribble/skribble.dart';
 import '../helpers/finders.dart';
 import '../helpers/pump_app.dart';
 
+Finder findWiredIcon(IconData icon) {
+  return find.byWidgetPredicate(
+    (widget) => widget is WiredIcon && widget.icon == icon,
+    description: 'WiredIcon($icon)',
+  );
+}
+
 void main() {
   group('WiredNavigationBar', () {
     const testDestinations = [
@@ -46,8 +53,9 @@ void main() {
         asBottomNav: true,
       );
 
-      expect(find.byIcon(Icons.home), findsOneWidget);
-      expect(find.byIcon(Icons.search), findsOneWidget);
+      expect(find.byType(WiredIcon), findsNWidgets(3));
+      expect(findWiredIcon(Icons.home), findsOneWidget);
+      expect(findWiredIcon(Icons.search), findsOneWidget);
     });
 
     testWidgets('default selectedIndex is 0', (tester) async {
@@ -158,7 +166,7 @@ void main() {
         asBottomNav: true,
       );
 
-      expect(find.byIcon(Icons.person), findsOneWidget);
+      expect(findWiredIcon(Icons.person), findsOneWidget);
     });
 
     testWidgets('uses regular icon when item is not selected', (tester) async {
@@ -168,7 +176,7 @@ void main() {
         asBottomNav: true,
       );
 
-      expect(find.byIcon(Icons.person_outline), findsOneWidget);
+      expect(findWiredIcon(Icons.person_outline), findsOneWidget);
     });
 
     testWidgets('each destination is wrapped in GestureDetector', (

--- a/packages/skribble/test/widgets/wired_navigation_rail_test.dart
+++ b/packages/skribble/test/widgets/wired_navigation_rail_test.dart
@@ -5,6 +5,13 @@ import 'package:skribble/skribble.dart';
 import '../helpers/finders.dart';
 import '../helpers/pump_app.dart';
 
+Finder findWiredIcon(IconData icon) {
+  return find.byWidgetPredicate(
+    (widget) => widget is WiredIcon && widget.icon == icon,
+    description: 'WiredIcon($icon)',
+  );
+}
+
 void main() {
   group('WiredNavigationRail', () {
     const testDestinations = [
@@ -58,8 +65,9 @@ void main() {
         ),
       );
 
-      expect(find.byIcon(Icons.home), findsOneWidget);
-      expect(find.byIcon(Icons.search), findsOneWidget);
+      expect(find.byType(WiredIcon), findsNWidgets(3));
+      expect(findWiredIcon(Icons.home), findsOneWidget);
+      expect(findWiredIcon(Icons.search), findsOneWidget);
     });
 
     testWidgets('default selectedIndex is 0', (tester) async {
@@ -209,7 +217,7 @@ void main() {
       );
 
       // Profile destination has selectedIcon: Icons.person.
-      expect(find.byIcon(Icons.person), findsOneWidget);
+      expect(findWiredIcon(Icons.person), findsOneWidget);
     });
 
     testWidgets('uses regular icon when item is not selected', (tester) async {
@@ -227,7 +235,7 @@ void main() {
       );
 
       // Profile (index 2) is not selected, so it uses person_outline.
-      expect(find.byIcon(Icons.person_outline), findsOneWidget);
+      expect(findWiredIcon(Icons.person_outline), findsOneWidget);
     });
 
     testWidgets('renders leading widget', (tester) async {


### PR DESCRIPTION
## Summary
- update `WiredNavigationBar` destination icon rendering to use `WiredIcon`
- update `WiredBottomNavigationBar` item icon rendering to use `WiredIcon`
- update `WiredNavigationRail` destination icon rendering to use `WiredIcon`
- keep existing selected/unselected icon behavior and colors
- update widget tests to assert `WiredIcon` usage and icon data
- add changeset entry for release notes

## Validation
- `dart analyze --fatal-infos .`
- `flutter test packages/skribble/test/widgets/wired_navigation_bar_test.dart packages/skribble/test/widgets/wired_bottom_nav_test.dart packages/skribble/test/widgets/wired_navigation_rail_test.dart`