### PR TITLE
feat: adopt WiredIcon in remaining Material-icon widgets

### DIFF
--- a/.changeset/wired_icon_remaining_material_widgets.md
+++ b/.changeset/wired_icon_remaining_material_widgets.md
@@ -1,0 +1,10 @@
+---
+skribble: patch
+---
+
+# Adopt rough icons in remaining Material-icon widgets
+
+Updates icon rendering in `WiredContextMenu`, `WiredColorPicker`,
+`WiredAvatar` fallback, `WiredNavigationDrawer`, `WiredDismissible`,
+and `WiredReorderableListView` to use `WiredIcon` for consistent
+hand-drawn icon styling.

--- a/packages/skribble/lib/src/wired_avatar.dart
+++ b/packages/skribble/lib/src/wired_avatar.dart
@@ -4,6 +4,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'canvas/wired_canvas.dart';
 import 'rough/skribble_rough.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// A hand-drawn avatar corresponding to Flutter's [CircleAvatar].
@@ -118,7 +119,15 @@ class WiredAvatar extends HookWidget {
 
   Widget _buildFallback(Color fgColor) {
     return Center(
-      child: child ?? Icon(Icons.person, color: fgColor, size: radius),
+      child:
+          child ??
+          WiredIcon(
+            icon: Icons.person,
+            color: fgColor,
+            size: radius,
+            fillStyle: WiredIconFillStyle.solid,
+            strokeWidth: 1.2,
+          ),
     );
   }
 }

--- a/packages/skribble/lib/src/wired_color_picker.dart
+++ b/packages/skribble/lib/src/wired_color_picker.dart
@@ -4,6 +4,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'canvas/wired_canvas.dart';
 import 'rough/skribble_rough.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// A hand-drawn color picker with a grid of selectable color swatches.
@@ -135,7 +136,13 @@ class _ColorSwatch extends HookWidget {
             ),
             // Check mark for selected
             if (isSelected)
-              Icon(Icons.check, color: _contrastColor(color), size: size * 0.5),
+              WiredIcon(
+                icon: Icons.check,
+                color: _contrastColor(color),
+                size: size * 0.5,
+                fillStyle: WiredIconFillStyle.solid,
+                strokeWidth: 1.2,
+              ),
           ],
         ),
       ),

--- a/packages/skribble/lib/src/wired_context_menu.dart
+++ b/packages/skribble/lib/src/wired_context_menu.dart
@@ -3,6 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'canvas/wired_canvas.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// A hand-drawn context menu, corresponding to `CupertinoContextMenu`.
@@ -114,12 +115,14 @@ class _WiredContextMenuOverlay extends HookWidget {
                                 child: Row(
                                   children: [
                                     if (actions[i].icon != null) ...[
-                                      Icon(
-                                        actions[i].icon,
+                                      WiredIcon(
+                                        icon: actions[i].icon!,
                                         size: 18,
                                         color: actions[i].isDestructive
                                             ? Colors.red
                                             : theme.textColor,
+                                        fillStyle: WiredIconFillStyle.solid,
+                                        strokeWidth: 1.2,
                                       ),
                                       const SizedBox(width: 10),
                                     ],

--- a/packages/skribble/lib/src/wired_dismissible.dart
+++ b/packages/skribble/lib/src/wired_dismissible.dart
@@ -4,6 +4,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'canvas/wired_canvas.dart';
 import 'rough/skribble_rough.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// A hand-drawn dismissible wrapper corresponding to Flutter's [Dismissible].
@@ -99,7 +100,12 @@ class WiredDismissible extends HookWidget {
           color: deleteColor.withValues(alpha: 0.9),
           alignment: isSecondary ? Alignment.centerRight : Alignment.centerLeft,
           padding: const EdgeInsets.symmetric(horizontal: 20),
-          child: Icon(deleteIcon, color: Colors.white),
+          child: WiredIcon(
+            icon: deleteIcon,
+            color: Colors.white,
+            fillStyle: WiredIconFillStyle.solid,
+            strokeWidth: 1.2,
+          ),
         ),
       ],
     );

--- a/packages/skribble/lib/src/wired_navigation_drawer.dart
+++ b/packages/skribble/lib/src/wired_navigation_drawer.dart
@@ -3,6 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'canvas/wired_canvas.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// A hand-drawn M3-style navigation drawer with destination items.
@@ -158,10 +159,12 @@ class _WiredDrawerItem extends HookWidget {
               padding: const EdgeInsets.symmetric(horizontal: 16),
               child: Row(
                 children: [
-                  Icon(
-                    isSelected ? (selectedIcon ?? icon) : icon,
+                  WiredIcon(
+                    icon: isSelected ? (selectedIcon ?? icon) : icon,
                     size: 22,
                     color: isSelected ? Colors.white : theme.textColor,
+                    fillStyle: WiredIconFillStyle.solid,
+                    strokeWidth: 1.2,
                   ),
                   const SizedBox(width: 12),
                   Expanded(

--- a/packages/skribble/lib/src/wired_reorderable_list_view.dart
+++ b/packages/skribble/lib/src/wired_reorderable_list_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'canvas/wired_canvas.dart';
 import 'wired_base.dart';
+import 'wired_icon.dart';
 import 'wired_theme.dart';
 
 /// A hand-drawn version of Flutter's [ReorderableListView].
@@ -120,10 +121,12 @@ class _WiredReorderableItem extends HookWidget {
                   index: index,
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 8),
-                    child: Icon(
-                      Icons.drag_handle,
+                    child: WiredIcon(
+                      icon: Icons.drag_handle,
                       color: theme.textColor,
                       size: 20,
+                      fillStyle: WiredIconFillStyle.solid,
+                      strokeWidth: 1.2,
                     ),
                   ),
                 ),

--- a/packages/skribble/test/widgets/wired_color_picker_test.dart
+++ b/packages/skribble/test/widgets/wired_color_picker_test.dart
@@ -4,6 +4,13 @@ import 'package:skribble/skribble.dart';
 
 import '../helpers/pump_app.dart';
 
+Finder findWiredIcon(IconData icon) {
+  return find.byWidgetPredicate(
+    (widget) => widget is WiredIcon && widget.icon == icon,
+    description: 'WiredIcon($icon)',
+  );
+}
+
 void main() {
   Widget buildSubject({
     Color selectedColor = Colors.blue,
@@ -60,7 +67,7 @@ void main() {
       await tester.pumpWidget(
         buildSubject(selectedColor: Colors.blue, onColorChanged: (_) {}),
       );
-      expect(find.byIcon(Icons.check), findsOneWidget);
+      expect(findWiredIcon(Icons.check), findsOneWidget);
     });
 
     testWidgets('does not call callback when disabled', (tester) async {
@@ -101,7 +108,7 @@ void main() {
           },
         ),
       );
-      expect(find.byIcon(Icons.check), findsOneWidget);
+      expect(findWiredIcon(Icons.check), findsOneWidget);
     });
   });
 }

--- a/packages/skribble/test/widgets/wired_context_menu_test.dart
+++ b/packages/skribble/test/widgets/wired_context_menu_test.dart
@@ -4,6 +4,13 @@ import 'package:skribble/skribble.dart';
 
 import '../helpers/pump_app.dart';
 
+Finder findWiredIcon(IconData icon) {
+  return find.byWidgetPredicate(
+    (widget) => widget is WiredIcon && widget.icon == icon,
+    description: 'WiredIcon($icon)',
+  );
+}
+
 void main() {
   group('WiredContextMenu', () {
     testWidgets('renders child', (tester) async {
@@ -127,8 +134,8 @@ void main() {
       await tester.longPress(find.text('Press me'));
       await tester.pumpAndSettle();
 
-      expect(find.byIcon(Icons.edit), findsOneWidget);
-      expect(find.byIcon(Icons.share), findsOneWidget);
+      expect(findWiredIcon(Icons.edit), findsOneWidget);
+      expect(findWiredIcon(Icons.share), findsOneWidget);
     });
 
     testWidgets('contains RepaintBoundary', (tester) async {
@@ -151,10 +158,7 @@ void main() {
             child: Scaffold(
               body: WiredContextMenu(
                 actions: [
-                  WiredContextMenuAction(
-                    label: 'Action',
-                    onPressed: () {},
-                  ),
+                  WiredContextMenuAction(label: 'Action', onPressed: () {}),
                 ],
                 child: const Text('Long press me'),
               ),

--- a/packages/skribble/test/widgets/wired_dismissible_test.dart
+++ b/packages/skribble/test/widgets/wired_dismissible_test.dart
@@ -4,6 +4,13 @@ import 'package:skribble/skribble.dart';
 
 import '../helpers/pump_app.dart';
 
+Finder findWiredIcon(IconData icon) {
+  return find.byWidgetPredicate(
+    (widget) => widget is WiredIcon && widget.icon == icon,
+    description: 'WiredIcon($icon)',
+  );
+}
+
 void main() {
   group('WiredDismissible', () {
     testWidgets('renders without error', (tester) async {
@@ -57,7 +64,7 @@ void main() {
       // Start a drag to partially reveal background
       await tester.drag(find.text('Swipe right'), const Offset(100, 0));
       await tester.pump();
-      expect(find.byIcon(Icons.delete), findsOneWidget);
+      expect(findWiredIcon(Icons.delete), findsOneWidget);
     });
 
     testWidgets('respects confirmDismiss', (tester) async {
@@ -116,7 +123,7 @@ void main() {
       );
       await tester.drag(find.text('Custom icon'), const Offset(100, 0));
       await tester.pump();
-      expect(find.byIcon(Icons.archive), findsOneWidget);
+      expect(findWiredIcon(Icons.archive), findsOneWidget);
     });
 
     testWidgets('renders within WiredTheme', (tester) async {

--- a/packages/skribble/test/widgets/wired_navigation_drawer_test.dart
+++ b/packages/skribble/test/widgets/wired_navigation_drawer_test.dart
@@ -5,6 +5,13 @@ import 'package:skribble/skribble.dart';
 import '../helpers/finders.dart';
 import '../helpers/pump_app.dart';
 
+Finder findWiredIcon(IconData icon) {
+  return find.byWidgetPredicate(
+    (widget) => widget is WiredIcon && widget.icon == icon,
+    description: 'WiredIcon($icon)',
+  );
+}
+
 void main() {
   group('WiredNavigationDrawer', () {
     testWidgets('renders destinations', (tester) async {
@@ -157,8 +164,8 @@ void main() {
       scaffoldState.openDrawer();
       await tester.pumpAndSettle();
 
-      expect(find.byIcon(Icons.star), findsOneWidget);
-      expect(find.byIcon(Icons.archive), findsOneWidget);
+      expect(findWiredIcon(Icons.star), findsOneWidget);
+      expect(findWiredIcon(Icons.archive), findsOneWidget);
     });
 
     testWidgets('renders within WiredTheme', (tester) async {

--- a/packages/skribble/test/widgets/wired_reorderable_list_view_test.dart
+++ b/packages/skribble/test/widgets/wired_reorderable_list_view_test.dart
@@ -4,6 +4,13 @@ import 'package:skribble/skribble.dart';
 
 import '../helpers/pump_app.dart';
 
+Finder findWiredIcon(IconData icon) {
+  return find.byWidgetPredicate(
+    (widget) => widget is WiredIcon && widget.icon == icon,
+    description: 'WiredIcon($icon)',
+  );
+}
+
 void main() {
   group('WiredReorderableListView', () {
     testWidgets('renders all children', (tester) async {
@@ -37,7 +44,7 @@ void main() {
         ),
       );
 
-      expect(find.byIcon(Icons.drag_handle), findsNWidgets(2));
+      expect(findWiredIcon(Icons.drag_handle), findsNWidgets(2));
     });
 
     testWidgets('hides drag handles when showDragHandle is false', (
@@ -55,7 +62,7 @@ void main() {
         ),
       );
 
-      expect(find.byIcon(Icons.drag_handle), findsNothing);
+      expect(findWiredIcon(Icons.drag_handle), findsNothing);
     });
 
     testWidgets('calls onReorder callback', (tester) async {
@@ -76,7 +83,7 @@ void main() {
       );
 
       // Long-press the first drag handle to start reorder
-      final firstHandle = find.byIcon(Icons.drag_handle).first;
+      final firstHandle = findWiredIcon(Icons.drag_handle).first;
       final center = tester.getCenter(firstHandle);
 
       // Initiate long press
@@ -140,7 +147,7 @@ void main() {
       );
 
       expect(find.text('Solo'), findsOneWidget);
-      expect(find.byIcon(Icons.drag_handle), findsOneWidget);
+      expect(findWiredIcon(Icons.drag_handle), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary
- update icon rendering to `WiredIcon` in:
  - `WiredContextMenu`
  - `WiredColorPicker`
  - `WiredAvatar` fallback icon
  - `WiredNavigationDrawer`
  - `WiredDismissible`
  - `WiredReorderableListView`
- update widget tests to assert `WiredIcon` behavior
- add changeset entry

## Validation
- `dart analyze --fatal-infos .`
- `flutter test packages/skribble/test/widgets/wired_context_menu_test.dart packages/skribble/test/widgets/wired_color_picker_test.dart packages/skribble/test/widgets/wired_avatar_test.dart packages/skribble/test/widgets/wired_navigation_drawer_test.dart packages/skribble/test/widgets/wired_dismissible_test.dart packages/skribble/test/widgets/wired_reorderable_list_view_test.dart`