### PR TITLE
feat(rough-icons): add max-unresolved threshold control

### DIFF
--- a/.changeset/rough-icon-max-unresolved-threshold.md
+++ b/.changeset/rough-icon-max-unresolved-threshold.md
@@ -1,0 +1,13 @@
+---
+skribble: patch
+---
+
+Add unresolved threshold control to rough icon generation.
+
+- New CLI option: `--max-unresolved <int>`
+- Generator fails only when unresolved icon count exceeds the configured
+  threshold
+- `--fail-on-unresolved` remains supported as strict mode (`max = 0`)
+
+This enables gradual CI enforcement while unresolved icon remediation is still
+in progress.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -26,7 +26,7 @@ Compatibility alias (backward compatible):
    - emits Dart helpers for generated icon fonts (`--font-dart-output`)
    - emits unresolved icon reports as JSON (`--unresolved-output`)
    - emits supplemental manifest templates (`--supplemental-manifest-output`)
-   - can fail CI on unresolved icons (`--fail-on-unresolved`)
+   - can fail CI on unresolved icons (`--fail-on-unresolved`, `--max-unresolved`)
 
 ## Extensibility seam
 
@@ -133,12 +133,12 @@ edited by replacing placeholder `svgPath` values before passing it back via
 
 ## Strict unresolved mode
 
-To make generation fail when unresolved icons remain, pass:
+To control failure behavior for unresolved icons:
 
-- `--fail-on-unresolved`
+- `--fail-on-unresolved` (strict; equivalent to allowing 0 unresolved)
+- `--max-unresolved <int>` (bounded; fail only when unresolved count exceeds threshold)
 
-This is useful in CI once supplemental manifest coverage is expected to be
-complete.
+This is useful in CI while tightening coverage incrementally.
 
 ## Runtime prerequisites
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -208,6 +208,7 @@ Useful flags:
 - `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints.
 - `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring.
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.
+- `--max-unresolved <int>` to allow a bounded unresolved count before failing.
 - `--fail-on-unresolved` to make the command exit non-zero if unresolved icons remain.
 - `--font-name skribble_rough_icons` to customize generated font family name.
 - `--font-dart-output <path>` to emit Dart lookup helpers for generated font codepoints.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -567,6 +567,123 @@ class Icons {
     });
   });
 
+  group('runGenerateRoughIcons max unresolved threshold', () {
+    late Directory tempDirectory;
+
+    setUp(() {
+      tempDirectory = Directory.systemTemp.createTempSync(
+        'rough-icon-max-unresolved-test-',
+      );
+    });
+
+    tearDown(() {
+      tempDirectory.deleteSync(recursive: true);
+    });
+
+    test('does not throw when unresolved count equals threshold', () async {
+      final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+        ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+      final materialIconsRoot = Directory(
+        '${tempDirectory.path}/material-icons',
+      )..createSync(recursive: true);
+      final materialSymbolsRoot = Directory(
+        '${tempDirectory.path}/material-symbols',
+      )..createSync(recursive: true);
+      final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+        ..createSync(recursive: true);
+
+      File('${materialIconsRoot.path}/filled/label.svg')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(
+          '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+        );
+
+      final outputFile = File(
+        '${tempDirectory.path}/material_rough_icons.g.dart',
+      );
+
+      await tool.runGenerateRoughIcons(<String>[
+        '--kit',
+        'flutter-material',
+        '--flutter-icons',
+        flutterIconsFile.path,
+        '--material-icons-source',
+        materialIconsRoot.path,
+        '--material-symbols-source',
+        materialSymbolsRoot.path,
+        '--brand-icons-source',
+        brandIconsRoot.path,
+        '--max-unresolved',
+        '1',
+        '--output',
+        outputFile.path,
+      ]);
+
+      expect(outputFile.existsSync(), isTrue);
+    });
+
+    test('throws when unresolved count exceeds threshold', () async {
+      final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+        ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+      final materialIconsRoot = Directory(
+        '${tempDirectory.path}/material-icons',
+      )..createSync(recursive: true);
+      final materialSymbolsRoot = Directory(
+        '${tempDirectory.path}/material-symbols',
+      )..createSync(recursive: true);
+      final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+        ..createSync(recursive: true);
+
+      File('${materialIconsRoot.path}/filled/label.svg')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(
+          '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+        );
+
+      final outputFile = File(
+        '${tempDirectory.path}/material_rough_icons.g.dart',
+      );
+
+      await expectLater(
+        tool.runGenerateRoughIcons(<String>[
+          '--kit',
+          'flutter-material',
+          '--flutter-icons',
+          flutterIconsFile.path,
+          '--material-icons-source',
+          materialIconsRoot.path,
+          '--material-symbols-source',
+          materialSymbolsRoot.path,
+          '--brand-icons-source',
+          brandIconsRoot.path,
+          '--max-unresolved',
+          '0',
+          '--output',
+          outputFile.path,
+        ]),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+
   test(
     'renderFontCodePointsDartForTest renders stable helper names and order',
     () {

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -167,7 +167,11 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
     return;
   }
 
-  final severityLabel = options.failOnUnresolved ? 'Error' : 'Warning';
+  final failureThreshold = options.failOnUnresolved ? 0 : options.maxUnresolved;
+  final shouldFail =
+      failureThreshold != null && unresolved.length > failureThreshold;
+
+  final severityLabel = shouldFail ? 'Error' : 'Warning';
   stderr.writeln(
     '$severityLabel: ${unresolved.length} icon codepoints for kit '
     '"${options.kit}" could not be resolved to SVGs. WiredIcon will '
@@ -179,10 +183,10 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
     );
   }
 
-  if (options.failOnUnresolved) {
+  if (shouldFail) {
     throw StateError(
-      'Unresolved icon codepoints remain for kit "${options.kit}". '
-      'Re-run without --fail-on-unresolved for warnings only.',
+      'Unresolved icon codepoints remain for kit "${options.kit}" '
+      '(found ${unresolved.length}, allowed $failureThreshold).',
     );
   }
 }
@@ -209,6 +213,7 @@ Options:
   --unresolved-output <path>       Emit unresolved icon codepoint report as JSON.
   --supplemental-manifest-output <path>
                                    Emit supplemental manifest template JSON.
+  --max-unresolved <int>           Max unresolved icons allowed before failing.
   --fail-on-unresolved             Exit with error when unresolved icons remain.
   --output <path>                  Output Dart file.
   --rough-cli <path>               TypeScript script that converts SVG(s) (default: tool/deno/svg2roughjs_cli.ts).
@@ -259,6 +264,7 @@ final class _ScriptOptions {
     this.supplementalManifestPath,
     this.unresolvedOutputPath,
     this.supplementalManifestOutputPath,
+    this.maxUnresolved,
     this.outputPath,
     this.roughCliPath,
     this.roughCliRunner = _kDefaultRoughCliRunner,
@@ -286,6 +292,7 @@ final class _ScriptOptions {
   final String? supplementalManifestPath;
   final String? unresolvedOutputPath;
   final String? supplementalManifestOutputPath;
+  final int? maxUnresolved;
   final String? outputPath;
   final String? roughCliPath;
   final String roughCliRunner;
@@ -313,6 +320,7 @@ final class _ScriptOptions {
     String? supplementalManifestPath;
     String? unresolvedOutputPath;
     String? supplementalManifestOutputPath;
+    int? maxUnresolved;
     String? outputPath;
     String? roughCliPath;
     var roughCliRunner = _kDefaultRoughCliRunner;
@@ -389,6 +397,8 @@ final class _ScriptOptions {
           unresolvedOutputPath = value;
         case '--supplemental-manifest-output':
           supplementalManifestOutputPath = value;
+        case '--max-unresolved':
+          maxUnresolved = int.parse(value);
         case '--output':
           outputPath = value;
         case '--rough-cli':
@@ -416,6 +426,10 @@ final class _ScriptOptions {
       }
     }
 
+    if (maxUnresolved != null && maxUnresolved < 0) {
+      throw ArgumentError('--max-unresolved must be >= 0.');
+    }
+
     return _ScriptOptions(
       kit: kit,
       manifestPath: manifestPath,
@@ -426,6 +440,7 @@ final class _ScriptOptions {
       supplementalManifestPath: supplementalManifestPath,
       unresolvedOutputPath: unresolvedOutputPath,
       supplementalManifestOutputPath: supplementalManifestOutputPath,
+      maxUnresolved: maxUnresolved,
       outputPath: outputPath,
       roughCliPath: roughCliPath,
       roughCliRunner: roughCliRunner,


### PR DESCRIPTION
## Summary

This PR adds bounded unresolved failure control for rough icon generation.

### What changed

- New CLI option:
  - `--max-unresolved <int>`
- Generator now fails only when unresolved icon count exceeds the configured threshold.
- Existing strict mode remains:
  - `--fail-on-unresolved` (equivalent to allowing `0` unresolved)
- Added option validation:
  - `--max-unresolved` must be `>= 0`
- Added parser/generator test coverage for threshold behavior.
- Updated docs:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Added changeset.

## Validation

- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `flutter test test/widgets/wired_icon_catalog_test.dart`
- `dart analyze --fatal-infos .`

## Example

```bash
cd packages/skribble
dart run tool/generate_rough_icons.dart \
  --kit flutter-material \
  --output /tmp/material_rough_icons.g.dart \
  --max-unresolved 6
```

This exits non-zero if unresolved count is greater than 6.
