### PR TITLE
feat: adopt WiredIcon in combo/expansion/segmented/input-chip

### DIFF
--- a/.changeset/wired_icon_controls.md
+++ b/.changeset/wired_icon_controls.md
@@ -1,0 +1,9 @@
+---
+skribble: patch
+---
+
+# Adopt rough icons in combo/expansion/segmented/input chip widgets
+
+Updates icon rendering in `WiredCombo`, `WiredExpansionTile`,
+`WiredSegmentedButton`, and `WiredInputChip` to use `WiredIcon`
+for a consistent hand-drawn icon style across controls.

--- a/packages/skribble/lib/src/wired_combo.dart
+++ b/packages/skribble/lib/src/wired_combo.dart
@@ -4,6 +4,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'canvas/wired_canvas.dart';
 import 'rough/skribble_rough.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// A hand-drawn dropdown selector, corresponding to Flutter's
@@ -66,7 +67,11 @@ class WiredCombo<T> extends HookWidget {
                 elevation: 0,
                 icon: Visibility(
                   visible: false,
-                  child: Icon(Icons.arrow_downward),
+                  child: WiredIcon(
+                    icon: Icons.arrow_downward,
+                    fillStyle: WiredIconFillStyle.solid,
+                    strokeWidth: 1.2,
+                  ),
                 ),
                 value: internalValue.value,
                 items: items.map((item) {

--- a/packages/skribble/lib/src/wired_expansion_tile.dart
+++ b/packages/skribble/lib/src/wired_expansion_tile.dart
@@ -3,6 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'canvas/wired_canvas.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// An expandable tile with a hand-drawn border.
@@ -63,7 +64,12 @@ class WiredExpansionTile extends HookWidget {
                 AnimatedRotation(
                   turns: isExpanded.value ? 0.5 : 0,
                   duration: const Duration(milliseconds: 200),
-                  child: Icon(Icons.expand_more, color: theme.textColor),
+                  child: WiredIcon(
+                    icon: Icons.expand_more,
+                    color: theme.textColor,
+                    fillStyle: WiredIconFillStyle.solid,
+                    strokeWidth: 1.2,
+                  ),
                 ),
               ],
             ),

--- a/packages/skribble/lib/src/wired_input_chip.dart
+++ b/packages/skribble/lib/src/wired_input_chip.dart
@@ -3,6 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'canvas/wired_canvas.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// A hand-drawn input chip, corresponding to Flutter's [InputChip].
@@ -79,10 +80,12 @@ class WiredInputChip extends HookWidget {
                           const SizedBox(width: 4),
                           GestureDetector(
                             onTap: onDeleted,
-                            child: Icon(
-                              Icons.close,
+                            child: WiredIcon(
+                              icon: Icons.close,
                               size: 16,
                               color: selected ? Colors.white : theme.textColor,
+                              fillStyle: WiredIconFillStyle.solid,
+                              strokeWidth: 1.1,
                             ),
                           ),
                         ],

--- a/packages/skribble/lib/src/wired_segmented_button.dart
+++ b/packages/skribble/lib/src/wired_segmented_button.dart
@@ -4,6 +4,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'canvas/wired_canvas.dart';
 import 'rough/skribble_rough.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// A segment in a segmented button.
@@ -115,7 +116,13 @@ class WiredSegmentedButton<T> extends HookWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             if (segment.icon != null) ...[
-              Icon(segment.icon, size: 18, color: theme.textColor),
+              WiredIcon(
+                icon: segment.icon!,
+                size: 18,
+                color: theme.textColor,
+                fillStyle: WiredIconFillStyle.solid,
+                strokeWidth: 1.2,
+              ),
               const SizedBox(width: 8),
             ],
             segment.label,

--- a/packages/skribble/test/widgets/wired_expansion_tile_test.dart
+++ b/packages/skribble/test/widgets/wired_expansion_tile_test.dart
@@ -5,6 +5,13 @@ import 'package:skribble/skribble.dart';
 import '../helpers/finders.dart';
 import '../helpers/pump_app.dart';
 
+Finder findWiredIcon(IconData icon) {
+  return find.byWidgetPredicate(
+    (widget) => widget is WiredIcon && widget.icon == icon,
+    description: 'WiredIcon($icon)',
+  );
+}
+
 void main() {
   group('WiredExpansionTile', () {
     testWidgets('renders without error', (tester) async {
@@ -173,10 +180,10 @@ void main() {
       expect(find.text('Content'), findsNothing);
     });
 
-    testWidgets('contains expand_more icon', (tester) async {
+    testWidgets('contains rough expand_more icon', (tester) async {
       await pumpApp(tester, WiredExpansionTile(title: const Text('Title')));
 
-      expect(find.byIcon(Icons.expand_more), findsOneWidget);
+      expect(findWiredIcon(Icons.expand_more), findsOneWidget);
     });
 
     testWidgets('icon rotates when expanded', (tester) async {

--- a/packages/skribble/test/widgets/wired_input_chip_test.dart
+++ b/packages/skribble/test/widgets/wired_input_chip_test.dart
@@ -4,6 +4,13 @@ import 'package:skribble/skribble.dart';
 
 import '../helpers/pump_app.dart';
 
+Finder findWiredIcon(IconData icon) {
+  return find.byWidgetPredicate(
+    (widget) => widget is WiredIcon && widget.icon == icon,
+    description: 'WiredIcon($icon)',
+  );
+}
+
 void main() {
   group('WiredInputChip', () {
     testWidgets('renders label', (tester) async {
@@ -20,7 +27,7 @@ void main() {
           ),
         ),
       );
-      expect(find.byIcon(Icons.close), findsOneWidget);
+      expect(findWiredIcon(Icons.close), findsOneWidget);
     });
 
     testWidgets('calls onDeleted', (tester) async {
@@ -35,7 +42,7 @@ void main() {
           ),
         ),
       );
-      await tester.tap(find.byIcon(Icons.close));
+      await tester.tap(findWiredIcon(Icons.close));
       expect(deleted, isTrue);
     });
 

--- a/packages/skribble/test/widgets/wired_segmented_button_test.dart
+++ b/packages/skribble/test/widgets/wired_segmented_button_test.dart
@@ -5,6 +5,13 @@ import 'package:skribble/skribble.dart';
 import '../helpers/finders.dart';
 import '../helpers/pump_app.dart';
 
+Finder findWiredIcon(IconData icon) {
+  return find.byWidgetPredicate(
+    (widget) => widget is WiredIcon && widget.icon == icon,
+    description: 'WiredIcon($icon)',
+  );
+}
+
 void main() {
   group('WiredSegmentedButton', () {
     final segments = [
@@ -158,8 +165,8 @@ void main() {
         ),
       );
 
-      expect(find.byIcon(Icons.home), findsOneWidget);
-      expect(find.byIcon(Icons.work), findsOneWidget);
+      expect(findWiredIcon(Icons.home), findsOneWidget);
+      expect(findWiredIcon(Icons.work), findsOneWidget);
     });
 
     testWidgets('does not render icons when not provided', (tester) async {
@@ -172,7 +179,7 @@ void main() {
       expect(
         find.descendant(
           of: find.byType(WiredSegmentedButton<String>),
-          matching: find.byType(Icon),
+          matching: find.byType(WiredIcon),
         ),
         findsNothing,
       );


### PR DESCRIPTION
## Summary
- update `WiredExpansionTile` expand indicator to use `WiredIcon`
- update `WiredSegmentedButton` segment icons to use `WiredIcon`
- update `WiredInputChip` delete icon to use `WiredIcon`
- update `WiredCombo` hidden dropdown icon widget to use `WiredIcon`
- update widget tests to assert rough icon usage
- add changeset entry

## Validation
- `dart analyze --fatal-infos .`
- `flutter test packages/skribble/test/widgets/wired_combo_test.dart packages/skribble/test/widgets/wired_expansion_tile_test.dart packages/skribble/test/widgets/wired_segmented_button_test.dart packages/skribble/test/widgets/wired_input_chip_test.dart`