### PR TITLE
fix(rough-icons): support icons[] unresolved baseline format

### DIFF
--- a/.changeset/rough-icon-baseline-icons-format.md
+++ b/.changeset/rough-icon-baseline-icons-format.md
@@ -1,0 +1,13 @@
+---
+skribble: patch
+---
+
+Allow unresolved baseline regression checks to accept both report and manifest
+JSON formats.
+
+- `--unresolved-baseline` now supports:
+  - unresolved report format (`unresolved[]`)
+  - supplemental manifest format (`icons[]`)
+
+This lets generated supplemental manifest templates be reused directly as
+baseline inputs for `--fail-on-new-unresolved` checks.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -144,6 +144,11 @@ To detect only regressions relative to an existing unresolved baseline:
 - `--unresolved-baseline <path>`
 - `--fail-on-new-unresolved`
 
+Baseline input supports either:
+
+- unresolved report JSON (`unresolved[]`)
+- supplemental manifest JSON (`icons[]`)
+
 This is useful in CI while tightening coverage incrementally.
 
 ## Runtime prerequisites

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -208,7 +208,7 @@ Useful flags:
 - `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints.
 - `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring.
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.
-- `--unresolved-baseline <path>` to compare unresolved output against a stored baseline report.
+- `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`) or manifest (`icons[]`).
 - `--max-unresolved <int>` to allow a bounded unresolved count before failing.
 - `--fail-on-unresolved` to make the command exit non-zero if unresolved icons remain.
 - `--fail-on-new-unresolved` to fail only when unresolved entries regress versus baseline.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -779,6 +779,82 @@ class Icons {
       expect(decoded['newUnresolved'], <dynamic>[]);
     });
 
+    test(
+      'accepts supplemental manifest icons[] format as unresolved baseline',
+      () async {
+        final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+          ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+        final materialIconsRoot = Directory(
+          '${tempDirectory.path}/material-icons',
+        )..createSync(recursive: true);
+        final materialSymbolsRoot = Directory(
+          '${tempDirectory.path}/material-symbols',
+        )..createSync(recursive: true);
+        final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+          ..createSync(recursive: true);
+
+        File('${materialIconsRoot.path}/filled/label.svg')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+          );
+
+        final baselineFile = File('${tempDirectory.path}/baseline-icons.json')
+          ..writeAsStringSync('''
+{
+  "icons": [
+    {
+      "identifier": "adobe",
+      "codePoint": "0xf04b9",
+      "svgPath": "TODO/adobe.svg"
+    }
+  ]
+}
+''');
+        final unresolvedReportFile = File(
+          '${tempDirectory.path}/unresolved_report.json',
+        );
+        final outputFile = File(
+          '${tempDirectory.path}/material_rough_icons.g.dart',
+        );
+
+        await tool.runGenerateRoughIcons(<String>[
+          '--kit',
+          'flutter-material',
+          '--flutter-icons',
+          flutterIconsFile.path,
+          '--material-icons-source',
+          materialIconsRoot.path,
+          '--material-symbols-source',
+          materialSymbolsRoot.path,
+          '--brand-icons-source',
+          brandIconsRoot.path,
+          '--unresolved-baseline',
+          baselineFile.path,
+          '--fail-on-new-unresolved',
+          '--unresolved-output',
+          unresolvedReportFile.path,
+          '--output',
+          outputFile.path,
+        ]);
+
+        final decoded =
+            jsonDecode(unresolvedReportFile.readAsStringSync())
+                as Map<String, dynamic>;
+        expect(decoded['newUnresolvedCount'], 0);
+        expect(decoded['newUnresolved'], <dynamic>[]);
+      },
+    );
+
     test('throws when unresolved icons regress against baseline', () async {
       final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
         ..writeAsStringSync('''

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -249,7 +249,7 @@ Options:
   --unresolved-output <path>       Emit unresolved icon codepoint report as JSON.
   --supplemental-manifest-output <path>
                                    Emit supplemental manifest template JSON.
-  --unresolved-baseline <path>     Baseline unresolved report JSON for diffing.
+  --unresolved-baseline <path>     Baseline unresolved report or manifest JSON for diffing.
   --max-unresolved <int>           Max unresolved icons allowed before failing.
   --fail-on-unresolved             Exit with error when unresolved icons remain.
   --fail-on-new-unresolved         Exit with error on unresolved baseline regressions.
@@ -1366,22 +1366,34 @@ Set<int>? _loadUnresolvedBaselineCodePoints(String? baselinePath) {
   }
 
   final decoded = jsonDecode(baselineFile.readAsStringSync());
-  if (decoded is! Map<String, Object?>) {
-    throw FormatException(
-      'Expected unresolved baseline JSON object at ${baselineFile.path}.',
-    );
-  }
 
-  final unresolvedValue = decoded['unresolved'];
-  if (unresolvedValue is! List<Object?>) {
+  List<Object?> entries;
+  if (decoded is List<Object?>) {
+    entries = decoded;
+  } else if (decoded is Map<String, Object?>) {
+    final unresolvedValue = decoded['unresolved'];
+    final iconsValue = decoded['icons'];
+
+    if (unresolvedValue is List<Object?>) {
+      entries = unresolvedValue;
+    } else if (iconsValue is List<Object?>) {
+      entries = iconsValue;
+    } else {
+      throw FormatException(
+        'Expected unresolved baseline JSON to contain either an '
+        '"unresolved" list (report format) or "icons" list '
+        '(manifest format) at ${baselineFile.path}.',
+      );
+    }
+  } else {
     throw FormatException(
-      'Expected "unresolved" list in unresolved baseline report '
+      'Expected unresolved baseline JSON to be a list or object at '
       '${baselineFile.path}.',
     );
   }
 
   final codePoints = <int>{};
-  for (final entry in unresolvedValue) {
+  for (final entry in entries) {
     if (entry is Map<Object?, Object?>) {
       codePoints.add(
         _parseCodePointValue(


### PR DESCRIPTION
## Summary

This PR improves unresolved baseline regression checks by supporting baseline files in both report and manifest formats.

### What changed

- `--unresolved-baseline <path>` now accepts:
  - unresolved report format (`unresolved[]`)
  - supplemental manifest format (`icons[]`)
  - top-level list (codepoint entries)
- Updated usage text/help for `--unresolved-baseline`.
- Added parser/generator test coverage for `icons[]` baseline compatibility.
- Updated docs:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Added changeset.

## Why

This allows a generated supplemental manifest template to be reused directly as a baseline input for `--fail-on-new-unresolved`, simplifying remediation workflows.

## Validation

- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `flutter test test/widgets/wired_icon_catalog_test.dart`
- `dart analyze --fatal-infos .`
