### PR TITLE
feat(rough-icons): add fail-on-unresolved strict mode

### DIFF
--- a/.changeset/rough-icon-fail-on-unresolved.md
+++ b/.changeset/rough-icon-fail-on-unresolved.md
@@ -1,0 +1,12 @@
+---
+skribble: patch
+---
+
+Add strict unresolved failure mode to rough icon generation.
+
+- New CLI option: `--fail-on-unresolved`
+- When unresolved icons remain, the generator now exits with `StateError`
+  instead of warning-only behavior
+
+This allows CI to enforce complete rough icon coverage once supplemental
+manifests are in place.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -25,6 +25,7 @@ Compatibility alias (backward compatible):
    - generates icon fonts with `fantasticon` (`--font-output-dir`)
    - emits Dart helpers for generated icon fonts (`--font-dart-output`)
    - emits unresolved icon reports as JSON (`--unresolved-output`)
+   - can fail CI on unresolved icons (`--fail-on-unresolved`)
 
 ## Extensibility seam
 
@@ -118,6 +119,15 @@ The JSON report includes:
 - `resolvedCount`
 - `unresolvedCount`
 - `unresolved[]` entries with `codePoint` and `identifiers`
+
+## Strict unresolved mode
+
+To make generation fail when unresolved icons remain, pass:
+
+- `--fail-on-unresolved`
+
+This is useful in CI once supplemental manifest coverage is expected to be
+complete.
 
 ## Runtime prerequisites
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -207,6 +207,7 @@ Useful flags:
 - `--brand-icons-source <path>` to provide a local `simple-icons` package as fallback for brand identifiers missing in Material SVG packages.
 - `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints.
 - `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring.
+- `--fail-on-unresolved` to make the command exit non-zero if unresolved icons remain.
 - `--font-name skribble_rough_icons` to customize generated font family name.
 - `--font-dart-output <path>` to emit Dart lookup helpers for generated font codepoints.
 - `CHROME_PATH=/path/to/chrome` if Chromium/Chrome is not in a standard location.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -409,6 +409,82 @@ class Icons {
     });
   });
 
+  group('runGenerateRoughIcons fail on unresolved', () {
+    late Directory tempDirectory;
+
+    setUp(() {
+      tempDirectory = Directory.systemTemp.createTempSync(
+        'rough-icon-fail-on-unresolved-test-',
+      );
+    });
+
+    tearDown(() {
+      tempDirectory.deleteSync(recursive: true);
+    });
+
+    test('throws StateError when unresolved icons remain', () async {
+      final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+        ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+      final materialIconsRoot = Directory(
+        '${tempDirectory.path}/material-icons',
+      )..createSync(recursive: true);
+      final materialSymbolsRoot = Directory(
+        '${tempDirectory.path}/material-symbols',
+      )..createSync(recursive: true);
+      final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+        ..createSync(recursive: true);
+
+      File('${materialIconsRoot.path}/filled/label.svg')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(
+          '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+        );
+
+      final outputFile = File(
+        '${tempDirectory.path}/material_rough_icons.g.dart',
+      );
+      final unresolvedReportFile = File(
+        '${tempDirectory.path}/unresolved.json',
+      );
+
+      await expectLater(
+        tool.runGenerateRoughIcons(<String>[
+          '--kit',
+          'flutter-material',
+          '--flutter-icons',
+          flutterIconsFile.path,
+          '--material-icons-source',
+          materialIconsRoot.path,
+          '--material-symbols-source',
+          materialSymbolsRoot.path,
+          '--brand-icons-source',
+          brandIconsRoot.path,
+          '--unresolved-output',
+          unresolvedReportFile.path,
+          '--fail-on-unresolved',
+          '--output',
+          outputFile.path,
+        ]),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(unresolvedReportFile.existsSync(), isTrue);
+      final decoded =
+          jsonDecode(unresolvedReportFile.readAsStringSync())
+              as Map<String, dynamic>;
+      expect(decoded['unresolvedCount'], 1);
+    });
+  });
+
   test(
     'renderFontCodePointsDartForTest renders stable helper names and order',
     () {

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -154,14 +154,22 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
     return;
   }
 
+  final severityLabel = options.failOnUnresolved ? 'Error' : 'Warning';
   stderr.writeln(
-    'Warning: ${unresolved.length} icon codepoints for kit "${options.kit}" '
-    'could not be resolved to SVGs. WiredIcon will fall back to Icon for '
-    'those values.',
+    '$severityLabel: ${unresolved.length} icon codepoints for kit '
+    '"${options.kit}" could not be resolved to SVGs. WiredIcon will '
+    'fall back to Icon for those values.',
   );
   for (final item in unresolved) {
     stderr.writeln(
       '  0x${item.codePoint.toRadixString(16)}: ${item.identifiers.join(', ')}',
+    );
+  }
+
+  if (options.failOnUnresolved) {
+    throw StateError(
+      'Unresolved icon codepoints remain for kit "${options.kit}". '
+      'Re-run without --fail-on-unresolved for warnings only.',
     );
   }
 }
@@ -186,6 +194,7 @@ Options:
   --brand-icons-source <path>      Path to extracted simple-icons package (brand fallback).
   --supplemental-manifest <path>   JSON manifest for unresolved flutter-material icons.
   --unresolved-output <path>       Emit unresolved icon codepoint report as JSON.
+  --fail-on-unresolved             Exit with error when unresolved icons remain.
   --output <path>                  Output Dart file.
   --rough-cli <path>               TypeScript script that converts SVG(s) (default: tool/deno/svg2roughjs_cli.ts).
   --rough-cli-runner <exe>         Runner executable for --rough-cli (default: deno).
@@ -242,6 +251,7 @@ final class _ScriptOptions {
     this.roughNormalizeViewBox = 128,
     this.roughBulk = false,
     this.roughOnly = false,
+    this.failOnUnresolved = false,
     this.fontOutputDir,
     this.fontDartOutputPath,
     this.fontName = _kDefaultFontName,
@@ -267,6 +277,7 @@ final class _ScriptOptions {
   final double roughNormalizeViewBox;
   final bool roughBulk;
   final bool roughOnly;
+  final bool failOnUnresolved;
   final String? fontOutputDir;
   final String? fontDartOutputPath;
   final String fontName;
@@ -292,6 +303,7 @@ final class _ScriptOptions {
     var roughNormalizeViewBox = 128.0;
     var roughBulk = false;
     var roughOnly = false;
+    var failOnUnresolved = false;
     String? fontOutputDir;
     String? fontDartOutputPath;
     var fontName = _kDefaultFontName;
@@ -316,6 +328,10 @@ final class _ScriptOptions {
       }
       if (argument == '--rough-only') {
         roughOnly = true;
+        continue;
+      }
+      if (argument == '--fail-on-unresolved') {
+        failOnUnresolved = true;
         continue;
       }
 
@@ -397,6 +413,7 @@ final class _ScriptOptions {
       roughNormalizeViewBox: roughNormalizeViewBox,
       roughBulk: roughBulk,
       roughOnly: roughOnly,
+      failOnUnresolved: failOnUnresolved,
       fontOutputDir: fontOutputDir,
       fontDartOutputPath: fontDartOutputPath,
       fontName: fontName,


### PR DESCRIPTION
## Summary

This PR adds a strict mode for unresolved rough icon generation results.

### What changed

- New CLI option:
  - `--fail-on-unresolved`
- When unresolved icon codepoints remain, generation now throws a `StateError`
  (non-zero exit) if strict mode is enabled.
- Existing warning behavior remains unchanged when flag is not passed.
- Added parser/generator test coverage verifying strict-mode failure.
- Updated docs:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Added changeset.

## Validation

- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `flutter test test/widgets/wired_icon_catalog_test.dart`
- `dart analyze --fatal-infos .`

## Example

```bash
cd packages/skribble
dart run tool/generate_rough_icons.dart \
  --kit flutter-material \
  --output /tmp/material_rough_icons.g.dart \
  --unresolved-output /tmp/material_rough_icons_unresolved_report.json \
  --fail-on-unresolved
```
