### PR TITLE
feat(rough-icons): emit supplemental manifest templates

### DIFF
--- a/.changeset/rough-icon-supplemental-manifest-template-output.md
+++ b/.changeset/rough-icon-supplemental-manifest-template-output.md
@@ -1,0 +1,12 @@
+---
+skribble: patch
+---
+
+Add supplemental manifest template output support to rough icon generation.
+
+- New CLI option: `--supplemental-manifest-output <path>`
+- Emits a starter JSON manifest for unresolved icons using the same `icons[]`
+  schema consumed by `--supplemental-manifest`
+
+This streamlines unresolved icon remediation workflows by generating an editable
+manifest template directly from unresolved results.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -25,6 +25,7 @@ Compatibility alias (backward compatible):
    - generates icon fonts with `fantasticon` (`--font-output-dir`)
    - emits Dart helpers for generated icon fonts (`--font-dart-output`)
    - emits unresolved icon reports as JSON (`--unresolved-output`)
+   - emits supplemental manifest templates (`--supplemental-manifest-output`)
    - can fail CI on unresolved icons (`--fail-on-unresolved`)
 
 ## Extensibility seam
@@ -119,6 +120,16 @@ The JSON report includes:
 - `resolvedCount`
 - `unresolvedCount`
 - `unresolved[]` entries with `codePoint` and `identifiers`
+
+## Supplemental manifest template output
+
+To emit a starter supplemental manifest for unresolved icons, pass:
+
+- `--supplemental-manifest-output <path>`
+
+The output uses the same `icons[]` schema as `--kit svg-manifest` and can be
+edited by replacing placeholder `svgPath` values before passing it back via
+`--supplemental-manifest`.
 
 ## Strict unresolved mode
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -207,6 +207,7 @@ Useful flags:
 - `--brand-icons-source <path>` to provide a local `simple-icons` package as fallback for brand identifiers missing in Material SVG packages.
 - `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints.
 - `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring.
+- `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.
 - `--fail-on-unresolved` to make the command exit non-zero if unresolved icons remain.
 - `--font-name skribble_rough_icons` to customize generated font family name.
 - `--font-dart-output <path>` to emit Dart lookup helpers for generated font codepoints.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -409,6 +409,88 @@ class Icons {
     });
   });
 
+  group('runGenerateRoughIcons supplemental manifest template output', () {
+    late Directory tempDirectory;
+
+    setUp(() {
+      tempDirectory = Directory.systemTemp.createTempSync(
+        'rough-icon-supplemental-manifest-template-test-',
+      );
+    });
+
+    tearDown(() {
+      tempDirectory.deleteSync(recursive: true);
+    });
+
+    test(
+      'writes supplemental manifest template JSON for unresolved icons',
+      () async {
+        final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+          ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+        final materialIconsRoot = Directory(
+          '${tempDirectory.path}/material-icons',
+        )..createSync(recursive: true);
+        final materialSymbolsRoot = Directory(
+          '${tempDirectory.path}/material-symbols',
+        )..createSync(recursive: true);
+        final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+          ..createSync(recursive: true);
+
+        File('${materialIconsRoot.path}/filled/label.svg')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+          );
+
+        final outputFile = File(
+          '${tempDirectory.path}/material_rough_icons.g.dart',
+        );
+        final supplementalTemplateFile = File(
+          '${tempDirectory.path}/supplemental_template.json',
+        );
+
+        await tool.runGenerateRoughIcons(<String>[
+          '--kit',
+          'flutter-material',
+          '--flutter-icons',
+          flutterIconsFile.path,
+          '--material-icons-source',
+          materialIconsRoot.path,
+          '--material-symbols-source',
+          materialSymbolsRoot.path,
+          '--brand-icons-source',
+          brandIconsRoot.path,
+          '--supplemental-manifest-output',
+          supplementalTemplateFile.path,
+          '--output',
+          outputFile.path,
+        ]);
+
+        expect(supplementalTemplateFile.existsSync(), isTrue);
+
+        final decoded =
+            jsonDecode(supplementalTemplateFile.readAsStringSync())
+                as Map<String, dynamic>;
+        final icons = decoded['icons'] as List<dynamic>;
+        expect(icons, hasLength(1));
+
+        final firstIcon = icons.first as Map<String, dynamic>;
+        expect(firstIcon['identifier'], 'adobe');
+        expect(firstIcon['codePoint'], '0xf04b9');
+        expect(firstIcon['svgPath'], 'TODO/adobe.svg');
+      },
+    );
+  });
+
   group('runGenerateRoughIcons fail on unresolved', () {
     late Directory tempDirectory;
 

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -150,6 +150,19 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
     );
   }
 
+  if (options.supplementalManifestOutputPath
+      case final supplementalManifestOutputPath?) {
+    final supplementalManifestOutputFile = File(supplementalManifestOutputPath)
+      ..createSync(recursive: true);
+    supplementalManifestOutputFile.writeAsStringSync(
+      _renderSupplementalManifestTemplateJson(unresolved: unresolved),
+    );
+    stdout.writeln(
+      'Generated supplemental manifest template to '
+      '${supplementalManifestOutputFile.path}',
+    );
+  }
+
   if (unresolved.isEmpty) {
     return;
   }
@@ -194,6 +207,8 @@ Options:
   --brand-icons-source <path>      Path to extracted simple-icons package (brand fallback).
   --supplemental-manifest <path>   JSON manifest for unresolved flutter-material icons.
   --unresolved-output <path>       Emit unresolved icon codepoint report as JSON.
+  --supplemental-manifest-output <path>
+                                   Emit supplemental manifest template JSON.
   --fail-on-unresolved             Exit with error when unresolved icons remain.
   --output <path>                  Output Dart file.
   --rough-cli <path>               TypeScript script that converts SVG(s) (default: tool/deno/svg2roughjs_cli.ts).
@@ -243,6 +258,7 @@ final class _ScriptOptions {
     this.brandIconsSourcePath,
     this.supplementalManifestPath,
     this.unresolvedOutputPath,
+    this.supplementalManifestOutputPath,
     this.outputPath,
     this.roughCliPath,
     this.roughCliRunner = _kDefaultRoughCliRunner,
@@ -269,6 +285,7 @@ final class _ScriptOptions {
   final String? brandIconsSourcePath;
   final String? supplementalManifestPath;
   final String? unresolvedOutputPath;
+  final String? supplementalManifestOutputPath;
   final String? outputPath;
   final String? roughCliPath;
   final String roughCliRunner;
@@ -295,6 +312,7 @@ final class _ScriptOptions {
     String? brandIconsSourcePath;
     String? supplementalManifestPath;
     String? unresolvedOutputPath;
+    String? supplementalManifestOutputPath;
     String? outputPath;
     String? roughCliPath;
     var roughCliRunner = _kDefaultRoughCliRunner;
@@ -369,6 +387,8 @@ final class _ScriptOptions {
           supplementalManifestPath = value;
         case '--unresolved-output':
           unresolvedOutputPath = value;
+        case '--supplemental-manifest-output':
+          supplementalManifestOutputPath = value;
         case '--output':
           outputPath = value;
         case '--rough-cli':
@@ -405,6 +425,7 @@ final class _ScriptOptions {
       brandIconsSourcePath: brandIconsSourcePath,
       supplementalManifestPath: supplementalManifestPath,
       unresolvedOutputPath: unresolvedOutputPath,
+      supplementalManifestOutputPath: supplementalManifestOutputPath,
       outputPath: outputPath,
       roughCliPath: roughCliPath,
       roughCliRunner: roughCliRunner,
@@ -1280,6 +1301,26 @@ String _renderUnresolvedReportJson({
   };
 
   return const JsonEncoder.withIndent('  ').convert(report);
+}
+
+String _renderSupplementalManifestTemplateJson({
+  required List<_UnresolvedIcon> unresolved,
+}) {
+  final icons = unresolved
+      .map((item) {
+        final identifier = item.identifiers.isNotEmpty
+            ? item.identifiers.first
+            : 'icon_0x${item.codePoint.toRadixString(16)}';
+        return <String, Object>{
+          'identifier': identifier,
+          'codePoint': '0x${item.codePoint.toRadixString(16)}',
+          'svgPath': 'TODO/$identifier.svg',
+        };
+      })
+      .toList(growable: false);
+
+  final manifest = <String, Object>{'icons': icons};
+  return const JsonEncoder.withIndent('  ').convert(manifest);
 }
 
 String renderFontCodePointsDartForTest({


### PR DESCRIPTION
## Summary

This PR adds supplemental manifest template output to the rough icon generator.

### What changed

- New CLI option:
  - `--supplemental-manifest-output <path>`
- Generator can now emit a starter supplemental manifest JSON for unresolved icons.
- Template output uses the same `icons[]` schema consumed by `--supplemental-manifest`:
  - `identifier`
  - `codePoint`
  - `svgPath` placeholder (`TODO/<identifier>.svg`)
- Added parser/generator test coverage for template generation.
- Updated docs:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Added changeset.

## Validation

- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `flutter test test/widgets/wired_icon_catalog_test.dart`
- `dart analyze --fatal-infos .`

## Example

```bash
cd packages/skribble
dart run tool/generate_rough_icons.dart \
  --kit flutter-material \
  --output /tmp/material_rough_icons.g.dart \
  --supplemental-manifest-output /tmp/material_rough_icons_supplemental_template.json
```
