### PR TITLE
feat(rough-icons): add unresolved baseline regression gating

### DIFF
--- a/.changeset/rough-icon-unresolved-baseline-regression-gate.md
+++ b/.changeset/rough-icon-unresolved-baseline-regression-gate.md
@@ -1,0 +1,14 @@
+---
+skribble: patch
+---
+
+Add unresolved baseline regression gating to rough icon generation.
+
+- New option: `--unresolved-baseline <path>` to load previous unresolved report
+- New option: `--fail-on-new-unresolved` to fail only when new unresolved
+  codepoints appear versus baseline
+- Unresolved JSON output now includes optional baseline diff fields:
+  `newUnresolvedCount` and `newUnresolved`
+
+This supports incremental CI enforcement by preventing unresolved regressions
+without blocking on existing unresolved debt.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -26,7 +26,7 @@ Compatibility alias (backward compatible):
    - emits Dart helpers for generated icon fonts (`--font-dart-output`)
    - emits unresolved icon reports as JSON (`--unresolved-output`)
    - emits supplemental manifest templates (`--supplemental-manifest-output`)
-   - can fail CI on unresolved icons (`--fail-on-unresolved`, `--max-unresolved`)
+   - can fail CI on unresolved icons (`--fail-on-unresolved`, `--max-unresolved`, `--fail-on-new-unresolved`)
 
 ## Extensibility seam
 
@@ -120,6 +120,7 @@ The JSON report includes:
 - `resolvedCount`
 - `unresolvedCount`
 - `unresolved[]` entries with `codePoint` and `identifiers`
+- optional `newUnresolvedCount` / `newUnresolved[]` when baseline comparison is enabled
 
 ## Supplemental manifest template output
 
@@ -137,6 +138,11 @@ To control failure behavior for unresolved icons:
 
 - `--fail-on-unresolved` (strict; equivalent to allowing 0 unresolved)
 - `--max-unresolved <int>` (bounded; fail only when unresolved count exceeds threshold)
+
+To detect only regressions relative to an existing unresolved baseline:
+
+- `--unresolved-baseline <path>`
+- `--fail-on-new-unresolved`
 
 This is useful in CI while tightening coverage incrementally.
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -208,8 +208,10 @@ Useful flags:
 - `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints.
 - `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring.
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.
+- `--unresolved-baseline <path>` to compare unresolved output against a stored baseline report.
 - `--max-unresolved <int>` to allow a bounded unresolved count before failing.
 - `--fail-on-unresolved` to make the command exit non-zero if unresolved icons remain.
+- `--fail-on-new-unresolved` to fail only when unresolved entries regress versus baseline.
 - `--font-name skribble_rough_icons` to customize generated font family name.
 - `--font-dart-output <path>` to emit Dart lookup helpers for generated font codepoints.
 - `CHROME_PATH=/path/to/chrome` if Chromium/Chrome is not in a standard location.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -684,6 +684,177 @@ class Icons {
     });
   });
 
+  group('runGenerateRoughIcons unresolved baseline regression checks', () {
+    late Directory tempDirectory;
+
+    setUp(() {
+      tempDirectory = Directory.systemTemp.createTempSync(
+        'rough-icon-unresolved-baseline-test-',
+      );
+    });
+
+    tearDown(() {
+      tempDirectory.deleteSync(recursive: true);
+    });
+
+    test(
+      'requires baseline path when fail-on-new-unresolved is enabled',
+      () async {
+        await expectLater(
+          tool.runGenerateRoughIcons(<String>['--fail-on-new-unresolved']),
+          throwsA(isA<ArgumentError>()),
+        );
+      },
+    );
+
+    test('does not throw when unresolved icons are all in baseline', () async {
+      final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+        ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+      final materialIconsRoot = Directory(
+        '${tempDirectory.path}/material-icons',
+      )..createSync(recursive: true);
+      final materialSymbolsRoot = Directory(
+        '${tempDirectory.path}/material-symbols',
+      )..createSync(recursive: true);
+      final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+        ..createSync(recursive: true);
+
+      File('${materialIconsRoot.path}/filled/label.svg')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(
+          '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+        );
+
+      final baselineFile = File('${tempDirectory.path}/baseline.json')
+        ..writeAsStringSync('''
+{
+  "unresolved": [
+    {
+      "codePoint": "0xf04b9",
+      "identifiers": ["adobe"]
+    }
+  ]
+}
+''');
+      final unresolvedReportFile = File(
+        '${tempDirectory.path}/unresolved_report.json',
+      );
+      final outputFile = File(
+        '${tempDirectory.path}/material_rough_icons.g.dart',
+      );
+
+      await tool.runGenerateRoughIcons(<String>[
+        '--kit',
+        'flutter-material',
+        '--flutter-icons',
+        flutterIconsFile.path,
+        '--material-icons-source',
+        materialIconsRoot.path,
+        '--material-symbols-source',
+        materialSymbolsRoot.path,
+        '--brand-icons-source',
+        brandIconsRoot.path,
+        '--unresolved-baseline',
+        baselineFile.path,
+        '--fail-on-new-unresolved',
+        '--unresolved-output',
+        unresolvedReportFile.path,
+        '--output',
+        outputFile.path,
+      ]);
+
+      final decoded =
+          jsonDecode(unresolvedReportFile.readAsStringSync())
+              as Map<String, dynamic>;
+      expect(decoded['newUnresolvedCount'], 0);
+      expect(decoded['newUnresolved'], <dynamic>[]);
+    });
+
+    test('throws when unresolved icons regress against baseline', () async {
+      final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+        ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+      final materialIconsRoot = Directory(
+        '${tempDirectory.path}/material-icons',
+      )..createSync(recursive: true);
+      final materialSymbolsRoot = Directory(
+        '${tempDirectory.path}/material-symbols',
+      )..createSync(recursive: true);
+      final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+        ..createSync(recursive: true);
+
+      File('${materialIconsRoot.path}/filled/label.svg')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(
+          '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+        );
+
+      final baselineFile = File('${tempDirectory.path}/baseline-empty.json')
+        ..writeAsStringSync('''
+{
+  "unresolved": []
+}
+''');
+      final unresolvedReportFile = File(
+        '${tempDirectory.path}/unresolved_report.json',
+      );
+      final outputFile = File(
+        '${tempDirectory.path}/material_rough_icons.g.dart',
+      );
+
+      await expectLater(
+        tool.runGenerateRoughIcons(<String>[
+          '--kit',
+          'flutter-material',
+          '--flutter-icons',
+          flutterIconsFile.path,
+          '--material-icons-source',
+          materialIconsRoot.path,
+          '--material-symbols-source',
+          materialSymbolsRoot.path,
+          '--brand-icons-source',
+          brandIconsRoot.path,
+          '--unresolved-baseline',
+          baselineFile.path,
+          '--fail-on-new-unresolved',
+          '--unresolved-output',
+          unresolvedReportFile.path,
+          '--output',
+          outputFile.path,
+        ]),
+        throwsA(isA<StateError>()),
+      );
+
+      final decoded =
+          jsonDecode(unresolvedReportFile.readAsStringSync())
+              as Map<String, dynamic>;
+      expect(decoded['newUnresolvedCount'], 1);
+
+      final newUnresolved = decoded['newUnresolved'] as List<dynamic>;
+      expect(newUnresolved, hasLength(1));
+      final first = newUnresolved.first as Map<String, dynamic>;
+      expect(first['codePoint'], '0xf04b9');
+      expect(first['identifiers'], <String>['adobe']);
+    });
+  });
+
   test(
     'renderFontCodePointsDartForTest renders stable helper names and order',
     () {

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -91,6 +91,17 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
     );
   }
 
+  final baselineUnresolvedCodePoints = _loadUnresolvedBaselineCodePoints(
+    options.unresolvedBaselinePath,
+  );
+  final newUnresolved = baselineUnresolvedCodePoints == null
+      ? null
+      : unresolved
+            .where(
+              (item) => !baselineUnresolvedCodePoints.contains(item.codePoint),
+            )
+            .toList(growable: false);
+
   if (options.roughOutputDir != null) {
     await _generateRoughSvgs(options, roughTasks);
   }
@@ -143,6 +154,7 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
         kit: options.kit,
         resolvedCount: icons.length,
         unresolved: unresolved,
+        newUnresolved: newUnresolved,
       ),
     );
     stdout.writeln(
@@ -168,8 +180,11 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
   }
 
   final failureThreshold = options.failOnUnresolved ? 0 : options.maxUnresolved;
-  final shouldFail =
+  final thresholdFailure =
       failureThreshold != null && unresolved.length > failureThreshold;
+  final newUnresolvedFailure =
+      options.failOnNewUnresolved && (newUnresolved?.isNotEmpty ?? false);
+  final shouldFail = thresholdFailure || newUnresolvedFailure;
 
   final severityLabel = shouldFail ? 'Error' : 'Warning';
   stderr.writeln(
@@ -183,10 +198,31 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
     );
   }
 
+  if (newUnresolved case final baselineDiff?) {
+    final baselineSeverity = newUnresolvedFailure
+        ? 'Error'
+        : (shouldFail ? 'Warning' : 'Info');
+    stderr.writeln(
+      '$baselineSeverity: ${baselineDiff.length} newly unresolved '
+      'codepoints compared to baseline.',
+    );
+    for (final item in baselineDiff) {
+      stderr.writeln(
+        '  + 0x${item.codePoint.toRadixString(16)}: '
+        '${item.identifiers.join(', ')}',
+      );
+    }
+  }
+
   if (shouldFail) {
+    final details = <String>[
+      if (thresholdFailure)
+        'found ${unresolved.length}, allowed $failureThreshold',
+      if (newUnresolvedFailure)
+        'new unresolved regression detected (${newUnresolved!.length})',
+    ].join('; ');
     throw StateError(
-      'Unresolved icon codepoints remain for kit "${options.kit}" '
-      '(found ${unresolved.length}, allowed $failureThreshold).',
+      'Unresolved icon codepoints remain for kit "${options.kit}" ($details).',
     );
   }
 }
@@ -213,8 +249,10 @@ Options:
   --unresolved-output <path>       Emit unresolved icon codepoint report as JSON.
   --supplemental-manifest-output <path>
                                    Emit supplemental manifest template JSON.
+  --unresolved-baseline <path>     Baseline unresolved report JSON for diffing.
   --max-unresolved <int>           Max unresolved icons allowed before failing.
   --fail-on-unresolved             Exit with error when unresolved icons remain.
+  --fail-on-new-unresolved         Exit with error on unresolved baseline regressions.
   --output <path>                  Output Dart file.
   --rough-cli <path>               TypeScript script that converts SVG(s) (default: tool/deno/svg2roughjs_cli.ts).
   --rough-cli-runner <exe>         Runner executable for --rough-cli (default: deno).
@@ -264,6 +302,7 @@ final class _ScriptOptions {
     this.supplementalManifestPath,
     this.unresolvedOutputPath,
     this.supplementalManifestOutputPath,
+    this.unresolvedBaselinePath,
     this.maxUnresolved,
     this.outputPath,
     this.roughCliPath,
@@ -274,6 +313,7 @@ final class _ScriptOptions {
     this.roughBulk = false,
     this.roughOnly = false,
     this.failOnUnresolved = false,
+    this.failOnNewUnresolved = false,
     this.fontOutputDir,
     this.fontDartOutputPath,
     this.fontName = _kDefaultFontName,
@@ -292,6 +332,7 @@ final class _ScriptOptions {
   final String? supplementalManifestPath;
   final String? unresolvedOutputPath;
   final String? supplementalManifestOutputPath;
+  final String? unresolvedBaselinePath;
   final int? maxUnresolved;
   final String? outputPath;
   final String? roughCliPath;
@@ -302,6 +343,7 @@ final class _ScriptOptions {
   final bool roughBulk;
   final bool roughOnly;
   final bool failOnUnresolved;
+  final bool failOnNewUnresolved;
   final String? fontOutputDir;
   final String? fontDartOutputPath;
   final String fontName;
@@ -320,6 +362,7 @@ final class _ScriptOptions {
     String? supplementalManifestPath;
     String? unresolvedOutputPath;
     String? supplementalManifestOutputPath;
+    String? unresolvedBaselinePath;
     int? maxUnresolved;
     String? outputPath;
     String? roughCliPath;
@@ -330,6 +373,7 @@ final class _ScriptOptions {
     var roughBulk = false;
     var roughOnly = false;
     var failOnUnresolved = false;
+    var failOnNewUnresolved = false;
     String? fontOutputDir;
     String? fontDartOutputPath;
     var fontName = _kDefaultFontName;
@@ -358,6 +402,10 @@ final class _ScriptOptions {
       }
       if (argument == '--fail-on-unresolved') {
         failOnUnresolved = true;
+        continue;
+      }
+      if (argument == '--fail-on-new-unresolved') {
+        failOnNewUnresolved = true;
         continue;
       }
 
@@ -397,6 +445,8 @@ final class _ScriptOptions {
           unresolvedOutputPath = value;
         case '--supplemental-manifest-output':
           supplementalManifestOutputPath = value;
+        case '--unresolved-baseline':
+          unresolvedBaselinePath = value;
         case '--max-unresolved':
           maxUnresolved = int.parse(value);
         case '--output':
@@ -429,6 +479,11 @@ final class _ScriptOptions {
     if (maxUnresolved != null && maxUnresolved < 0) {
       throw ArgumentError('--max-unresolved must be >= 0.');
     }
+    if (failOnNewUnresolved && unresolvedBaselinePath == null) {
+      throw ArgumentError(
+        '--fail-on-new-unresolved requires --unresolved-baseline.',
+      );
+    }
 
     return _ScriptOptions(
       kit: kit,
@@ -440,6 +495,7 @@ final class _ScriptOptions {
       supplementalManifestPath: supplementalManifestPath,
       unresolvedOutputPath: unresolvedOutputPath,
       supplementalManifestOutputPath: supplementalManifestOutputPath,
+      unresolvedBaselinePath: unresolvedBaselinePath,
       maxUnresolved: maxUnresolved,
       outputPath: outputPath,
       roughCliPath: roughCliPath,
@@ -450,6 +506,7 @@ final class _ScriptOptions {
       roughBulk: roughBulk,
       roughOnly: roughOnly,
       failOnUnresolved: failOnUnresolved,
+      failOnNewUnresolved: failOnNewUnresolved,
       fontOutputDir: fontOutputDir,
       fontDartOutputPath: fontDartOutputPath,
       fontName: fontName,
@@ -1296,10 +1353,76 @@ String _renderGeneratedFile(List<_GeneratedIcon> icons) {
   return buffer.toString();
 }
 
+Set<int>? _loadUnresolvedBaselineCodePoints(String? baselinePath) {
+  if (baselinePath == null) {
+    return null;
+  }
+
+  final baselineFile = File(baselinePath);
+  if (!baselineFile.existsSync()) {
+    throw StateError(
+      'Unresolved baseline file not found: ${baselineFile.path}',
+    );
+  }
+
+  final decoded = jsonDecode(baselineFile.readAsStringSync());
+  if (decoded is! Map<String, Object?>) {
+    throw FormatException(
+      'Expected unresolved baseline JSON object at ${baselineFile.path}.',
+    );
+  }
+
+  final unresolvedValue = decoded['unresolved'];
+  if (unresolvedValue is! List<Object?>) {
+    throw FormatException(
+      'Expected "unresolved" list in unresolved baseline report '
+      '${baselineFile.path}.',
+    );
+  }
+
+  final codePoints = <int>{};
+  for (final entry in unresolvedValue) {
+    if (entry is Map<Object?, Object?>) {
+      codePoints.add(
+        _parseCodePointValue(
+          entry['codePoint'],
+          context: 'unresolved baseline entry',
+        ),
+      );
+      continue;
+    }
+
+    codePoints.add(
+      _parseCodePointValue(entry, context: 'unresolved baseline entry'),
+    );
+  }
+
+  return codePoints;
+}
+
+int _parseCodePointValue(Object? value, {required String context}) {
+  if (value is int) {
+    return value;
+  }
+
+  if (value is String) {
+    final normalized = value.trim().toLowerCase();
+    if (normalized.startsWith('0x')) {
+      return int.parse(normalized.substring(2), radix: 16);
+    }
+    return int.parse(normalized);
+  }
+
+  throw FormatException(
+    'Invalid codePoint in $context. Expected int or string, got $value.',
+  );
+}
+
 String _renderUnresolvedReportJson({
   required String kit,
   required int resolvedCount,
   required List<_UnresolvedIcon> unresolved,
+  required List<_UnresolvedIcon>? newUnresolved,
 }) {
   final report = <String, Object>{
     'kit': kit,
@@ -1313,6 +1436,17 @@ String _renderUnresolvedReportJson({
           },
         )
         .toList(growable: false),
+    if (newUnresolved != null) ...<String, Object>{
+      'newUnresolvedCount': newUnresolved.length,
+      'newUnresolved': newUnresolved
+          .map(
+            (item) => <String, Object>{
+              'codePoint': '0x${item.codePoint.toRadixString(16)}',
+              'identifiers': item.identifiers,
+            },
+          )
+          .toList(growable: false),
+    },
   };
 
   return const JsonEncoder.withIndent('  ').convert(report);


### PR DESCRIPTION
## Summary

This PR adds unresolved baseline regression support to rough icon generation.

### What changed

- New option:
  - `--unresolved-baseline <path>`
- New option:
  - `--fail-on-new-unresolved`
- Behavior:
  - compares current unresolved set against baseline report (`unresolved[]`)
  - can fail only when *new* unresolved codepoints appear
- Unresolved report output (`--unresolved-output`) now includes baseline diff fields when baseline mode is used:
  - `newUnresolvedCount`
  - `newUnresolved[]`
- Validation in argument parsing:
  - `--fail-on-new-unresolved` requires `--unresolved-baseline`
- Updated docs:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Added test coverage for:
  - required baseline argument
  - non-failing baseline-matched unresolved set
  - failing baseline regression path
- Added changeset.

## Validation

- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `flutter test test/widgets/wired_icon_catalog_test.dart`
- `dart analyze --fatal-infos .`

## Example

```bash
cd packages/skribble
# existing baseline report
# /tmp/material_rough_icons_baseline.json

dart run tool/generate_rough_icons.dart \
  --kit flutter-material \
  --output /tmp/material_rough_icons.g.dart \
  --unresolved-baseline /tmp/material_rough_icons_baseline.json \
  --fail-on-new-unresolved \
  --unresolved-output /tmp/material_rough_icons_report.json
```
