### PR TITLE
feat(rough-icons): report resolved-since-baseline codepoints

### DIFF
--- a/.changeset/rough-icon-baseline-diff-report-fields.md
+++ b/.changeset/rough-icon-baseline-diff-report-fields.md
@@ -1,0 +1,15 @@
+---
+skribble: patch
+---
+
+Improve unresolved baseline comparison reporting for rough icon generation.
+
+- `--unresolved-baseline` now records both regression and recovery context in
+  unresolved JSON output
+- New optional report fields when baseline comparison is enabled:
+  - `baselineUnresolvedCount`
+  - `resolvedSinceBaselineCount`
+  - `resolvedSinceBaseline`
+
+This makes baseline-driven CI runs easier to interpret by surfacing not only
+new unresolved regressions, but also baseline entries that are now resolved.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -120,7 +120,9 @@ The JSON report includes:
 - `resolvedCount`
 - `unresolvedCount`
 - `unresolved[]` entries with `codePoint` and `identifiers`
+- optional `baselineUnresolvedCount`
 - optional `newUnresolvedCount` / `newUnresolved[]` when baseline comparison is enabled
+- optional `resolvedSinceBaselineCount` / `resolvedSinceBaseline[]` (codepoint strings)
 
 ## Supplemental manifest template output
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -208,7 +208,7 @@ Useful flags:
 - `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints.
 - `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring.
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.
-- `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`) or manifest (`icons[]`).
+- `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`) or manifest (`icons[]`), including `newUnresolved` and `resolvedSinceBaseline` report fields.
 - `--max-unresolved <int>` to allow a bounded unresolved count before failing.
 - `--fail-on-unresolved` to make the command exit non-zero if unresolved icons remain.
 - `--fail-on-new-unresolved` to fail only when unresolved entries regress versus baseline.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -775,8 +775,11 @@ class Icons {
       final decoded =
           jsonDecode(unresolvedReportFile.readAsStringSync())
               as Map<String, dynamic>;
+      expect(decoded['baselineUnresolvedCount'], 1);
       expect(decoded['newUnresolvedCount'], 0);
       expect(decoded['newUnresolved'], <dynamic>[]);
+      expect(decoded['resolvedSinceBaselineCount'], 0);
+      expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
     });
 
     test(
@@ -850,8 +853,92 @@ class Icons {
         final decoded =
             jsonDecode(unresolvedReportFile.readAsStringSync())
                 as Map<String, dynamic>;
+        expect(decoded['baselineUnresolvedCount'], 1);
         expect(decoded['newUnresolvedCount'], 0);
         expect(decoded['newUnresolved'], <dynamic>[]);
+        expect(decoded['resolvedSinceBaselineCount'], 0);
+        expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
+      },
+    );
+
+    test(
+      'reports resolvedSinceBaseline when baseline entries are now resolved',
+      () async {
+        final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+          ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+        final materialIconsRoot = Directory(
+          '${tempDirectory.path}/material-icons',
+        )..createSync(recursive: true);
+        final materialSymbolsRoot = Directory(
+          '${tempDirectory.path}/material-symbols',
+        )..createSync(recursive: true);
+        final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+          ..createSync(recursive: true);
+
+        File('${materialIconsRoot.path}/filled/label.svg')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+          );
+
+        final baselineFile = File('${tempDirectory.path}/baseline-mixed.json')
+          ..writeAsStringSync('''
+{
+  "unresolved": [
+    {
+      "codePoint": "0xe364",
+      "identifiers": ["label_outline"]
+    },
+    {
+      "codePoint": "0xf04b9",
+      "identifiers": ["adobe"]
+    }
+  ]
+}
+''');
+        final unresolvedReportFile = File(
+          '${tempDirectory.path}/unresolved_report.json',
+        );
+        final outputFile = File(
+          '${tempDirectory.path}/material_rough_icons.g.dart',
+        );
+
+        await tool.runGenerateRoughIcons(<String>[
+          '--kit',
+          'flutter-material',
+          '--flutter-icons',
+          flutterIconsFile.path,
+          '--material-icons-source',
+          materialIconsRoot.path,
+          '--material-symbols-source',
+          materialSymbolsRoot.path,
+          '--brand-icons-source',
+          brandIconsRoot.path,
+          '--unresolved-baseline',
+          baselineFile.path,
+          '--fail-on-new-unresolved',
+          '--unresolved-output',
+          unresolvedReportFile.path,
+          '--output',
+          outputFile.path,
+        ]);
+
+        final decoded =
+            jsonDecode(unresolvedReportFile.readAsStringSync())
+                as Map<String, dynamic>;
+        expect(decoded['baselineUnresolvedCount'], 2);
+        expect(decoded['newUnresolvedCount'], 0);
+        expect(decoded['resolvedSinceBaselineCount'], 1);
+        expect(decoded['resolvedSinceBaseline'], <String>['0xe364']);
       },
     );
 
@@ -921,7 +1008,10 @@ class Icons {
       final decoded =
           jsonDecode(unresolvedReportFile.readAsStringSync())
               as Map<String, dynamic>;
+      expect(decoded['baselineUnresolvedCount'], 0);
       expect(decoded['newUnresolvedCount'], 1);
+      expect(decoded['resolvedSinceBaselineCount'], 0);
+      expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
 
       final newUnresolved = decoded['newUnresolved'] as List<dynamic>;
       expect(newUnresolved, hasLength(1));

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -94,6 +94,7 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
   final baselineUnresolvedCodePoints = _loadUnresolvedBaselineCodePoints(
     options.unresolvedBaselinePath,
   );
+  final unresolvedCodePoints = unresolved.map((item) => item.codePoint).toSet();
   final newUnresolved = baselineUnresolvedCodePoints == null
       ? null
       : unresolved
@@ -101,6 +102,15 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
               (item) => !baselineUnresolvedCodePoints.contains(item.codePoint),
             )
             .toList(growable: false);
+  final resolvedSinceBaseline = baselineUnresolvedCodePoints == null
+      ? null
+      : (() {
+          final resolved = baselineUnresolvedCodePoints
+              .where((codePoint) => !unresolvedCodePoints.contains(codePoint))
+              .toList(growable: false);
+          resolved.sort();
+          return resolved;
+        })();
 
   if (options.roughOutputDir != null) {
     await _generateRoughSvgs(options, roughTasks);
@@ -154,7 +164,9 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
         kit: options.kit,
         resolvedCount: icons.length,
         unresolved: unresolved,
+        baselineUnresolvedCount: baselineUnresolvedCodePoints?.length,
         newUnresolved: newUnresolved,
+        resolvedSinceBaseline: resolvedSinceBaseline,
       ),
     );
     stdout.writeln(
@@ -211,6 +223,19 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
         '  + 0x${item.codePoint.toRadixString(16)}: '
         '${item.identifiers.join(', ')}',
       );
+    }
+  }
+
+  if (resolvedSinceBaseline case final resolvedDiff?) {
+    if (resolvedDiff.isNotEmpty) {
+      final baselineSeverity = shouldFail ? 'Warning' : 'Info';
+      stderr.writeln(
+        '$baselineSeverity: ${resolvedDiff.length} baseline unresolved '
+        'codepoints are now resolved.',
+      );
+      for (final codePoint in resolvedDiff) {
+        stderr.writeln('  - 0x${codePoint.toRadixString(16)}');
+      }
     }
   }
 
@@ -1434,7 +1459,9 @@ String _renderUnresolvedReportJson({
   required String kit,
   required int resolvedCount,
   required List<_UnresolvedIcon> unresolved,
+  required int? baselineUnresolvedCount,
   required List<_UnresolvedIcon>? newUnresolved,
+  required List<int>? resolvedSinceBaseline,
 }) {
   final report = <String, Object>{
     'kit': kit,
@@ -1448,6 +1475,9 @@ String _renderUnresolvedReportJson({
           },
         )
         .toList(growable: false),
+    if (baselineUnresolvedCount != null) ...<String, Object>{
+      'baselineUnresolvedCount': baselineUnresolvedCount,
+    },
     if (newUnresolved != null) ...<String, Object>{
       'newUnresolvedCount': newUnresolved.length,
       'newUnresolved': newUnresolved
@@ -1457,6 +1487,12 @@ String _renderUnresolvedReportJson({
               'identifiers': item.identifiers,
             },
           )
+          .toList(growable: false),
+    },
+    if (resolvedSinceBaseline != null) ...<String, Object>{
+      'resolvedSinceBaselineCount': resolvedSinceBaseline.length,
+      'resolvedSinceBaseline': resolvedSinceBaseline
+          .map((codePoint) => '0x${codePoint.toRadixString(16)}')
           .toList(growable: false),
     },
   };


### PR DESCRIPTION
## Summary

This PR enriches unresolved baseline comparison reporting for rough icon generation.

### What changed

- Baseline comparison now also tracks **resolved-since-baseline** codepoints.
- `--unresolved-output` report gains optional fields (when `--unresolved-baseline` is used):
  - `baselineUnresolvedCount`
  - `resolvedSinceBaselineCount`
  - `resolvedSinceBaseline` (hex codepoint strings)
- Existing baseline regression fields remain:
  - `newUnresolvedCount`
  - `newUnresolved[]`
- Added parser/generator test coverage for:
  - resolved-since-baseline reporting
  - baseline fields in report output
- Updated docs:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Added changeset.

## Validation

- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `flutter test test/widgets/wired_icon_catalog_test.dart`
- `dart analyze --fatal-infos .`

## Example

```bash
cd packages/skribble
dart run tool/generate_rough_icons.dart \
  --kit flutter-material \
  --output /tmp/material_rough_icons.g.dart \
  --unresolved-baseline /tmp/material_rough_icons_baseline.json \
  --unresolved-output /tmp/material_rough_icons_report.json
```
