### PR TITLE
feat(rough-icons): emit unresolved icon report JSON

### DIFF
--- a/.changeset/rough-icon-unresolved-report-output.md
+++ b/.changeset/rough-icon-unresolved-report-output.md
@@ -1,0 +1,12 @@
+---
+skribble: patch
+---
+
+Add unresolved report output support to rough icon generation.
+
+- New CLI option: `--unresolved-output <path>`
+- Emits a JSON report with `resolvedCount`, `unresolvedCount`, and unresolved
+  entries (`codePoint`, `identifiers`)
+
+This helps author follow-up supplemental manifests for unresolved
+`flutter-material` icon codepoints.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -24,6 +24,7 @@ Compatibility alias (backward compatible):
    - emits rough SVG files (`--rough-output-dir`)
    - generates icon fonts with `fantasticon` (`--font-output-dir`)
    - emits Dart helpers for generated icon fonts (`--font-dart-output`)
+   - emits unresolved icon reports as JSON (`--unresolved-output`)
 
 ## Extensibility seam
 
@@ -104,6 +105,19 @@ packages and brand fallback packages, pass a custom manifest file:
 This uses the same JSON schema as `--kit svg-manifest` (`identifier`,
 `codePoint`, `svgPath`) and is applied as a fallback during
 `--kit flutter-material` resolution.
+
+## Unresolved report output
+
+To emit a machine-readable unresolved report for follow-up work, pass:
+
+- `--unresolved-output <path>`
+
+The JSON report includes:
+
+- `kit`
+- `resolvedCount`
+- `unresolvedCount`
+- `unresolved[]` entries with `codePoint` and `identifiers`
 
 ## Runtime prerequisites
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -206,6 +206,7 @@ Useful flags:
 - `--rough-normalize-viewbox 128` to upscale SVG geometry before roughing.
 - `--brand-icons-source <path>` to provide a local `simple-icons` package as fallback for brand identifiers missing in Material SVG packages.
 - `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints.
+- `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring.
 - `--font-name skribble_rough_icons` to customize generated font family name.
 - `--font-dart-output <path>` to emit Dart lookup helpers for generated font codepoints.
 - `CHROME_PATH=/path/to/chrome` if Chromium/Chrome is not in a standard location.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -320,6 +321,92 @@ class Icons {
         expect(generated, contains('0xe951'));
       },
     );
+  });
+
+  group('runGenerateRoughIcons unresolved report', () {
+    late Directory tempDirectory;
+
+    setUp(() {
+      tempDirectory = Directory.systemTemp.createTempSync(
+        'rough-icon-unresolved-report-test-',
+      );
+    });
+
+    tearDown(() {
+      tempDirectory.deleteSync(recursive: true);
+    });
+
+    test('writes unresolved icon report JSON when requested', () async {
+      final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+        ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+      final materialIconsRoot = Directory(
+        '${tempDirectory.path}/material-icons',
+      )..createSync(recursive: true);
+      final materialSymbolsRoot = Directory(
+        '${tempDirectory.path}/material-symbols',
+      )..createSync(recursive: true);
+      final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+        ..createSync(recursive: true);
+
+      File('${materialIconsRoot.path}/filled/label.svg')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(
+          '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+        );
+
+      final outputFile = File(
+        '${tempDirectory.path}/material_rough_icons.g.dart',
+      );
+      final unresolvedReportFile = File(
+        '${tempDirectory.path}/unresolved.json',
+      );
+
+      await tool.runGenerateRoughIcons(<String>[
+        '--kit',
+        'flutter-material',
+        '--flutter-icons',
+        flutterIconsFile.path,
+        '--material-icons-source',
+        materialIconsRoot.path,
+        '--material-symbols-source',
+        materialSymbolsRoot.path,
+        '--brand-icons-source',
+        brandIconsRoot.path,
+        '--unresolved-output',
+        unresolvedReportFile.path,
+        '--output',
+        outputFile.path,
+      ]);
+
+      expect(unresolvedReportFile.existsSync(), isTrue);
+
+      final decoded =
+          jsonDecode(unresolvedReportFile.readAsStringSync())
+              as Map<String, dynamic>;
+      expect(decoded['kit'], 'flutter-material');
+      expect(decoded['resolvedCount'], 1);
+      expect(decoded['unresolvedCount'], 1);
+
+      final unresolved = decoded['unresolved'] as List<dynamic>;
+      expect(unresolved, hasLength(1));
+
+      final firstUnresolved = unresolved.first as Map<String, dynamic>;
+      expect(firstUnresolved['codePoint'], '0xf04b9');
+      expect(firstUnresolved['identifiers'], <String>['adobe']);
+
+      final generated = outputFile.readAsStringSync();
+      expect(generated, contains('// label_outline'));
+      expect(generated, isNot(contains('// adobe')));
+    });
   });
 
   test(

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -135,6 +135,21 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
     );
   }
 
+  if (options.unresolvedOutputPath case final unresolvedOutputPath?) {
+    final unresolvedOutputFile = File(unresolvedOutputPath)
+      ..createSync(recursive: true);
+    unresolvedOutputFile.writeAsStringSync(
+      _renderUnresolvedReportJson(
+        kit: options.kit,
+        resolvedCount: icons.length,
+        unresolved: unresolved,
+      ),
+    );
+    stdout.writeln(
+      'Generated unresolved icon report to ${unresolvedOutputFile.path}',
+    );
+  }
+
   if (unresolved.isEmpty) {
     return;
   }
@@ -170,6 +185,7 @@ Options:
   --material-symbols-source <path> Path to extracted @material-symbols/svg-400 package.
   --brand-icons-source <path>      Path to extracted simple-icons package (brand fallback).
   --supplemental-manifest <path>   JSON manifest for unresolved flutter-material icons.
+  --unresolved-output <path>       Emit unresolved icon codepoint report as JSON.
   --output <path>                  Output Dart file.
   --rough-cli <path>               TypeScript script that converts SVG(s) (default: tool/deno/svg2roughjs_cli.ts).
   --rough-cli-runner <exe>         Runner executable for --rough-cli (default: deno).
@@ -217,6 +233,7 @@ final class _ScriptOptions {
     this.materialSymbolsSourcePath,
     this.brandIconsSourcePath,
     this.supplementalManifestPath,
+    this.unresolvedOutputPath,
     this.outputPath,
     this.roughCliPath,
     this.roughCliRunner = _kDefaultRoughCliRunner,
@@ -241,6 +258,7 @@ final class _ScriptOptions {
   final String? materialSymbolsSourcePath;
   final String? brandIconsSourcePath;
   final String? supplementalManifestPath;
+  final String? unresolvedOutputPath;
   final String? outputPath;
   final String? roughCliPath;
   final String roughCliRunner;
@@ -265,6 +283,7 @@ final class _ScriptOptions {
     String? materialSymbolsSourcePath;
     String? brandIconsSourcePath;
     String? supplementalManifestPath;
+    String? unresolvedOutputPath;
     String? outputPath;
     String? roughCliPath;
     var roughCliRunner = _kDefaultRoughCliRunner;
@@ -332,6 +351,8 @@ final class _ScriptOptions {
           brandIconsSourcePath = value;
         case '--supplemental-manifest':
           supplementalManifestPath = value;
+        case '--unresolved-output':
+          unresolvedOutputPath = value;
         case '--output':
           outputPath = value;
         case '--rough-cli':
@@ -367,6 +388,7 @@ final class _ScriptOptions {
       materialSymbolsSourcePath: materialSymbolsSourcePath,
       brandIconsSourcePath: brandIconsSourcePath,
       supplementalManifestPath: supplementalManifestPath,
+      unresolvedOutputPath: unresolvedOutputPath,
       outputPath: outputPath,
       roughCliPath: roughCliPath,
       roughCliRunner: roughCliRunner,
@@ -1219,6 +1241,28 @@ String _renderGeneratedFile(List<_GeneratedIcon> icons) {
     ..writeln();
 
   return buffer.toString();
+}
+
+String _renderUnresolvedReportJson({
+  required String kit,
+  required int resolvedCount,
+  required List<_UnresolvedIcon> unresolved,
+}) {
+  final report = <String, Object>{
+    'kit': kit,
+    'resolvedCount': resolvedCount,
+    'unresolvedCount': unresolved.length,
+    'unresolved': unresolved
+        .map(
+          (item) => <String, Object>{
+            'codePoint': '0x${item.codePoint.toRadixString(16)}',
+            'identifiers': item.identifiers,
+          },
+        )
+        .toList(growable: false),
+  };
+
+  return const JsonEncoder.withIndent('  ').convert(report);
 }
 
 String renderFontCodePointsDartForTest({


### PR DESCRIPTION
## Summary

This PR adds unresolved report output support to the rough icon generator.

### What changed

- New CLI option:
  - `--unresolved-output <path>`
- Generator now emits a JSON report with:
  - `kit`
  - `resolvedCount`
  - `unresolvedCount`
  - `unresolved[]` (`codePoint`, `identifiers`)
- Added parser/generator test coverage verifying report generation and contents.
- Updated docs:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Added changeset.

## Validation

- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `flutter test test/widgets/wired_icon_catalog_test.dart`
- `dart analyze --fatal-infos .`

## Example

```bash
cd packages/skribble
dart run tool/generate_rough_icons.dart \
  --kit flutter-material \
  --output /tmp/material_rough_icons.g.dart \
  --unresolved-output /tmp/material_rough_icons_unresolved_report.json
```
