### PR TITLE
feat(rough-icons): add simple-icons fallback for brand glyph coverage

### DIFF
--- a/.changeset/rough-icon-brand-fallback-source.md
+++ b/.changeset/rough-icon-brand-fallback-source.md
@@ -1,0 +1,13 @@
+---
+skribble: patch
+---
+
+Improve rough Material icon SVG resolution for brand/social glyphs by adding a
+`simple-icons` fallback source to the generator.
+
+- New CLI option: `--brand-icons-source <path>`
+- Default behavior now attempts a best-effort `simple-icons` package fallback
+- Adds `woo_commerce -> woocommerce` brand slug mapping for fallback lookup
+
+This reduces unresolved Material rough icon codepoints when Flutter exposes
+brand identifiers that are not present in upstream Material SVG packages.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -14,6 +14,7 @@ Compatibility alias (backward compatible):
 2. Resolves source SVGs from:
    - `@material-design-icons/svg`
    - `@material-symbols/svg-400`
+   - optional brand fallback from `simple-icons` (for names missing in Material SVG packages)
 3. Normalizes source SVGs to a large viewBox (`--rough-normalize-viewbox`, default `128`).
 4. Runs `svg2roughjs` through a Deno TypeScript wrapper script:
    - `packages/skribble/tool/deno/svg2roughjs_cli.ts`
@@ -84,6 +85,14 @@ To add another icon kit, implement a provider that:
 - resolves a declaration to SVG source + parsed icon metadata (`resolveIcon`)
 
 The roughing and font stages remain unchanged.
+
+## Brand icon fallback source
+
+When a Flutter Material icon identifier does not exist in Material SVG packages
+(e.g. social/brand icons), the CLI can also resolve from `simple-icons`.
+
+- Auto mode (default): tries `npm pack simple-icons` best-effort.
+- Manual source override: `--brand-icons-source <path>`.
 
 ## Runtime prerequisites
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -204,6 +204,7 @@ Useful flags:
 - `--kit svg-manifest --manifest <path>` to rough non-Material icon sets from JSON manifests (unique `identifier`/`codePoint` required).
 - `--rough-only` to skip Dart map generation and emit rough SVGs only.
 - `--rough-normalize-viewbox 128` to upscale SVG geometry before roughing.
+- `--brand-icons-source <path>` to provide a local `simple-icons` package as fallback for brand identifiers missing in Material SVG packages.
 - `--font-name skribble_rough_icons` to customize generated font family name.
 - `--font-dart-output <path>` to emit Dart lookup helpers for generated font codepoints.
 - `CHROME_PATH=/path/to/chrome` if Chromium/Chrome is not in a standard location.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -153,6 +153,85 @@ class Icons {
     );
   });
 
+  group('runGenerateRoughIcons brand fallback', () {
+    late Directory tempDirectory;
+
+    setUp(() {
+      tempDirectory = Directory.systemTemp.createTempSync(
+        'rough-icon-brand-fallback-test-',
+      );
+    });
+
+    tearDown(() {
+      tempDirectory.deleteSync(recursive: true);
+    });
+
+    test(
+      'resolves selected brand icons from simple-icons fallback source',
+      () async {
+        final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+          ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "facebook".
+  static const IconData facebook = IconData(0xe255, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "woo commerce" (outlined).
+  static const IconData woo_commerce_outlined = IconData(0xf069f, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+        final materialIconsRoot = Directory(
+          '${tempDirectory.path}/material-icons',
+        )..createSync(recursive: true);
+        final materialSymbolsRoot = Directory(
+          '${tempDirectory.path}/material-symbols',
+        )..createSync(recursive: true);
+        final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+          ..createSync(recursive: true);
+
+        File('${brandIconsRoot.path}/icons/facebook.svg')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '<svg viewBox="0 0 24 24"><path d="M4 4h16v16H4z"/></svg>',
+          );
+        File('${brandIconsRoot.path}/icons/woocommerce.svg')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '<svg viewBox="0 0 24 24"><path d="M6 6h12v12H6z"/></svg>',
+          );
+
+        final outputFile = File(
+          '${tempDirectory.path}/material_rough_icons.g.dart',
+        );
+
+        await tool.runGenerateRoughIcons(<String>[
+          '--kit',
+          'flutter-material',
+          '--flutter-icons',
+          flutterIconsFile.path,
+          '--material-icons-source',
+          materialIconsRoot.path,
+          '--material-symbols-source',
+          materialSymbolsRoot.path,
+          '--brand-icons-source',
+          brandIconsRoot.path,
+          '--output',
+          outputFile.path,
+        ]);
+
+        final generated = outputFile.readAsStringSync();
+        expect(generated, contains('// facebook'));
+        expect(generated, contains('// woo_commerce_outlined'));
+        expect(generated, contains('0xe255'));
+        expect(generated, contains('0xf069f'));
+        expect(generated, isNot(contains('// adobe')));
+      },
+    );
+  });
+
   test(
     'renderFontCodePointsDartForTest renders stable helper names and order',
     () {

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -14,6 +14,7 @@ const _kDefaultRoughCliPath = 'tool/deno/svg2roughjs_cli.ts';
 const _kDefaultRoughCliRunner = 'deno';
 const _kDefaultFontGeneratorExecutable = 'npx';
 const _kDefaultFontGeneratorPackage = 'fantasticon';
+const _kDefaultBrandIconsPackage = 'simple-icons';
 const _kDefaultFontName = 'material_rough_icons';
 const _kSupportedKitDescriptions = <String, String>{
   _kDefaultKit:
@@ -167,6 +168,7 @@ Options:
   --flutter-icons <path>           Path to Flutter material icons.dart.
   --material-icons-source <path>   Path to extracted @material-design-icons/svg package.
   --material-symbols-source <path> Path to extracted @material-symbols/svg-400 package.
+  --brand-icons-source <path>      Path to extracted simple-icons package (brand fallback).
   --output <path>                  Output Dart file.
   --rough-cli <path>               TypeScript script that converts SVG(s) (default: tool/deno/svg2roughjs_cli.ts).
   --rough-cli-runner <exe>         Runner executable for --rough-cli (default: deno).
@@ -212,6 +214,7 @@ final class _ScriptOptions {
     this.flutterIconsPath,
     this.materialIconsSourcePath,
     this.materialSymbolsSourcePath,
+    this.brandIconsSourcePath,
     this.outputPath,
     this.roughCliPath,
     this.roughCliRunner = _kDefaultRoughCliRunner,
@@ -234,6 +237,7 @@ final class _ScriptOptions {
   final String? flutterIconsPath;
   final String? materialIconsSourcePath;
   final String? materialSymbolsSourcePath;
+  final String? brandIconsSourcePath;
   final String? outputPath;
   final String? roughCliPath;
   final String roughCliRunner;
@@ -256,6 +260,7 @@ final class _ScriptOptions {
     String? flutterIconsPath;
     String? materialIconsSourcePath;
     String? materialSymbolsSourcePath;
+    String? brandIconsSourcePath;
     String? outputPath;
     String? roughCliPath;
     var roughCliRunner = _kDefaultRoughCliRunner;
@@ -319,6 +324,8 @@ final class _ScriptOptions {
           materialIconsSourcePath = value;
         case '--material-symbols-source':
           materialSymbolsSourcePath = value;
+        case '--brand-icons-source':
+          brandIconsSourcePath = value;
         case '--output':
           outputPath = value;
         case '--rough-cli':
@@ -352,6 +359,7 @@ final class _ScriptOptions {
       flutterIconsPath: flutterIconsPath,
       materialIconsSourcePath: materialIconsSourcePath,
       materialSymbolsSourcePath: materialSymbolsSourcePath,
+      brandIconsSourcePath: brandIconsSourcePath,
       outputPath: outputPath,
       roughCliPath: roughCliPath,
       roughCliRunner: roughCliRunner,
@@ -435,6 +443,31 @@ Future<Directory> _resolvePackageRoot({
   return Directory('${tempDirectory.path}/package');
 }
 
+Future<Directory?> _resolveOptionalPackageRoot({
+  required String packageName,
+  required String? suppliedPath,
+}) async {
+  if (suppliedPath != null) {
+    return _resolvePackageRoot(
+      packageName: packageName,
+      suppliedPath: suppliedPath,
+    );
+  }
+
+  try {
+    return await _resolvePackageRoot(
+      packageName: packageName,
+      suppliedPath: suppliedPath,
+    );
+  } on Object catch (error) {
+    stderr.writeln(
+      'Warning: Optional package "$packageName" could not be resolved. '
+      'Continuing without this fallback source.\n$error',
+    );
+    return null;
+  }
+}
+
 Future<
   IconKitProvider<
     _FlutterIconDeclaration,
@@ -460,11 +493,16 @@ _createProvider(_ScriptOptions options) async {
         packageName: '@material-symbols/svg-400',
         suppliedPath: options.materialSymbolsSourcePath,
       );
+      final brandIconsRoot = await _resolveOptionalPackageRoot(
+        packageName: _kDefaultBrandIconsPackage,
+        suppliedPath: options.brandIconsSourcePath,
+      );
 
       return _MaterialIconKitProvider(
         flutterIconsFile: flutterIconsFile,
         materialIconsRoot: materialIconsRoot,
         materialSymbolsRoot: materialSymbolsRoot,
+        brandIconsRoot: brandIconsRoot,
       );
     case _kManifestKit:
       final manifestPath = options.manifestPath;
@@ -717,11 +755,13 @@ final class _MaterialIconKitProvider
     required this.flutterIconsFile,
     required this.materialIconsRoot,
     required this.materialSymbolsRoot,
+    this.brandIconsRoot,
   });
 
   final File flutterIconsFile;
   final Directory materialIconsRoot;
   final Directory materialSymbolsRoot;
+  final Directory? brandIconsRoot;
 
   @override
   Future<List<_FlutterIconDeclaration>> loadDeclarations() async {
@@ -736,6 +776,7 @@ final class _MaterialIconKitProvider
       declaration,
       materialIconsRoot: materialIconsRoot,
       materialSymbolsRoot: materialSymbolsRoot,
+      brandIconsRoot: brandIconsRoot,
     );
   }
 }
@@ -833,6 +874,7 @@ ResolvedSvgCandidate<_GeneratedIconData>? _resolveIconData(
   _FlutterIconDeclaration declaration, {
   required Directory materialIconsRoot,
   required Directory materialSymbolsRoot,
+  required Directory? brandIconsRoot,
 }) {
   final candidates = <String>{
     declaration.svgName,
@@ -866,10 +908,39 @@ ResolvedSvgCandidate<_GeneratedIconData>? _resolveIconData(
         );
       }
     }
+
+    if (brandIconsRoot case final root?) {
+      final brandFile = _resolveBrandIconSvgFile(root, candidate);
+      if (brandFile != null && brandFile.existsSync()) {
+        return ResolvedSvgCandidate<_GeneratedIconData>(
+          data: _parseSvgIcon(brandFile),
+          sourcePath: brandFile.path,
+        );
+      }
+    }
   }
 
   return null;
 }
+
+File? _resolveBrandIconSvgFile(Directory brandIconsRoot, String identifier) {
+  final slug = _brandIconAliases[identifier] ?? identifier;
+  final iconDirectoryCandidate = File('${brandIconsRoot.path}/icons/$slug.svg');
+  if (iconDirectoryCandidate.existsSync()) {
+    return iconDirectoryCandidate;
+  }
+
+  final rootCandidate = File('${brandIconsRoot.path}/$slug.svg');
+  if (rootCandidate.existsSync()) {
+    return rootCandidate;
+  }
+
+  return null;
+}
+
+const Map<String, String> _brandIconAliases = <String, String>{
+  'woo_commerce': 'woocommerce',
+};
 
 const Map<String, List<String>> _svgAliases = <String, List<String>>{
   'airplanemode_off': <String>['airplanemode_inactive'],


### PR DESCRIPTION
## Summary

This PR improves rough Material icon generation coverage for Flutter brand/social icon identifiers that do not currently exist in upstream Material SVG packages.

### What changed

- Added optional **brand fallback source** in generator:
  - New CLI flag: `--brand-icons-source <path>`
  - Default behavior now attempts best-effort resolution from `simple-icons`
- Added fallback slug mapping:
  - `woo_commerce` → `woocommerce`
- Updated docs:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Added parser/generator test coverage for brand fallback resolution.
- Added changeset entry.

## Validation

- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `flutter test test/widgets/wired_icon_catalog_test.dart`
- `dart analyze --fatal-infos .`

## Impact

With default source discovery:

- `dart run tool/generate_rough_icons.dart --output /tmp/material_rough_icons_brand_fallback_check.g.dart`

Unresolved codepoints dropped from **59 → 7** in my local run.
