### PR TITLE
docs: polish rough icon scripts and snapshot docs

### DIFF
--- a/.changeset/rough-icon-polish-docs-scripts.md
+++ b/.changeset/rough-icon-polish-docs-scripts.md
@@ -1,0 +1,6 @@
+---
+skribble: patch
+---
+
+Add workspace scripts for rough icon generation, and document the new rough
+icons snapshot category in UI screenshot docs.

--- a/docs/ui-snapshots/index.md
+++ b/docs/ui-snapshots/index.md
@@ -13,6 +13,7 @@ Each category page documents the screenshot artifacts produced by the integratio
 - [Feedback](./feedback.md) - `feedback/feedback` + widget snapshots
 - [Layout](./layout.md) - `layout/layout` + widget snapshots
 - [Data Display](./data-display.md) - `data-display/data-display` + widget snapshots
+- [Rough Icons](./rough-icons.md) - `rough-icons/rough-icons` generated icon catalog snapshot
 
 ## Screenshot Hosting
 

--- a/docs/ui-snapshots/rough-icons.md
+++ b/docs/ui-snapshots/rough-icons.md
@@ -1,0 +1,16 @@
+# Rough Icons Gallery
+
+Snapshot of the generated rough Material icon catalog rendered in Storybook.
+
+## Screenshot Artifacts
+
+- Category snapshot: `rough-icons/rough-icons`
+
+![Rough Icons Snapshot](https://f005.backblazeb2.com/file/skribble-screenshots/rough-icons/rough-icons.png)
+
+## Notes
+
+- Uses `materialRoughIconCodePoints` from `WiredIcon` internals to render all
+  currently generated rough icon entries.
+- This view is intended as a quick visual regression check for icon generation
+  changes.

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -190,6 +190,13 @@ dart run tool/generate_material_rough_icons.dart \
   --font-output-dir tool/icon_exports/font
 ```
 
+Workspace shortcuts:
+
+```bash
+melos run rough-icons
+melos run rough-icons-font
+```
+
 Useful flags:
 
 - `--rough-only` to skip Dart map generation and emit rough SVGs only.
@@ -206,6 +213,7 @@ conventions, testing requirements, and quality gates.
 
 - [Parity Matrix](docs/ui-snapshots/parity-matrix.md) — coverage vs Flutter defaults
 - [Screenshot Manifest](docs/ui-snapshots/screenshot-manifest.txt) — all visual snapshots
+- [Rough Icon Pipeline](../../docs/rough-icon-pipeline.md) — icon generation and font tooling
 - [CHANGELOG](CHANGELOG.md) — release history
 
 ## License

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,3 +46,20 @@ melos:
     screenshot:
       description: Capture component screenshots via integration tests.
       run: cd apps/skribble_storybook && flutter test integration_test/screenshots_test.dart
+
+    rough-icons:
+      description: Generate rough Material icon artifacts (Dart map + rough SVG files).
+      run: >-
+        cd packages/skribble &&
+        dart run tool/generate_material_rough_icons.dart
+        --kit flutter-material
+        --rough-output-dir tool/icon_exports/rough-svg
+
+    rough-icons-font:
+      description: Generate rough Material icon font artifacts (TTF) from rough SVGs.
+      run: >-
+        cd packages/skribble &&
+        dart run tool/generate_material_rough_icons.dart
+        --kit flutter-material
+        --rough-output-dir tool/icon_exports/rough-svg
+        --font-output-dir tool/icon_exports/font


### PR DESCRIPTION
## Summary
- add workspace Melos shortcuts for rough icon generation (`rough-icons`, `rough-icons-font`)
- add a dedicated UI snapshot docs page for the rough icon gallery
- link the new rough icon snapshot category from the UI snapshots index
- link rough icon pipeline docs from the package README
- add a changeset entry for the docs/tooling polish

## Validation
- `flutter pub get`
- `dart analyze --fatal-infos .`
