### PR TITLE
fix(rough-icons): improve SVG alias resolution for label/wifi variants

### DIFF
--- a/.changeset/rough-icon-alias-resolution.md
+++ b/.changeset/rough-icon-alias-resolution.md
@@ -1,0 +1,11 @@
+---
+skribble: patch
+---
+
+Improve Flutter Material rough icon SVG alias resolution in the generator:
+
+- map `label_outline` variants to `label`
+- map `wifi_tethering_error_rounded` variants to `wifi_tethering_error`
+
+This recovers rough SVG coverage for these icon codepoints and reduces
+runtime fallback-to-`Icon` cases.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -80,6 +80,79 @@ class Icons {
     });
   });
 
+  group('runGenerateRoughIcons alias resolution', () {
+    late Directory tempDirectory;
+
+    setUp(() {
+      tempDirectory = Directory.systemTemp.createTempSync(
+        'rough-icon-alias-resolution-test-',
+      );
+    });
+
+    tearDown(() {
+      tempDirectory.deleteSync(recursive: true);
+    });
+
+    test(
+      'resolves known Flutter alias names to available SVG sources',
+      () async {
+        final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+          ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "wifi tethering error rounded" (round).
+  static const IconData wifi_tethering_error_rounded_rounded = IconData(0xf02c0, fontFamily: 'MaterialIcons');
+}
+''');
+
+        final materialIconsRoot = Directory(
+          '${tempDirectory.path}/material-icons',
+        )..createSync(recursive: true);
+        final materialSymbolsRoot = Directory(
+          '${tempDirectory.path}/material-symbols',
+        )..createSync(recursive: true);
+
+        File('${materialIconsRoot.path}/filled/label.svg')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+          );
+        File(
+            '${materialSymbolsRoot.path}/rounded/wifi_tethering_error-fill.svg',
+          )
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '<svg viewBox="0 0 24 24"><path d="M2 2h20v20H2z"/></svg>',
+          );
+
+        final outputFile = File(
+          '${tempDirectory.path}/material_rough_icons.g.dart',
+        );
+
+        await tool.runGenerateRoughIcons(<String>[
+          '--kit',
+          'flutter-material',
+          '--flutter-icons',
+          flutterIconsFile.path,
+          '--material-icons-source',
+          materialIconsRoot.path,
+          '--material-symbols-source',
+          materialSymbolsRoot.path,
+          '--output',
+          outputFile.path,
+        ]);
+
+        final generated = outputFile.readAsStringSync();
+        expect(generated, contains('// label_outline'));
+        expect(generated, contains('0xe364'));
+        expect(generated, contains('// wifi_tethering_error_rounded_rounded'));
+        expect(generated, contains('0xf02c0'));
+      },
+    );
+  });
+
   test(
     'renderFontCodePointsDartForTest renders stable helper names and order',
     () {

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -897,6 +897,7 @@ const Map<String, List<String>> _svgAliases = <String, List<String>>{
   'invert_colors_on': <String>['invert_colors'],
   'keyboard_control': <String>['keyboard_control_key'],
   'label_important_outline': <String>['label_important'],
+  'label_outline': <String>['label'],
   'leave_bags_at_home': <String>['no_luggage'],
   'lightbulb_outline': <String>['lightbulb'],
   'local_attraction': <String>['local_activity'],
@@ -934,6 +935,7 @@ const Map<String, List<String>> _svgAliases = <String, List<String>>{
   'wallet_membership': <String>['card_membership'],
   'wallet_travel': <String>['card_travel'],
   'wb_twighlight': <String>['wb_twilight'],
+  'wifi_tethering_error_rounded': <String>['wifi_tethering_error'],
   'workspaces_filled': <String>['workspaces'],
   'workspaces_outline': <String>['workspaces'],
 };


### PR DESCRIPTION
## Summary

This PR improves rough SVG resolution for Flutter Material icons whose SDK identifiers no longer match upstream SVG filenames.

### Changes

- Added alias mapping:
  - `label_outline` → `label`
  - `wifi_tethering_error_rounded` → `wifi_tethering_error`
- Added a parser/generator integration-style unit test that verifies `runGenerateRoughIcons` can resolve:
  - `label_outline`
  - `wifi_tethering_error_rounded_rounded`
  via alias lookups against temporary SVG source roots.
- Added a changeset entry.

## Validation

- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `flutter test test/widgets/wired_icon_catalog_test.dart`
- `dart analyze --fatal-infos .`

## Impact

With current upstream icon packages, unresolved Flutter Material rough icon codepoints drop from **63** to **59** when running:

- `dart run tool/generate_rough_icons.dart --output /tmp/material_rough_icons_alias_check.g.dart`
