### PR TITLE
chore(rough-icons): gate workspace scripts with baseline

### DIFF
--- a/.changeset/rough-icon-baseline-workspace-gate.md
+++ b/.changeset/rough-icon-baseline-workspace-gate.md
@@ -1,0 +1,13 @@
+---
+skribble: patch
+---
+
+Add workspace-level unresolved baseline gating for rough icon generation.
+
+- Add committed baseline report:
+  - `packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`
+- Update melos scripts:
+  - `rough-icons` and `rough-icons-font` now pass
+    `--unresolved-baseline ... --fail-on-new-unresolved`
+  - add `rough-icons-baseline` to refresh the committed baseline report
+- Document baseline workflow in rough icon docs and package README.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -153,6 +153,20 @@ Baseline input supports either:
 
 This is useful in CI while tightening coverage incrementally.
 
+Workspace defaults:
+
+- `melos run rough-icons`
+- `melos run rough-icons-font`
+
+both enforce `--fail-on-new-unresolved` against
+`packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`.
+
+To refresh that baseline after intentional coverage changes:
+
+```bash
+melos run rough-icons-baseline
+```
+
 ## Runtime prerequisites
 
 - `deno` available on PATH

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -196,7 +196,12 @@ Workspace shortcuts:
 ```bash
 melos run rough-icons
 melos run rough-icons-font
+melos run rough-icons-baseline
 ```
+
+`rough-icons` and `rough-icons-font` both enforce unresolved regression gating
+via `--unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json`
+plus `--fail-on-new-unresolved`.
 
 Useful flags:
 

--- a/packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
+++ b/packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
@@ -1,0 +1,49 @@
+{
+  "kit": "flutter-material",
+  "resolvedCount": 8615,
+  "unresolvedCount": 7,
+  "unresolved": [
+    {
+      "codePoint": "0xe951",
+      "identifiers": [
+        "face_unlock_sharp"
+      ]
+    },
+    {
+      "codePoint": "0xf043",
+      "identifiers": [
+        "face_unlock_outlined"
+      ]
+    },
+    {
+      "codePoint": "0xf730",
+      "identifiers": [
+        "face_unlock_rounded"
+      ]
+    },
+    {
+      "codePoint": "0xf02d3",
+      "identifiers": [
+        "adobe_rounded"
+      ]
+    },
+    {
+      "codePoint": "0xf03c6",
+      "identifiers": [
+        "adobe_sharp"
+      ]
+    },
+    {
+      "codePoint": "0xf04b9",
+      "identifiers": [
+        "adobe"
+      ]
+    },
+    {
+      "codePoint": "0xf05b4",
+      "identifiers": [
+        "adobe_outlined"
+      ]
+    }
+  ]
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,18 +48,31 @@ melos:
       run: cd apps/skribble_storybook && flutter test integration_test/screenshots_test.dart
 
     rough-icons:
-      description: Generate rough Material icon artifacts (Dart map + rough SVG files).
+      description: Generate rough Material icon artifacts (Dart map + rough SVG files), failing on unresolved regressions.
       run: >-
         cd packages/skribble &&
         dart run tool/generate_rough_icons.dart
         --kit flutter-material
         --rough-output-dir tool/icon_exports/rough-svg
+        --unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json
+        --fail-on-new-unresolved
 
     rough-icons-font:
-      description: Generate rough Material icon font artifacts (TTF) from rough SVGs.
+      description: Generate rough Material icon font artifacts (TTF) from rough SVGs, failing on unresolved regressions.
       run: >-
         cd packages/skribble &&
         dart run tool/generate_rough_icons.dart
         --kit flutter-material
         --rough-output-dir tool/icon_exports/rough-svg
         --font-output-dir tool/icon_exports/font
+        --unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json
+        --fail-on-new-unresolved
+
+    rough-icons-baseline:
+      description: Refresh unresolved baseline JSON used for rough icon regression gating.
+      run: >-
+        cd packages/skribble &&
+        dart run tool/generate_rough_icons.dart
+        --kit flutter-material
+        --rough-only
+        --unresolved-output tool/examples/material_rough_icons.unresolved-baseline.json


### PR DESCRIPTION
## Summary

Add a committed unresolved baseline and wire workspace rough-icon scripts to
fail only on unresolved regressions.

### Changes

- Added baseline report file:
  - `packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`
- Updated melos scripts in `pubspec.yaml`:
  - `rough-icons` now includes:
    - `--unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json`
    - `--fail-on-new-unresolved`
  - `rough-icons-font` now includes the same regression-gate flags
  - Added `rough-icons-baseline` script to refresh the committed baseline
- Updated docs:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Added changeset.

## Validation

- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `flutter test test/widgets/wired_icon_catalog_test.dart`
- `dart analyze --fatal-infos .`
- `dart run tool/generate_rough_icons.dart --kit flutter-material --rough-only --unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json --fail-on-new-unresolved`
