### PR TITLE
feat: emit Dart helpers for generated rough icon fonts

### DIFF
--- a/.changeset/rough-icon-font-dart-output.md
+++ b/.changeset/rough-icon-font-dart-output.md
@@ -1,0 +1,7 @@
+---
+skribble: patch
+---
+
+Add `--font-dart-output` to rough icon generation so the CLI can emit a Dart
+helper file containing the generated font family constant, codepoint map, and
+lookup function. This prepares follow-up custom hand-drawn font integration.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -22,6 +22,7 @@ Compatibility alias (backward compatible):
    - emits Dart map (`material_rough_icons.g.dart`)
    - emits rough SVG files (`--rough-output-dir`)
    - generates icon fonts with `fantasticon` (`--font-output-dir`)
+   - emits Dart helpers for generated icon fonts (`--font-dart-output`)
 
 ## Extensibility seam
 
@@ -73,7 +74,8 @@ dart run tool/generate_rough_icons.dart \
   --kit svg-manifest \
   --manifest tool/examples/custom_icons.manifest.json \
   --output lib/src/generated/custom_rough_icons.g.dart \
-  --rough-output-dir tool/icon_exports/custom-rough-svg
+  --rough-output-dir tool/icon_exports/custom-rough-svg \
+  --font-dart-output lib/src/generated/custom_rough_icon_font.g.dart
 ```
 
 To add another icon kit, implement a provider that:

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -187,7 +187,8 @@ deno cache tool/deno/svg2roughjs_cli.ts
 dart run tool/generate_rough_icons.dart \
   --kit flutter-material \
   --rough-output-dir tool/icon_exports/rough-svg \
-  --font-output-dir tool/icon_exports/font
+  --font-output-dir tool/icon_exports/font \
+  --font-dart-output lib/src/generated/material_rough_icon_font.g.dart
 ```
 
 Workspace shortcuts:
@@ -204,6 +205,7 @@ Useful flags:
 - `--rough-only` to skip Dart map generation and emit rough SVGs only.
 - `--rough-normalize-viewbox 128` to upscale SVG geometry before roughing.
 - `--font-name skribble_rough_icons` to customize generated font family name.
+- `--font-dart-output <path>` to emit Dart lookup helpers for generated font codepoints.
 - `CHROME_PATH=/path/to/chrome` if Chromium/Chrome is not in a standard location.
 
 ## Contributing

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -80,6 +80,37 @@ class Icons {
     });
   });
 
+  test(
+    'renderFontCodePointsDartForTest renders stable helper names and order',
+    () {
+      final rendered = tool.renderFontCodePointsDartForTest(
+        fontName: 'my-rough-icons',
+        codePoints: <String, int>{
+          'zeta': 0xe200,
+          'beta': 0xe100,
+          'alpha': 0xe100,
+        },
+      );
+
+      expect(
+        rendered,
+        contains('const String kMyRoughIconsFontFamily = "my-rough-icons";'),
+      );
+      expect(
+        rendered,
+        contains('IconData? lookupMyRoughIconsIconData(String identifier) {'),
+      );
+
+      final alphaIndex = rendered.indexOf('"alpha": 0xe100');
+      final betaIndex = rendered.indexOf('"beta": 0xe100');
+      final zetaIndex = rendered.indexOf('"zeta": 0xe200');
+
+      expect(alphaIndex, isNonNegative);
+      expect(betaIndex, greaterThan(alphaIndex));
+      expect(zetaIndex, greaterThan(betaIndex));
+    },
+  );
+
   group('parseSvgManifestDeclarationsForTest', () {
     late Directory tempDirectory;
 

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -105,6 +105,24 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
     );
   }
 
+  if (options.fontDartOutputPath case final outputPath?) {
+    final outputFile = File(outputPath)..createSync(recursive: true);
+    outputFile.writeAsStringSync(
+      _renderFontCodePointsDart(
+        fontName: options.fontName,
+        glyphs: roughTasks
+            .map(
+              (task) => _FontGlyph(
+                identifier: task.identifier,
+                codePoint: task.codePoint,
+              ),
+            )
+            .toList(growable: false),
+      ),
+    );
+    stdout.writeln('Generated icon font Dart helpers to ${outputFile.path}');
+  }
+
   if (!options.roughOnly) {
     final outputFile = File(
       options.outputPath ?? _defaultOutputPathForKit(options.kit),
@@ -158,6 +176,7 @@ Options:
   --rough-bulk                     Use one manifest-driven converter invocation.
   --rough-only                     Skip Dart map generation; only emit rough SVG files.
   --font-output-dir <path>         Build an icon font from rough SVGs into this directory.
+  --font-dart-output <path>        Emit Dart helpers (font family + codepoint lookup map).
   --font-name <name>               Name of generated icon font (default: material_rough_icons).
   --font-generator-executable <e>  Font generator executable (default: npx).
   --font-generator-package <name>  Package passed to generator executable (default: fantasticon).
@@ -202,6 +221,7 @@ final class _ScriptOptions {
     this.roughBulk = false,
     this.roughOnly = false,
     this.fontOutputDir,
+    this.fontDartOutputPath,
     this.fontName = _kDefaultFontName,
     this.fontGeneratorExecutable = _kDefaultFontGeneratorExecutable,
     this.fontGeneratorPackage = _kDefaultFontGeneratorPackage,
@@ -223,6 +243,7 @@ final class _ScriptOptions {
   final bool roughBulk;
   final bool roughOnly;
   final String? fontOutputDir;
+  final String? fontDartOutputPath;
   final String fontName;
   final String fontGeneratorExecutable;
   final String fontGeneratorPackage;
@@ -244,6 +265,7 @@ final class _ScriptOptions {
     var roughBulk = false;
     var roughOnly = false;
     String? fontOutputDir;
+    String? fontDartOutputPath;
     var fontName = _kDefaultFontName;
     var fontGeneratorExecutable = _kDefaultFontGeneratorExecutable;
     var fontGeneratorPackage = _kDefaultFontGeneratorPackage;
@@ -311,6 +333,8 @@ final class _ScriptOptions {
           roughNormalizeViewBox = double.parse(value);
         case '--font-output-dir':
           fontOutputDir = value;
+        case '--font-dart-output':
+          fontDartOutputPath = value;
         case '--font-name':
           fontName = value;
         case '--font-generator-executable':
@@ -337,6 +361,7 @@ final class _ScriptOptions {
       roughBulk: roughBulk,
       roughOnly: roughOnly,
       fontOutputDir: fontOutputDir,
+      fontDartOutputPath: fontDartOutputPath,
       fontName: fontName,
       fontGeneratorExecutable: fontGeneratorExecutable,
       fontGeneratorPackage: fontGeneratorPackage,
@@ -1039,6 +1064,87 @@ String _renderGeneratedFile(List<_GeneratedIcon> icons) {
   return buffer.toString();
 }
 
+String renderFontCodePointsDartForTest({
+  required String fontName,
+  required Map<String, int> codePoints,
+}) {
+  final glyphs = codePoints.entries
+      .map((entry) => _FontGlyph(identifier: entry.key, codePoint: entry.value))
+      .toList(growable: false);
+  return _renderFontCodePointsDart(fontName: fontName, glyphs: glyphs);
+}
+
+String _renderFontCodePointsDart({
+  required String fontName,
+  required List<_FontGlyph> glyphs,
+}) {
+  final sortedGlyphs = [...glyphs]
+    ..sort((a, b) {
+      final byCodePoint = a.codePoint.compareTo(b.codePoint);
+      if (byCodePoint != 0) {
+        return byCodePoint;
+      }
+      return a.identifier.compareTo(b.identifier);
+    });
+
+  final upperCamelName = _toUpperCamelIdentifier(fontName);
+  final familyConstName = 'k${upperCamelName}FontFamily';
+  final codePointsConstName = 'k${upperCamelName}CodePoints';
+  final lookupFunctionName = 'lookup${upperCamelName}IconData';
+
+  final buffer = StringBuffer()
+    ..writeln('// GENERATED CODE - DO NOT MODIFY BY HAND.')
+    ..writeln()
+    ..writeln('''import 'package:flutter/widgets.dart';''')
+    ..writeln()
+    ..writeln('const String $familyConstName = ${jsonEncode(fontName)};')
+    ..writeln()
+    ..writeln('const Map<String, int> $codePointsConstName = <String, int>{');
+
+  for (final glyph in sortedGlyphs) {
+    buffer.writeln(
+      '  ${jsonEncode(glyph.identifier)}: '
+      '0x${glyph.codePoint.toRadixString(16)},',
+    );
+  }
+
+  buffer
+    ..writeln('};')
+    ..writeln()
+    ..writeln('IconData? $lookupFunctionName(String identifier) {')
+    ..writeln('  final codePoint = $codePointsConstName[identifier];')
+    ..writeln('  if (codePoint == null) {')
+    ..writeln('    return null;')
+    ..writeln('  }')
+    ..writeln('  return IconData(codePoint, fontFamily: $familyConstName);')
+    ..writeln('}')
+    ..writeln();
+
+  return buffer.toString();
+}
+
+String _toUpperCamelIdentifier(String value) {
+  final words = value
+      .split(RegExp('[^a-zA-Z0-9]+'))
+      .where((word) => word.isNotEmpty)
+      .toList(growable: false);
+  if (words.isEmpty) {
+    return 'GeneratedRoughIcons';
+  }
+
+  final transformed = words
+      .map(
+        (word) =>
+            '${word.substring(0, 1).toUpperCase()}${word.substring(1).toLowerCase()}',
+      )
+      .join();
+
+  if (RegExp('^[0-9]').hasMatch(transformed)) {
+    return 'Font$transformed';
+  }
+  return transformed;
+}
+
 String _formatDouble(double value) {
   return value == value.roundToDouble()
       ? value.toStringAsFixed(1)
@@ -1410,6 +1516,13 @@ final class _ManifestIconEntry {
   final String identifier;
   final int codePoint;
   final File svgFile;
+}
+
+final class _FontGlyph {
+  const _FontGlyph({required this.identifier, required this.codePoint});
+
+  final String identifier;
+  final int codePoint;
 }
 
 final class _GeneratedIcon {


### PR DESCRIPTION
## Summary
- add `--font-dart-output <path>` to rough icon generation CLI
- emit generated Dart helpers containing:
  - font family constant
  - identifier -> codepoint map
  - lookup helper returning `IconData?`
- keep helper naming deterministic from `--font-name`
- add test coverage for Dart helper rendering order + symbol naming
- document the new flag in rough icon pipeline docs and package README

## Validation
- `flutter pub get`
- `dart analyze --fatal-infos .`
- `flutter test packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart`
- smoke test:
  - `dart run tool/generate_rough_icons.dart --kit svg-manifest --manifest <tmp-manifest> --font-name custom_hand_drawn --font-dart-output <tmp-file>`
