### PR TITLE
feat: add generic rough icon CLI entrypoint

### DIFF
--- a/.changeset/generic-rough-icons-cli-entrypoint.md
+++ b/.changeset/generic-rough-icons-cli-entrypoint.md
@@ -1,0 +1,8 @@
+---
+skribble: patch
+---
+
+Add a kit-agnostic rough icon CLI entrypoint (`tool/generate_rough_icons.dart`),
+keep `generate_material_rough_icons.dart` as a compatibility alias, and add
+`--list-kits` support for discoverability. Update docs and workspace scripts to
+use the new entrypoint.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -2,6 +2,10 @@
 
 This repository ships a Dart CLI at:
 
+- `packages/skribble/tool/generate_rough_icons.dart`
+
+Compatibility alias (backward compatible):
+
 - `packages/skribble/tool/generate_material_rough_icons.dart`
 
 ## What it does
@@ -26,6 +30,13 @@ The script uses `IconKitProvider` (`packages/skribble/tool/icon_kit_provider.dar
 Current provider:
 
 - `flutter-material`
+
+To inspect available providers from CLI:
+
+```bash
+cd packages/skribble
+dart run tool/generate_rough_icons.dart --list-kits
+```
 
 To add another icon kit, implement a provider that:
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -184,7 +184,7 @@ Generate/refresh rough Material icons:
 cd packages/skribble
 deno cache tool/deno/svg2roughjs_cli.ts
 
-dart run tool/generate_material_rough_icons.dart \
+dart run tool/generate_rough_icons.dart \
   --kit flutter-material \
   --rough-output-dir tool/icon_exports/rough-svg \
   --font-output-dir tool/icon_exports/font
@@ -199,6 +199,7 @@ melos run rough-icons-font
 
 Useful flags:
 
+- `--list-kits` to print available icon-kit providers.
 - `--rough-only` to skip Dart map generation and emit rough SVGs only.
 - `--rough-normalize-viewbox 128` to upscale SVG geometry before roughing.
 - `--font-name skribble_rough_icons` to customize generated font family name.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -3,6 +3,10 @@ import 'package:flutter_test/flutter_test.dart';
 import '../../tool/generate_material_rough_icons.dart' as tool;
 
 void main() {
+  test('supportedIconKitsForTest includes flutter-material', () {
+    expect(tool.supportedIconKitsForTest(), contains('flutter-material'));
+  });
+
   group('parseFlutterIconDeclarationsForTest', () {
     test('parses canonical docs metadata', () {
       final declarations = tool.parseFlutterIconDeclarationsForTest('''

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -14,11 +14,22 @@ const _kDefaultRoughCliRunner = 'deno';
 const _kDefaultFontGeneratorExecutable = 'npx';
 const _kDefaultFontGeneratorPackage = 'fantasticon';
 const _kDefaultFontName = 'material_rough_icons';
+const _kSupportedKitDescriptions = <String, String>{
+  _kDefaultKit:
+      'Flutter Material Icons (from Flutter icons.dart + Material SVG packages)',
+};
 
-Future<void> main(List<String> args) async {
+Future<void> main(List<String> args) => runGenerateRoughIcons(args);
+
+Future<void> runGenerateRoughIcons(List<String> args) async {
   final options = _ScriptOptions.parse(args);
   if (options.showHelp) {
     _printUsage();
+    return;
+  }
+
+  if (options.listKits) {
+    _printSupportedKits();
     return;
   }
 
@@ -94,7 +105,7 @@ Future<void> main(List<String> args) async {
 
   if (!options.roughOnly) {
     final outputFile = File(
-      options.outputPath ?? 'lib/src/generated/material_rough_icons.g.dart',
+      options.outputPath ?? _defaultOutputPathForKit(options.kit),
     );
     outputFile.createSync(recursive: true);
     outputFile.writeAsStringSync(_renderGeneratedFile(icons));
@@ -123,10 +134,14 @@ void _printUsage() {
 Generate rough icon artifacts for WiredIcon.
 
 Usage:
+  dart run tool/generate_rough_icons.dart [options]
+
+Compatibility alias:
   dart run tool/generate_material_rough_icons.dart [options]
 
 Options:
   --kit <flutter-material>         Icon kit provider to use.
+  --list-kits                      Print supported --kit values and exit.
   --flutter-icons <path>           Path to Flutter material icons.dart.
   --material-icons-source <path>   Path to extracted @material-design-icons/svg package.
   --material-symbols-source <path> Path to extracted @material-symbols/svg-400 package.
@@ -149,6 +164,24 @@ a temporary directory.
 ''');
 }
 
+void _printSupportedKits() {
+  stdout.writeln('Supported icon kits:');
+  for (final entry in _kSupportedKitDescriptions.entries) {
+    stdout.writeln('  - ${entry.key}: ${entry.value}');
+  }
+}
+
+String _defaultOutputPathForKit(String kit) {
+  if (kit == _kDefaultKit) {
+    return 'lib/src/generated/material_rough_icons.g.dart';
+  }
+  final normalized = kit.toLowerCase().replaceAll(RegExp('[^a-z0-9_]+'), '_');
+  return 'lib/src/generated/${normalized}_rough_icons.g.dart';
+}
+
+List<String> supportedIconKitsForTest() =>
+    _kSupportedKitDescriptions.keys.toList(growable: false);
+
 final class _ScriptOptions {
   const _ScriptOptions({
     this.kit = _kDefaultKit,
@@ -168,6 +201,7 @@ final class _ScriptOptions {
     this.fontGeneratorExecutable = _kDefaultFontGeneratorExecutable,
     this.fontGeneratorPackage = _kDefaultFontGeneratorPackage,
     this.showHelp = false,
+    this.listKits = false,
   });
 
   final String kit;
@@ -187,6 +221,7 @@ final class _ScriptOptions {
   final String fontGeneratorExecutable;
   final String fontGeneratorPackage;
   final bool showHelp;
+  final bool listKits;
 
   static _ScriptOptions parse(List<String> args) {
     var kit = _kDefaultKit;
@@ -206,11 +241,16 @@ final class _ScriptOptions {
     var fontGeneratorExecutable = _kDefaultFontGeneratorExecutable;
     var fontGeneratorPackage = _kDefaultFontGeneratorPackage;
     var showHelp = false;
+    var listKits = false;
 
     for (var index = 0; index < args.length; index++) {
       final argument = args[index];
       if (argument == '--help' || argument == '-h') {
         showHelp = true;
+        continue;
+      }
+      if (argument == '--list-kits') {
+        listKits = true;
         continue;
       }
       if (argument == '--rough-bulk') {
@@ -291,6 +331,7 @@ final class _ScriptOptions {
       fontGeneratorExecutable: fontGeneratorExecutable,
       fontGeneratorPackage: fontGeneratorPackage,
       showHelp: showHelp,
+      listKits: listKits,
     );
   }
 }
@@ -392,7 +433,8 @@ _createProvider(_ScriptOptions options) async {
       );
     default:
       throw ArgumentError(
-        'Unknown --kit value: ${options.kit}. Supported: $_kDefaultKit',
+        'Unknown --kit value: ${options.kit}. Supported: '
+        '${_kSupportedKitDescriptions.keys.join(', ')}',
       );
   }
 }

--- a/packages/skribble/tool/generate_rough_icons.dart
+++ b/packages/skribble/tool/generate_rough_icons.dart
@@ -1,0 +1,3 @@
+import 'generate_material_rough_icons.dart' as material;
+
+Future<void> main(List<String> args) => material.runGenerateRoughIcons(args);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,7 +51,7 @@ melos:
       description: Generate rough Material icon artifacts (Dart map + rough SVG files).
       run: >-
         cd packages/skribble &&
-        dart run tool/generate_material_rough_icons.dart
+        dart run tool/generate_rough_icons.dart
         --kit flutter-material
         --rough-output-dir tool/icon_exports/rough-svg
 
@@ -59,7 +59,7 @@ melos:
       description: Generate rough Material icon font artifacts (TTF) from rough SVGs.
       run: >-
         cd packages/skribble &&
-        dart run tool/generate_material_rough_icons.dart
+        dart run tool/generate_rough_icons.dart
         --kit flutter-material
         --rough-output-dir tool/icon_exports/rough-svg
         --font-output-dir tool/icon_exports/font


### PR DESCRIPTION
## Summary
- add `tool/generate_rough_icons.dart` as the canonical, kit-agnostic CLI entrypoint
- keep `generate_material_rough_icons.dart` as a backwards-compatible alias
- add `--list-kits` support to improve provider discoverability
- make output path default kit-aware (`material_rough_icons.g.dart` for flutter-material)
- update workspace scripts and docs to use the new canonical entrypoint

## Validation
- `flutter pub get`
- `dart analyze --fatal-infos .`
- `flutter test packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart`
- `cd packages/skribble && dart run tool/generate_rough_icons.dart --list-kits`
