### PR TITLE
feat(rough-icons): add supplemental manifest fallback

### DIFF
--- a/.changeset/rough-icon-supplemental-manifest-fallback.md
+++ b/.changeset/rough-icon-supplemental-manifest-fallback.md
@@ -1,0 +1,13 @@
+---
+skribble: patch
+---
+
+Add a supplemental manifest fallback for `flutter-material` rough icon
+generation.
+
+- New CLI option: `--supplemental-manifest <path>`
+- Manifest entries (`identifier`, `codePoint`, `svgPath`) are used as a final
+  fallback when Material and brand SVG sources cannot resolve an icon
+
+This makes it possible to supply custom SVGs for remaining unresolved Material
+icon codepoints without switching to `--kit svg-manifest`.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -94,6 +94,17 @@ When a Flutter Material icon identifier does not exist in Material SVG packages
 - Auto mode (default): tries `npm pack simple-icons` best-effort.
 - Manual source override: `--brand-icons-source <path>`.
 
+## Supplemental manifest source
+
+For unresolved Flutter Material icons that are absent from both Material SVG
+packages and brand fallback packages, pass a custom manifest file:
+
+- `--supplemental-manifest <path>`
+
+This uses the same JSON schema as `--kit svg-manifest` (`identifier`,
+`codePoint`, `svgPath`) and is applied as a fallback during
+`--kit flutter-material` resolution.
+
 ## Runtime prerequisites
 
 - `deno` available on PATH

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -205,6 +205,7 @@ Useful flags:
 - `--rough-only` to skip Dart map generation and emit rough SVGs only.
 - `--rough-normalize-viewbox 128` to upscale SVG geometry before roughing.
 - `--brand-icons-source <path>` to provide a local `simple-icons` package as fallback for brand identifiers missing in Material SVG packages.
+- `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints.
 - `--font-name skribble_rough_icons` to customize generated font family name.
 - `--font-dart-output <path>` to emit Dart lookup helpers for generated font codepoints.
 - `CHROME_PATH=/path/to/chrome` if Chromium/Chrome is not in a standard location.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -232,6 +232,96 @@ class Icons {
     );
   });
 
+  group('runGenerateRoughIcons supplemental manifest', () {
+    late Directory tempDirectory;
+
+    setUp(() {
+      tempDirectory = Directory.systemTemp.createTempSync(
+        'rough-icon-supplemental-manifest-test-',
+      );
+    });
+
+    tearDown(() {
+      tempDirectory.deleteSync(recursive: true);
+    });
+
+    test(
+      'resolves unresolved declarations from supplemental manifest',
+      () async {
+        final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+          ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "face unlock" (sharp).
+  static const IconData face_unlock_sharp = IconData(0xe951, fontFamily: 'MaterialIcons');
+}
+''');
+
+        final materialIconsRoot = Directory(
+          '${tempDirectory.path}/material-icons',
+        )..createSync(recursive: true);
+        final materialSymbolsRoot = Directory(
+          '${tempDirectory.path}/material-symbols',
+        )..createSync(recursive: true);
+        final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+          ..createSync(recursive: true);
+
+        File('${tempDirectory.path}/adobe.svg').writeAsStringSync(
+          '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+        );
+        File('${tempDirectory.path}/face_unlock.svg').writeAsStringSync(
+          '<svg viewBox="0 0 24 24"><path d="M2 2h20v20H2z"/></svg>',
+        );
+        final supplementalManifestFile =
+            File('${tempDirectory.path}/extra.json')..writeAsStringSync('''
+{
+  "icons": [
+    {
+      "identifier": "adobe",
+      "codePoint": "0xf04b9",
+      "svgPath": "adobe.svg"
+    },
+    {
+      "identifier": "face_unlock",
+      "codePoint": "0xe951",
+      "svgPath": "face_unlock.svg"
+    }
+  ]
+}
+''');
+
+        final outputFile = File(
+          '${tempDirectory.path}/material_rough_icons.g.dart',
+        );
+
+        await tool.runGenerateRoughIcons(<String>[
+          '--kit',
+          'flutter-material',
+          '--flutter-icons',
+          flutterIconsFile.path,
+          '--material-icons-source',
+          materialIconsRoot.path,
+          '--material-symbols-source',
+          materialSymbolsRoot.path,
+          '--brand-icons-source',
+          brandIconsRoot.path,
+          '--supplemental-manifest',
+          supplementalManifestFile.path,
+          '--output',
+          outputFile.path,
+        ]);
+
+        final generated = outputFile.readAsStringSync();
+        expect(generated, contains('// adobe'));
+        expect(generated, contains('// face_unlock_sharp'));
+        expect(generated, contains('0xf04b9'));
+        expect(generated, contains('0xe951'));
+      },
+    );
+  });
+
   test(
     'renderFontCodePointsDartForTest renders stable helper names and order',
     () {

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -169,6 +169,7 @@ Options:
   --material-icons-source <path>   Path to extracted @material-design-icons/svg package.
   --material-symbols-source <path> Path to extracted @material-symbols/svg-400 package.
   --brand-icons-source <path>      Path to extracted simple-icons package (brand fallback).
+  --supplemental-manifest <path>   JSON manifest for unresolved flutter-material icons.
   --output <path>                  Output Dart file.
   --rough-cli <path>               TypeScript script that converts SVG(s) (default: tool/deno/svg2roughjs_cli.ts).
   --rough-cli-runner <exe>         Runner executable for --rough-cli (default: deno).
@@ -215,6 +216,7 @@ final class _ScriptOptions {
     this.materialIconsSourcePath,
     this.materialSymbolsSourcePath,
     this.brandIconsSourcePath,
+    this.supplementalManifestPath,
     this.outputPath,
     this.roughCliPath,
     this.roughCliRunner = _kDefaultRoughCliRunner,
@@ -238,6 +240,7 @@ final class _ScriptOptions {
   final String? materialIconsSourcePath;
   final String? materialSymbolsSourcePath;
   final String? brandIconsSourcePath;
+  final String? supplementalManifestPath;
   final String? outputPath;
   final String? roughCliPath;
   final String roughCliRunner;
@@ -261,6 +264,7 @@ final class _ScriptOptions {
     String? materialIconsSourcePath;
     String? materialSymbolsSourcePath;
     String? brandIconsSourcePath;
+    String? supplementalManifestPath;
     String? outputPath;
     String? roughCliPath;
     var roughCliRunner = _kDefaultRoughCliRunner;
@@ -326,6 +330,8 @@ final class _ScriptOptions {
           materialSymbolsSourcePath = value;
         case '--brand-icons-source':
           brandIconsSourcePath = value;
+        case '--supplemental-manifest':
+          supplementalManifestPath = value;
         case '--output':
           outputPath = value;
         case '--rough-cli':
@@ -360,6 +366,7 @@ final class _ScriptOptions {
       materialIconsSourcePath: materialIconsSourcePath,
       materialSymbolsSourcePath: materialSymbolsSourcePath,
       brandIconsSourcePath: brandIconsSourcePath,
+      supplementalManifestPath: supplementalManifestPath,
       outputPath: outputPath,
       roughCliPath: roughCliPath,
       roughCliRunner: roughCliRunner,
@@ -498,11 +505,34 @@ _createProvider(_ScriptOptions options) async {
         suppliedPath: options.brandIconsSourcePath,
       );
 
+      var supplementalEntriesByDeclarationKey = <String, _ManifestIconEntry>{};
+      if (options.supplementalManifestPath
+          case final supplementalManifestPath?) {
+        final supplementalManifestFile = File(supplementalManifestPath);
+        if (!supplementalManifestFile.existsSync()) {
+          throw StateError(
+            'Supplemental manifest file not found: '
+            '${supplementalManifestFile.path}',
+          );
+        }
+
+        final supplementalEntries = _parseSvgManifest(
+          supplementalManifestFile.readAsStringSync(),
+          manifestDirectory: supplementalManifestFile.parent,
+        );
+        supplementalEntriesByDeclarationKey = <String, _ManifestIconEntry>{
+          for (final entry in supplementalEntries)
+            _manifestDeclarationKey(entry.identifier, entry.codePoint): entry,
+        };
+      }
+
       return _MaterialIconKitProvider(
         flutterIconsFile: flutterIconsFile,
         materialIconsRoot: materialIconsRoot,
         materialSymbolsRoot: materialSymbolsRoot,
         brandIconsRoot: brandIconsRoot,
+        supplementalEntriesByDeclarationKey:
+            supplementalEntriesByDeclarationKey,
       );
     case _kManifestKit:
       final manifestPath = options.manifestPath;
@@ -756,12 +786,15 @@ final class _MaterialIconKitProvider
     required this.materialIconsRoot,
     required this.materialSymbolsRoot,
     this.brandIconsRoot,
+    this.supplementalEntriesByDeclarationKey =
+        const <String, _ManifestIconEntry>{},
   });
 
   final File flutterIconsFile;
   final Directory materialIconsRoot;
   final Directory materialSymbolsRoot;
   final Directory? brandIconsRoot;
+  final Map<String, _ManifestIconEntry> supplementalEntriesByDeclarationKey;
 
   @override
   Future<List<_FlutterIconDeclaration>> loadDeclarations() async {
@@ -777,6 +810,7 @@ final class _MaterialIconKitProvider
       materialIconsRoot: materialIconsRoot,
       materialSymbolsRoot: materialSymbolsRoot,
       brandIconsRoot: brandIconsRoot,
+      supplementalEntriesByDeclarationKey: supplementalEntriesByDeclarationKey,
     );
   }
 }
@@ -875,6 +909,7 @@ ResolvedSvgCandidate<_GeneratedIconData>? _resolveIconData(
   required Directory materialIconsRoot,
   required Directory materialSymbolsRoot,
   required Directory? brandIconsRoot,
+  required Map<String, _ManifestIconEntry> supplementalEntriesByDeclarationKey,
 }) {
   final candidates = <String>{
     declaration.svgName,
@@ -918,6 +953,22 @@ ResolvedSvgCandidate<_GeneratedIconData>? _resolveIconData(
         );
       }
     }
+  }
+
+  for (final candidate in candidates) {
+    final supplementalEntry =
+        supplementalEntriesByDeclarationKey[_manifestDeclarationKey(
+          candidate,
+          declaration.codePoint,
+        )];
+    if (supplementalEntry == null) {
+      continue;
+    }
+
+    return ResolvedSvgCandidate<_GeneratedIconData>(
+      data: _parseSvgIcon(supplementalEntry.svgFile),
+      sourcePath: supplementalEntry.svgFile.path,
+    );
   }
 
   return null;


### PR DESCRIPTION
## Summary

This PR adds a supplemental manifest fallback for `flutter-material` rough icon generation.

### What changed

- Added new CLI flag:
  - `--supplemental-manifest <path>`
- For `--kit flutter-material`, the generator now applies supplemental manifest entries as a **final fallback** after:
  1. Material SVG packages (`@material-design-icons/svg`, `@material-symbols/svg-400`)
  2. brand fallback (`simple-icons`)
- Supplemental entries use the same schema as `svg-manifest`:
  - `identifier`
  - `codePoint`
  - `svgPath`
- Added parser/generator test coverage that verifies unresolved declarations can be resolved from a supplemental manifest.
- Updated docs:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Added changeset.

## Validation

- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `flutter test test/widgets/wired_icon_catalog_test.dart`
- `dart analyze --fatal-infos .`
