### PR TITLE
feat: validate svg-manifest uniqueness constraints

### DIFF
--- a/.changeset/rough-icon-manifest-validation.md
+++ b/.changeset/rough-icon-manifest-validation.md
@@ -1,0 +1,6 @@
+---
+skribble: patch
+---
+
+Validate `svg-manifest` icon entries for duplicate `identifier` and duplicate
+`codePoint` values, and fail fast with clear `FormatException` details.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -48,8 +48,8 @@ writing Dart provider code.
 Manifest supports either a top-level list or `{ "icons": [...] }`, where each
 entry includes:
 
-- `identifier` (string)
-- `codePoint` (int or hex string like `"0xe001"`)
+- `identifier` (string, must be unique)
+- `codePoint` (int or hex string like `"0xe001"`, must be unique)
 - `svgPath` (preferred) or `svg`/`path` alias
 
 Example:

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -201,7 +201,7 @@ melos run rough-icons-font
 Useful flags:
 
 - `--list-kits` to print available icon-kit providers.
-- `--kit svg-manifest --manifest <path>` to rough non-Material icon sets from JSON manifests.
+- `--kit svg-manifest --manifest <path>` to rough non-Material icon sets from JSON manifests (unique `identifier`/`codePoint` required).
 - `--rough-only` to skip Dart map generation and emit rough SVGs only.
 - `--rough-normalize-viewbox 128` to upscale SVG geometry before roughing.
 - `--font-name skribble_rough_icons` to customize generated font family name.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -171,5 +171,71 @@ class Icons {
       expect(parsed.single.codePoint, 57346);
       expect(parsed.single.svgPath, starSvgFile.path);
     });
+
+    test('throws when identifiers are duplicated', () {
+      File('${tempDirectory.path}/one.svg').writeAsStringSync(
+        '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+      );
+      File('${tempDirectory.path}/two.svg').writeAsStringSync(
+        '<svg viewBox="0 0 24 24"><path d="M2 2h20v20H2z"/></svg>',
+      );
+
+      expect(
+        () => tool.parseSvgManifestDeclarationsForTest('''
+[
+  {
+    "identifier": "dup",
+    "codePoint": "0xe001",
+    "svgPath": "one.svg"
+  },
+  {
+    "identifier": "dup",
+    "codePoint": "0xe002",
+    "svgPath": "two.svg"
+  }
+]
+''', manifestDirectoryPath: tempDirectory.path),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('duplicate identifiers'),
+          ),
+        ),
+      );
+    });
+
+    test('throws when codePoints are duplicated', () {
+      File('${tempDirectory.path}/one.svg').writeAsStringSync(
+        '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+      );
+      File('${tempDirectory.path}/two.svg').writeAsStringSync(
+        '<svg viewBox="0 0 24 24"><path d="M2 2h20v20H2z"/></svg>',
+      );
+
+      expect(
+        () => tool.parseSvgManifestDeclarationsForTest('''
+[
+  {
+    "identifier": "alpha",
+    "codePoint": "0xe001",
+    "svgPath": "one.svg"
+  },
+  {
+    "identifier": "beta",
+    "codePoint": "0xe001",
+    "svgPath": "two.svg"
+  }
+]
+''', manifestDirectoryPath: tempDirectory.path),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('duplicate codePoints'),
+          ),
+        ),
+      );
+    });
   });
 }

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -577,9 +577,42 @@ List<_ManifestIconEntry> _parseSvgManifest(
     );
   }
 
-  return entries
+  final parsedEntries = entries
       .map((item) => _parseManifestIconEntry(item, manifestDirectory))
       .toList(growable: false);
+
+  _validateManifestEntries(parsedEntries);
+  return parsedEntries;
+}
+
+void _validateManifestEntries(List<_ManifestIconEntry> entries) {
+  final seenIdentifiers = <String>{};
+  final duplicateIdentifiers = <String>{};
+
+  final seenCodePoints = <int>{};
+  final duplicateCodePoints = <int>{};
+
+  for (final entry in entries) {
+    if (!seenIdentifiers.add(entry.identifier)) {
+      duplicateIdentifiers.add(entry.identifier);
+    }
+    if (!seenCodePoints.add(entry.codePoint)) {
+      duplicateCodePoints.add(entry.codePoint);
+    }
+  }
+
+  if (duplicateIdentifiers.isEmpty && duplicateCodePoints.isEmpty) {
+    return;
+  }
+
+  final details = <String>[
+    if (duplicateIdentifiers.isNotEmpty)
+      'duplicate identifiers: ${duplicateIdentifiers.join(', ')}',
+    if (duplicateCodePoints.isNotEmpty)
+      'duplicate codePoints: ${duplicateCodePoints.map((codePoint) => '0x${codePoint.toRadixString(16)}').join(', ')}',
+  ];
+
+  throw FormatException('Invalid manifest entries: ${details.join('; ')}');
 }
 
 _ManifestIconEntry _parseManifestIconEntry(


### PR DESCRIPTION
## Summary
- add `svg-manifest` validation for duplicate `identifier` values
- add `svg-manifest` validation for duplicate `codePoint` values
- fail fast with actionable `FormatException` details when duplicates are found
- add parser tests that cover both duplicate-identifier and duplicate-codepoint errors
- document uniqueness requirements in rough icon docs and README

## Validation
- `flutter pub get`
- `dart analyze --fatal-infos .`
- `flutter test packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart`
