### PR TITLE
feat: add svg-manifest support for rough icon generation

### DIFF
--- a/.changeset/rough-icon-svg-manifest-kit.md
+++ b/.changeset/rough-icon-svg-manifest-kit.md
@@ -1,0 +1,7 @@
+---
+skribble: patch
+---
+
+Add `svg-manifest` icon-kit support to rough icon generation so non-Material
+SVG sets can be processed with `--kit svg-manifest --manifest <path>`. Includes
+manifest parser tests, docs updates, and an example manifest file.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -27,15 +27,53 @@ Compatibility alias (backward compatible):
 
 The script uses `IconKitProvider` (`packages/skribble/tool/icon_kit_provider.dart`).
 
-Current provider:
+Current providers:
 
 - `flutter-material`
+- `svg-manifest`
 
 To inspect available providers from CLI:
 
 ```bash
 cd packages/skribble
 dart run tool/generate_rough_icons.dart --list-kits
+```
+
+### `svg-manifest` kit format
+
+Use `--kit svg-manifest --manifest <path>` to rough any icon set without
+writing Dart provider code.
+
+Manifest supports either a top-level list or `{ "icons": [...] }`, where each
+entry includes:
+
+- `identifier` (string)
+- `codePoint` (int or hex string like `"0xe001"`)
+- `svgPath` (preferred) or `svg`/`path` alias
+
+Example:
+
+```json
+{
+  "icons": [
+    {
+      "identifier": "my_star",
+      "codePoint": "0xe001",
+      "svgPath": "icons/my_star.svg"
+    }
+  ]
+}
+```
+
+Run:
+
+```bash
+cd packages/skribble
+dart run tool/generate_rough_icons.dart \
+  --kit svg-manifest \
+  --manifest tool/examples/custom_icons.manifest.json \
+  --output lib/src/generated/custom_rough_icons.g.dart \
+  --rough-output-dir tool/icon_exports/custom-rough-svg
 ```
 
 To add another icon kit, implement a provider that:

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -200,6 +200,7 @@ melos run rough-icons-font
 Useful flags:
 
 - `--list-kits` to print available icon-kit providers.
+- `--kit svg-manifest --manifest <path>` to rough non-Material icon sets from JSON manifests.
 - `--rough-only` to skip Dart map generation and emit rough SVGs only.
 - `--rough-normalize-viewbox 128` to upscale SVG geometry before roughing.
 - `--font-name skribble_rough_icons` to customize generated font family name.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -1,10 +1,14 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../tool/generate_material_rough_icons.dart' as tool;
 
 void main() {
-  test('supportedIconKitsForTest includes flutter-material', () {
-    expect(tool.supportedIconKitsForTest(), contains('flutter-material'));
+  test('supportedIconKitsForTest includes built-in providers', () {
+    final kits = tool.supportedIconKitsForTest();
+    expect(kits, contains('flutter-material'));
+    expect(kits, contains('svg-manifest'));
   });
 
   group('parseFlutterIconDeclarationsForTest', () {
@@ -73,6 +77,68 @@ class Icons {
       expect(declarations[1].oldPackageFolder, 'sharp');
       expect(declarations[1].symbolPackageFolder, 'sharp');
       expect(declarations[1].useSymbolFillVariant, isTrue);
+    });
+  });
+
+  group('parseSvgManifestDeclarationsForTest', () {
+    late Directory tempDirectory;
+
+    setUp(() {
+      tempDirectory = Directory.systemTemp.createTempSync(
+        'rough-icon-manifest-test-',
+      );
+    });
+
+    tearDown(() {
+      tempDirectory.deleteSync(recursive: true);
+    });
+
+    test('parses object format and resolves relative svgPath', () {
+      final iconsDirectory = Directory('${tempDirectory.path}/icons')
+        ..createSync(recursive: true);
+      final heartSvgFile = File('${iconsDirectory.path}/heart.svg')
+        ..writeAsStringSync(
+          '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+        );
+
+      final parsed = tool.parseSvgManifestDeclarationsForTest('''
+{
+  "icons": [
+    {
+      "identifier": "heart",
+      "codePoint": "0xe001",
+      "svgPath": "icons/heart.svg"
+    }
+  ]
+}
+''', manifestDirectoryPath: tempDirectory.path);
+
+      expect(parsed, hasLength(1));
+      expect(parsed.single.identifier, 'heart');
+      expect(parsed.single.codePoint, 0xe001);
+      expect(parsed.single.svgPath, heartSvgFile.path);
+    });
+
+    test('parses list format and supports svg alias key', () {
+      final starSvgFile = File('${tempDirectory.path}/star.svg')
+        ..writeAsStringSync(
+          '<svg viewBox="0 0 24 24"><path d="M2 2h20v20H2z"/></svg>',
+        );
+
+      final parsed = tool.parseSvgManifestDeclarationsForTest('''
+[
+  {
+    "identifier": "star",
+    "codePoint": 57346,
+    "svg": "star.svg"
+  }
+]
+''', manifestDirectoryPath: tempDirectory.path);
+
+      expect(parsed, hasLength(1));
+      expect(parsed.single.identifier, 'star');
+      expect(parsed.single.codePoint, 57346);
+      expect(parsed.single.svgPath, starSvgFile.path);
     });
   });
 }

--- a/packages/skribble/tool/examples/custom_icons.manifest.json
+++ b/packages/skribble/tool/examples/custom_icons.manifest.json
@@ -1,0 +1,14 @@
+{
+  "icons": [
+    {
+      "identifier": "my_star",
+      "codePoint": "0xe001",
+      "svgPath": "icons/my_star.svg"
+    },
+    {
+      "identifier": "my_heart",
+      "codePoint": "0xe002",
+      "svgPath": "icons/my_heart.svg"
+    }
+  ]
+}

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -9,6 +9,7 @@ import 'package:xml/xml.dart';
 import 'icon_kit_provider.dart';
 
 const _kDefaultKit = 'flutter-material';
+const _kManifestKit = 'svg-manifest';
 const _kDefaultRoughCliPath = 'tool/deno/svg2roughjs_cli.ts';
 const _kDefaultRoughCliRunner = 'deno';
 const _kDefaultFontGeneratorExecutable = 'npx';
@@ -17,6 +18,7 @@ const _kDefaultFontName = 'material_rough_icons';
 const _kSupportedKitDescriptions = <String, String>{
   _kDefaultKit:
       'Flutter Material Icons (from Flutter icons.dart + Material SVG packages)',
+  _kManifestKit: 'Custom SVG manifest file for non-Material icon kits',
 };
 
 Future<void> main(List<String> args) => runGenerateRoughIcons(args);
@@ -119,8 +121,9 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
   }
 
   stderr.writeln(
-    'Warning: ${unresolved.length} Flutter icon codepoints could not be '
-    'resolved to SVGs. WiredIcon will fall back to Icon for those values.',
+    'Warning: ${unresolved.length} icon codepoints for kit "${options.kit}" '
+    'could not be resolved to SVGs. WiredIcon will fall back to Icon for '
+    'those values.',
   );
   for (final item in unresolved) {
     stderr.writeln(
@@ -140,8 +143,9 @@ Compatibility alias:
   dart run tool/generate_material_rough_icons.dart [options]
 
 Options:
-  --kit <flutter-material>         Icon kit provider to use.
+  --kit <flutter-material|svg-manifest> Icon kit provider to use.
   --list-kits                      Print supported --kit values and exit.
+  --manifest <path>                JSON manifest for --kit svg-manifest.
   --flutter-icons <path>           Path to Flutter material icons.dart.
   --material-icons-source <path>   Path to extracted @material-design-icons/svg package.
   --material-symbols-source <path> Path to extracted @material-symbols/svg-400 package.
@@ -185,6 +189,7 @@ List<String> supportedIconKitsForTest() =>
 final class _ScriptOptions {
   const _ScriptOptions({
     this.kit = _kDefaultKit,
+    this.manifestPath,
     this.flutterIconsPath,
     this.materialIconsSourcePath,
     this.materialSymbolsSourcePath,
@@ -205,6 +210,7 @@ final class _ScriptOptions {
   });
 
   final String kit;
+  final String? manifestPath;
   final String? flutterIconsPath;
   final String? materialIconsSourcePath;
   final String? materialSymbolsSourcePath;
@@ -225,6 +231,7 @@ final class _ScriptOptions {
 
   static _ScriptOptions parse(List<String> args) {
     var kit = _kDefaultKit;
+    String? manifestPath;
     String? flutterIconsPath;
     String? materialIconsSourcePath;
     String? materialSymbolsSourcePath;
@@ -282,6 +289,8 @@ final class _ScriptOptions {
       switch (option) {
         case '--kit':
           kit = value;
+        case '--manifest':
+          manifestPath = value;
         case '--flutter-icons':
           flutterIconsPath = value;
         case '--material-icons-source':
@@ -315,6 +324,7 @@ final class _ScriptOptions {
 
     return _ScriptOptions(
       kit: kit,
+      manifestPath: manifestPath,
       flutterIconsPath: flutterIconsPath,
       materialIconsSourcePath: materialIconsSourcePath,
       materialSymbolsSourcePath: materialSymbolsSourcePath,
@@ -431,12 +441,212 @@ _createProvider(_ScriptOptions options) async {
         materialIconsRoot: materialIconsRoot,
         materialSymbolsRoot: materialSymbolsRoot,
       );
+    case _kManifestKit:
+      final manifestPath = options.manifestPath;
+      if (manifestPath == null) {
+        throw ArgumentError('--manifest is required when --kit=$_kManifestKit');
+      }
+      final manifestFile = File(manifestPath);
+      if (!manifestFile.existsSync()) {
+        throw StateError('Manifest file not found: ${manifestFile.path}');
+      }
+      return _SvgManifestIconKitProvider.fromManifest(manifestFile);
     default:
       throw ArgumentError(
         'Unknown --kit value: ${options.kit}. Supported: '
         '${_kSupportedKitDescriptions.keys.join(', ')}',
       );
   }
+}
+
+final class _SvgManifestIconKitProvider
+    implements
+        IconKitProvider<
+          _FlutterIconDeclaration,
+          ResolvedSvgCandidate<_GeneratedIconData>
+        > {
+  _SvgManifestIconKitProvider._({
+    required this.entriesByDeclarationKey,
+    required this.declarations,
+  });
+
+  factory _SvgManifestIconKitProvider.fromManifest(File manifestFile) {
+    final entries = _parseSvgManifest(
+      manifestFile.readAsStringSync(),
+      manifestDirectory: manifestFile.parent,
+    );
+    final entriesByDeclarationKey = <String, _ManifestIconEntry>{
+      for (final entry in entries)
+        _manifestDeclarationKey(entry.identifier, entry.codePoint): entry,
+    };
+    final declarations = entries
+        .map(
+          (entry) => _FlutterIconDeclaration(
+            identifier: entry.identifier,
+            baseIdentifier: entry.identifier,
+            codePoint: entry.codePoint,
+            svgName: entry.identifier,
+            oldPackageFolder: 'filled',
+            symbolPackageFolder: 'outlined',
+            useSymbolFillVariant: false,
+          ),
+        )
+        .toList(growable: false);
+
+    return _SvgManifestIconKitProvider._(
+      entriesByDeclarationKey: entriesByDeclarationKey,
+      declarations: declarations,
+    );
+  }
+
+  final Map<String, _ManifestIconEntry> entriesByDeclarationKey;
+  final List<_FlutterIconDeclaration> declarations;
+
+  @override
+  Future<List<_FlutterIconDeclaration>> loadDeclarations() async =>
+      declarations;
+
+  @override
+  ResolvedSvgCandidate<_GeneratedIconData>? resolveIcon(
+    _FlutterIconDeclaration declaration,
+  ) {
+    final entry =
+        entriesByDeclarationKey[_manifestDeclarationKey(
+          declaration.identifier,
+          declaration.codePoint,
+        )];
+    if (entry == null) {
+      return null;
+    }
+
+    return ResolvedSvgCandidate<_GeneratedIconData>(
+      data: _parseSvgIcon(entry.svgFile),
+      sourcePath: entry.svgFile.path,
+    );
+  }
+}
+
+String _manifestDeclarationKey(String identifier, int codePoint) =>
+    '$identifier|$codePoint';
+
+List<_ManifestIconEntry> _parseSvgManifest(
+  String source, {
+  required Directory manifestDirectory,
+}) {
+  final decoded = jsonDecode(source);
+
+  List<Object?> entries;
+  if (decoded is List<Object?>) {
+    entries = decoded;
+  } else if (decoded is Map<String, Object?>) {
+    final icons = decoded['icons'];
+    if (icons is! List<Object?>) {
+      throw FormatException(
+        'Expected top-level "icons" list in manifest JSON object.',
+      );
+    }
+    entries = icons;
+  } else {
+    throw FormatException(
+      'Expected manifest JSON to be either a list or an object with "icons".',
+    );
+  }
+
+  return entries
+      .map((item) => _parseManifestIconEntry(item, manifestDirectory))
+      .toList(growable: false);
+}
+
+_ManifestIconEntry _parseManifestIconEntry(
+  Object? item,
+  Directory manifestDirectory,
+) {
+  if (item is! Map<Object?, Object?>) {
+    throw FormatException('Manifest icon entry must be an object.');
+  }
+
+  final identifier = item['identifier'];
+  if (identifier is! String || identifier.isEmpty) {
+    throw FormatException('Manifest entry is missing string "identifier".');
+  }
+
+  final codePoint = _parseManifestCodePoint(item['codePoint'], identifier);
+
+  final svgPathValue = item['svgPath'] ?? item['svg'] ?? item['path'];
+  if (svgPathValue is! String || svgPathValue.isEmpty) {
+    throw FormatException(
+      'Manifest entry "$identifier" is missing "svgPath" (or "svg").',
+    );
+  }
+
+  final svgFile = _resolveManifestSvgFile(
+    svgPathValue,
+    manifestDirectory: manifestDirectory,
+  );
+  if (!svgFile.existsSync()) {
+    throw StateError(
+      'Manifest entry "$identifier" points to missing SVG: ${svgFile.path}',
+    );
+  }
+
+  return _ManifestIconEntry(
+    identifier: identifier,
+    codePoint: codePoint,
+    svgFile: svgFile,
+  );
+}
+
+int _parseManifestCodePoint(Object? value, String identifier) {
+  if (value is int) {
+    return value;
+  }
+
+  if (value is String) {
+    final normalized = value.trim().toLowerCase();
+    if (normalized.startsWith('0x')) {
+      return int.parse(normalized.substring(2), radix: 16);
+    }
+    return int.parse(normalized);
+  }
+
+  throw FormatException(
+    'Manifest entry "$identifier" must define codePoint as int or string.',
+  );
+}
+
+File _resolveManifestSvgFile(
+  String svgPath, {
+  required Directory manifestDirectory,
+}) {
+  final directFile = File(svgPath);
+  if (_isAbsolutePath(svgPath)) {
+    return directFile;
+  }
+  return File('${manifestDirectory.path}/$svgPath');
+}
+
+bool _isAbsolutePath(String path) {
+  return path.startsWith('/') ||
+      path.startsWith(r'\\') ||
+      RegExp(r'^[a-zA-Z]:[\\/]').hasMatch(path);
+}
+
+List<ParsedManifestIconDeclaration> parseSvgManifestDeclarationsForTest(
+  String source, {
+  required String manifestDirectoryPath,
+}) {
+  return _parseSvgManifest(
+        source,
+        manifestDirectory: Directory(manifestDirectoryPath),
+      )
+      .map(
+        (entry) => ParsedManifestIconDeclaration(
+          identifier: entry.identifier,
+          codePoint: entry.codePoint,
+          svgPath: entry.svgFile.path,
+        ),
+      )
+      .toList(growable: false);
 }
 
 final class _MaterialIconKitProvider
@@ -1190,6 +1400,18 @@ final class _FlutterIconDeclaration {
   final bool useSymbolFillVariant;
 }
 
+final class _ManifestIconEntry {
+  const _ManifestIconEntry({
+    required this.identifier,
+    required this.codePoint,
+    required this.svgFile,
+  });
+
+  final String identifier;
+  final int codePoint;
+  final File svgFile;
+}
+
 final class _GeneratedIcon {
   const _GeneratedIcon({
     required this.codePoint,
@@ -1239,6 +1461,18 @@ final class ParsedFlutterIconDeclaration {
   final String oldPackageFolder;
   final String symbolPackageFolder;
   final bool useSymbolFillVariant;
+}
+
+final class ParsedManifestIconDeclaration {
+  const ParsedManifestIconDeclaration({
+    required this.identifier,
+    required this.codePoint,
+    required this.svgPath,
+  });
+
+  final String identifier;
+  final int codePoint;
+  final String svgPath;
 }
 
 final class _ResolvedSvgSize {


### PR DESCRIPTION
## Summary
- add a new built-in kit: `svg-manifest`
- support `--manifest <path>` for `--kit svg-manifest`
- parse manifest JSON in either list form or `{ "icons": [...] }` form
- support `svgPath` (preferred) plus `svg` / `path` aliases in manifest entries
- resolve manifest SVG paths relative to the manifest file
- add parser test coverage for manifest parsing and kit discovery
- update rough icon docs + README and add example manifest at `tool/examples/custom_icons.manifest.json`

## Validation
- `flutter pub get`
- `dart analyze --fatal-infos .`
- `flutter test packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart`
- `cd packages/skribble && dart run tool/generate_rough_icons.dart --list-kits`
- smoke test: run `--kit svg-manifest --manifest <tmp-manifest> --output <tmp-file>` with a temp SVG
