### PR TITLE
feat: adopt WiredIcon in search/chip/popup/stepper widgets

### DIFF
--- a/.changeset/wired_icon_search_chip_popup_stepper.md
+++ b/.changeset/wired_icon_search_chip_popup_stepper.md
@@ -1,0 +1,9 @@
+---
+skribble: patch
+---
+
+# Adopt rough icons in search/chip/popup/stepper widgets
+
+Updates the default icon rendering in `WiredSearchBar`, `WiredChip`,
+`WiredFilterChip`, `WiredPopupMenuButton`, and `WiredStepper` to use
+`WiredIcon` for a consistent hand-drawn appearance.

--- a/packages/skribble/lib/src/wired_chip.dart
+++ b/packages/skribble/lib/src/wired_chip.dart
@@ -3,6 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'canvas/wired_canvas.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// A chip with a hand-drawn rounded rectangle border.
@@ -51,10 +52,12 @@ class WiredChip extends HookWidget {
                       const SizedBox(width: 4),
                       GestureDetector(
                         onTap: onDeleted,
-                        child: Icon(
-                          Icons.close,
+                        child: WiredIcon(
+                          icon: Icons.close,
                           size: 16,
                           color: theme.textColor,
+                          fillStyle: WiredIconFillStyle.solid,
+                          strokeWidth: 1.1,
                         ),
                       ),
                     ],

--- a/packages/skribble/lib/src/wired_filter_chip.dart
+++ b/packages/skribble/lib/src/wired_filter_chip.dart
@@ -4,6 +4,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'canvas/wired_canvas.dart';
 import 'rough/skribble_rough.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// A filter chip with a hand-drawn border and optional checkmark.
@@ -50,7 +51,13 @@ class WiredFilterChip extends HookWidget {
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       if (selected) ...[
-                        Icon(Icons.check, size: 16, color: theme.fillColor),
+                        WiredIcon(
+                          icon: Icons.check,
+                          size: 16,
+                          color: theme.fillColor,
+                          fillStyle: WiredIconFillStyle.solid,
+                          strokeWidth: 1.1,
+                        ),
                         const SizedBox(width: 4),
                       ],
                       DefaultTextStyle(

--- a/packages/skribble/lib/src/wired_popup_menu.dart
+++ b/packages/skribble/lib/src/wired_popup_menu.dart
@@ -3,6 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'rough/skribble_rough.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// A popup menu item for [WiredPopupMenuButton].
@@ -31,7 +32,14 @@ class WiredPopupMenuButton<T> extends HookWidget {
     final theme = WiredTheme.of(context);
     return buildWiredElement(
       child: PopupMenuButton<T>(
-        icon: icon ?? Icon(Icons.more_vert, color: theme.textColor),
+        icon:
+            icon ??
+            WiredIcon(
+              icon: Icons.more_vert,
+              color: theme.textColor,
+              fillStyle: WiredIconFillStyle.solid,
+              strokeWidth: 1.2,
+            ),
         onSelected: onSelected,
         color: theme.fillColor,
         shape: RoundedRectangleBorder(

--- a/packages/skribble/lib/src/wired_search_bar.dart
+++ b/packages/skribble/lib/src/wired_search_bar.dart
@@ -3,6 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'canvas/wired_canvas.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// A search bar with a hand-drawn rounded rectangle border.
@@ -45,7 +46,14 @@ class WiredSearchBar extends HookWidget {
             padding: const EdgeInsets.symmetric(horizontal: 12),
             child: Row(
               children: [
-                leading ?? Icon(Icons.search, color: theme.disabledTextColor),
+                leading ??
+                    WiredIcon(
+                      icon: Icons.search,
+                      color: theme.disabledTextColor,
+                      size: 20,
+                      fillStyle: WiredIconFillStyle.solid,
+                      strokeWidth: 1.2,
+                    ),
                 const SizedBox(width: 8),
                 Expanded(
                   child: TextField(

--- a/packages/skribble/lib/src/wired_stepper.dart
+++ b/packages/skribble/lib/src/wired_stepper.dart
@@ -4,6 +4,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'canvas/wired_canvas.dart';
 import 'rough/skribble_rough.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// A step in [WiredStepper].
@@ -89,7 +90,13 @@ class WiredStepper extends HookWidget {
                   fillerConfig: FillerConfig.build(hachureGap: 2.0),
                 ),
                 if (isCompleted)
-                  Icon(Icons.check, size: 16, color: theme.fillColor)
+                  WiredIcon(
+                    icon: Icons.check,
+                    size: 16,
+                    color: theme.fillColor,
+                    fillStyle: WiredIconFillStyle.solid,
+                    strokeWidth: 1.1,
+                  )
                 else
                   Text(
                     '${index + 1}',

--- a/packages/skribble/test/widgets/wired_chip_test.dart
+++ b/packages/skribble/test/widgets/wired_chip_test.dart
@@ -5,6 +5,13 @@ import 'package:skribble/skribble.dart';
 import '../helpers/finders.dart';
 import '../helpers/pump_app.dart';
 
+Finder findWiredIcon(IconData icon) {
+  return find.byWidgetPredicate(
+    (widget) => widget is WiredIcon && widget.icon == icon,
+    description: 'WiredIcon($icon)',
+  );
+}
+
 void main() {
   group('WiredChip', () {
     testWidgets('renders without error', (tester) async {
@@ -40,7 +47,7 @@ void main() {
       expect(find.byIcon(Icons.person), findsNothing);
     });
 
-    testWidgets('renders delete icon when onDeleted is provided', (
+    testWidgets('renders rough delete icon when onDeleted is provided', (
       tester,
     ) async {
       await tester.pumpWidget(
@@ -51,7 +58,7 @@ void main() {
         ),
       );
 
-      expect(find.byIcon(Icons.close), findsOneWidget);
+      expect(findWiredIcon(Icons.close), findsOneWidget);
     });
 
     testWidgets('does not render delete icon when onDeleted is null', (
@@ -59,7 +66,7 @@ void main() {
     ) async {
       await pumpApp(tester, WiredChip(label: const Text('Chip')));
 
-      expect(find.byIcon(Icons.close), findsNothing);
+      expect(findWiredIcon(Icons.close), findsNothing);
     });
 
     testWidgets('calls onDeleted when delete icon is tapped', (tester) async {
@@ -76,7 +83,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byIcon(Icons.close));
+      await tester.tap(findWiredIcon(Icons.close));
       await tester.pump();
 
       expect(deleted, isTrue);

--- a/packages/skribble/test/widgets/wired_filter_chip_test.dart
+++ b/packages/skribble/test/widgets/wired_filter_chip_test.dart
@@ -5,6 +5,13 @@ import 'package:skribble/skribble.dart';
 import '../helpers/finders.dart';
 import '../helpers/pump_app.dart';
 
+Finder findWiredIcon(IconData icon) {
+  return find.byWidgetPredicate(
+    (widget) => widget is WiredIcon && widget.icon == icon,
+    description: 'WiredIcon($icon)',
+  );
+}
+
 void main() {
   group('WiredFilterChip', () {
     testWidgets('renders without error', (tester) async {
@@ -28,7 +35,7 @@ void main() {
         ),
       );
 
-      expect(find.byIcon(Icons.check), findsOneWidget);
+      expect(findWiredIcon(Icons.check), findsOneWidget);
     });
 
     testWidgets('does not show check icon when not selected', (tester) async {
@@ -40,7 +47,7 @@ void main() {
         ),
       );
 
-      expect(find.byIcon(Icons.check), findsNothing);
+      expect(findWiredIcon(Icons.check), findsNothing);
     });
 
     testWidgets('calls onSelected with toggled value when tapped', (
@@ -179,7 +186,7 @@ void main() {
 
       expect(find.byType(WiredFilterChip), findsOneWidget);
       expect(find.text('Active'), findsOneWidget);
-      expect(find.byIcon(Icons.check), findsOneWidget);
+      expect(findWiredIcon(Icons.check), findsOneWidget);
     });
 
     testWidgets('renders correctly when selected is false', (tester) async {
@@ -196,7 +203,7 @@ void main() {
 
       expect(find.byType(WiredFilterChip), findsOneWidget);
       expect(find.text('Inactive'), findsOneWidget);
-      expect(find.byIcon(Icons.check), findsNothing);
+      expect(findWiredIcon(Icons.check), findsNothing);
     });
   });
 }

--- a/packages/skribble/test/widgets/wired_popup_menu_test.dart
+++ b/packages/skribble/test/widgets/wired_popup_menu_test.dart
@@ -4,6 +4,13 @@ import 'package:skribble/skribble.dart';
 
 import '../helpers/pump_app.dart';
 
+Finder findWiredIcon(IconData icon) {
+  return find.byWidgetPredicate(
+    (widget) => widget is WiredIcon && widget.icon == icon,
+    description: 'WiredIcon($icon)',
+  );
+}
+
 void main() {
   group('WiredPopupMenuButton', () {
     testWidgets('renders without error', (tester) async {
@@ -17,7 +24,7 @@ void main() {
       expect(find.byType(WiredPopupMenuButton<String>), findsOneWidget);
     });
 
-    testWidgets('renders default more_vert icon', (tester) async {
+    testWidgets('renders default rough more_vert icon', (tester) async {
       await pumpApp(
         tester,
         WiredPopupMenuButton<String>(
@@ -25,7 +32,7 @@ void main() {
         ),
       );
 
-      expect(find.byIcon(Icons.more_vert), findsOneWidget);
+      expect(findWiredIcon(Icons.more_vert), findsOneWidget);
     });
 
     testWidgets('renders custom icon when provided', (tester) async {
@@ -38,7 +45,7 @@ void main() {
       );
 
       expect(find.byIcon(Icons.menu), findsOneWidget);
-      expect(find.byIcon(Icons.more_vert), findsNothing);
+      expect(findWiredIcon(Icons.more_vert), findsNothing);
     });
 
     testWidgets('shows popup menu items on tap', (tester) async {
@@ -100,7 +107,7 @@ void main() {
           of: find.byType(WiredPopupMenuButton<String>),
           matching: find.byType(RepaintBoundary),
         ),
-        findsOneWidget,
+        findsAtLeastNWidgets(1),
       );
     });
 

--- a/packages/skribble/test/widgets/wired_search_bar_test.dart
+++ b/packages/skribble/test/widgets/wired_search_bar_test.dart
@@ -5,6 +5,13 @@ import 'package:skribble/skribble.dart';
 import '../helpers/finders.dart';
 import '../helpers/pump_app.dart';
 
+Finder findWiredIcon(IconData icon) {
+  return find.byWidgetPredicate(
+    (widget) => widget is WiredIcon && widget.icon == icon,
+    description: 'WiredIcon($icon)',
+  );
+}
+
 void main() {
   group('WiredSearchBar', () {
     testWidgets('renders without error', (tester) async {
@@ -13,10 +20,10 @@ void main() {
       expect(find.byType(WiredSearchBar), findsOneWidget);
     });
 
-    testWidgets('renders default search icon', (tester) async {
+    testWidgets('renders default rough search icon', (tester) async {
       await pumpApp(tester, WiredSearchBar());
 
-      expect(find.byIcon(Icons.search), findsOneWidget);
+      expect(findWiredIcon(Icons.search), findsOneWidget);
     });
 
     testWidgets('renders custom leading widget', (tester) async {
@@ -29,9 +36,9 @@ void main() {
       );
 
       expect(find.byIcon(Icons.filter_list), findsOneWidget);
-      // The default search icon should not be present when a custom leading
-      // widget is provided.
-      expect(find.byIcon(Icons.search), findsNothing);
+      // The default rough search icon should not be present when a custom
+      // leading widget is provided.
+      expect(findWiredIcon(Icons.search), findsNothing);
     });
 
     testWidgets('renders trailing widget when provided', (tester) async {

--- a/packages/skribble/test/widgets/wired_stepper_test.dart
+++ b/packages/skribble/test/widgets/wired_stepper_test.dart
@@ -5,6 +5,13 @@ import 'package:skribble/skribble.dart';
 import '../helpers/finders.dart';
 import '../helpers/pump_app.dart';
 
+Finder findWiredIcon(IconData icon) {
+  return find.byWidgetPredicate(
+    (widget) => widget is WiredIcon && widget.icon == icon,
+    description: 'WiredIcon($icon)',
+  );
+}
+
 void main() {
   group('WiredStepper', () {
     List<WiredStep> buildSteps({int count = 3}) {
@@ -98,7 +105,7 @@ void main() {
 
       // Steps 0 and 1 are completed (index < currentStep), so they show
       // check icons. Step 3 (active) shows its number.
-      expect(find.byIcon(Icons.check), findsNWidgets(2));
+      expect(findWiredIcon(Icons.check), findsNWidgets(2));
       expect(find.text('3'), findsOneWidget);
     });
 


### PR DESCRIPTION
## Summary
- update `WiredSearchBar` default leading icon to use `WiredIcon`
- update `WiredChip` delete icon to use `WiredIcon`
- update `WiredFilterChip` selected check icon to use `WiredIcon`
- update `WiredPopupMenuButton` default menu icon to use `WiredIcon`
- update `WiredStepper` completed-step check icon to use `WiredIcon`
- update widget tests to assert rough icon usage
- add changeset entry

## Validation
- `dart analyze --fatal-infos .`
- `flutter test packages/skribble/test/widgets/wired_search_bar_test.dart packages/skribble/test/widgets/wired_chip_test.dart packages/skribble/test/widgets/wired_filter_chip_test.dart packages/skribble/test/widgets/wired_popup_menu_test.dart packages/skribble/test/widgets/wired_stepper_test.dart`