### PR TITLE
feat(rough-icons): add normalized unresolved baseline output

### DIFF
--- a/.changeset/rough-icon-normalized-baseline-output.md
+++ b/.changeset/rough-icon-normalized-baseline-output.md
@@ -1,0 +1,13 @@
+---
+skribble: patch
+---
+
+Add normalized unresolved baseline output for rough icon regression workflows.
+
+- New CLI option: `--unresolved-baseline-output <path>`
+  - emits a minimal JSON file containing only `unresolved[]` entries
+  - uses deterministic sorting for stable baseline diffs
+- Keep `--unresolved-output` as the richer diagnostics report (counts, kit, etc.)
+- Update workspace baseline refresh script (`melos run rough-icons-baseline`) to
+  use normalized baseline output
+- Update docs and README to describe the new flag and workflow.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -124,6 +124,15 @@ The JSON report includes:
 - optional `newUnresolvedCount` / `newUnresolved[]` when baseline comparison is enabled
 - optional `resolvedSinceBaselineCount` / `resolvedSinceBaseline[]` (codepoint strings)
 
+## Normalized unresolved baseline output
+
+To emit a minimal baseline file dedicated to regression checks, pass:
+
+- `--unresolved-baseline-output <path>`
+
+This output intentionally contains only an `unresolved[]` list so baseline
+updates are smaller and avoid churn in unrelated report metadata.
+
 ## Supplemental manifest template output
 
 To emit a starter supplemental manifest for unresolved icons, pass:
@@ -161,7 +170,7 @@ Workspace defaults:
 both enforce `--fail-on-new-unresolved` against
 `packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`.
 
-To refresh that baseline after intentional coverage changes:
+To refresh that normalized baseline after intentional coverage changes:
 
 ```bash
 melos run rough-icons-baseline

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -201,7 +201,8 @@ melos run rough-icons-baseline
 
 `rough-icons` and `rough-icons-font` both enforce unresolved regression gating
 via `--unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json`
-plus `--fail-on-new-unresolved`.
+plus `--fail-on-new-unresolved`. Use `rough-icons-baseline` to refresh that
+normalized baseline file after intentional changes.
 
 Useful flags:
 
@@ -212,6 +213,7 @@ Useful flags:
 - `--brand-icons-source <path>` to provide a local `simple-icons` package as fallback for brand identifiers missing in Material SVG packages.
 - `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints.
 - `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring.
+- `--unresolved-baseline-output <path>` to emit a normalized unresolved baseline (`unresolved[]` only) for regression gating.
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.
 - `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`) or manifest (`icons[]`), including `newUnresolved` and `resolvedSinceBaseline` report fields.
 - `--max-unresolved <int>` to allow a bounded unresolved count before failing.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -409,6 +409,87 @@ class Icons {
     });
   });
 
+  group('runGenerateRoughIcons unresolved baseline output', () {
+    late Directory tempDirectory;
+
+    setUp(() {
+      tempDirectory = Directory.systemTemp.createTempSync(
+        'rough-icon-unresolved-baseline-output-test-',
+      );
+    });
+
+    tearDown(() {
+      tempDirectory.deleteSync(recursive: true);
+    });
+
+    test('writes normalized unresolved baseline JSON when requested', () async {
+      final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+        ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "face unlock" (sharp).
+  static const IconData face_unlock_sharp = IconData(0xe951, fontFamily: 'MaterialIcons');
+}
+''');
+
+      final materialIconsRoot = Directory(
+        '${tempDirectory.path}/material-icons',
+      )..createSync(recursive: true);
+      final materialSymbolsRoot = Directory(
+        '${tempDirectory.path}/material-symbols',
+      )..createSync(recursive: true);
+      final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+        ..createSync(recursive: true);
+
+      final outputFile = File(
+        '${tempDirectory.path}/material_rough_icons.g.dart',
+      );
+      final unresolvedBaselineFile = File(
+        '${tempDirectory.path}/unresolved-baseline.json',
+      );
+
+      await tool.runGenerateRoughIcons(<String>[
+        '--kit',
+        'flutter-material',
+        '--flutter-icons',
+        flutterIconsFile.path,
+        '--material-icons-source',
+        materialIconsRoot.path,
+        '--material-symbols-source',
+        materialSymbolsRoot.path,
+        '--brand-icons-source',
+        brandIconsRoot.path,
+        '--unresolved-baseline-output',
+        unresolvedBaselineFile.path,
+        '--output',
+        outputFile.path,
+      ]);
+
+      expect(unresolvedBaselineFile.existsSync(), isTrue);
+
+      final decoded =
+          jsonDecode(unresolvedBaselineFile.readAsStringSync())
+              as Map<String, dynamic>;
+      expect(decoded.containsKey('unresolved'), isTrue);
+      expect(decoded.containsKey('kit'), isFalse);
+      expect(decoded.containsKey('resolvedCount'), isFalse);
+      expect(decoded.containsKey('unresolvedCount'), isFalse);
+
+      final unresolved = decoded['unresolved'] as List<dynamic>;
+      expect(unresolved, hasLength(2));
+
+      final firstUnresolved = unresolved.first as Map<String, dynamic>;
+      expect(firstUnresolved['codePoint'], '0xe951');
+      expect(firstUnresolved['identifiers'], <String>['face_unlock_sharp']);
+
+      final secondUnresolved = unresolved[1] as Map<String, dynamic>;
+      expect(secondUnresolved['codePoint'], '0xf04b9');
+      expect(secondUnresolved['identifiers'], <String>['adobe']);
+    });
+  });
+
   group('runGenerateRoughIcons supplemental manifest template output', () {
     late Directory tempDirectory;
 

--- a/packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
+++ b/packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
@@ -1,7 +1,4 @@
 {
-  "kit": "flutter-material",
-  "resolvedCount": 8615,
-  "unresolvedCount": 7,
   "unresolved": [
     {
       "codePoint": "0xe951",

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -174,6 +174,19 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
     );
   }
 
+  if (options.unresolvedBaselineOutputPath
+      case final unresolvedBaselineOutputPath?) {
+    final unresolvedBaselineOutputFile = File(unresolvedBaselineOutputPath)
+      ..createSync(recursive: true);
+    unresolvedBaselineOutputFile.writeAsStringSync(
+      _renderUnresolvedBaselineJson(unresolved: unresolved),
+    );
+    stdout.writeln(
+      'Generated unresolved baseline JSON to '
+      '${unresolvedBaselineOutputFile.path}',
+    );
+  }
+
   if (options.supplementalManifestOutputPath
       case final supplementalManifestOutputPath?) {
     final supplementalManifestOutputFile = File(supplementalManifestOutputPath)
@@ -272,6 +285,8 @@ Options:
   --brand-icons-source <path>      Path to extracted simple-icons package (brand fallback).
   --supplemental-manifest <path>   JSON manifest for unresolved flutter-material icons.
   --unresolved-output <path>       Emit unresolved icon codepoint report as JSON.
+  --unresolved-baseline-output <path>
+                                   Emit normalized unresolved baseline JSON.
   --supplemental-manifest-output <path>
                                    Emit supplemental manifest template JSON.
   --unresolved-baseline <path>     Baseline unresolved report or manifest JSON for diffing.
@@ -326,6 +341,7 @@ final class _ScriptOptions {
     this.brandIconsSourcePath,
     this.supplementalManifestPath,
     this.unresolvedOutputPath,
+    this.unresolvedBaselineOutputPath,
     this.supplementalManifestOutputPath,
     this.unresolvedBaselinePath,
     this.maxUnresolved,
@@ -356,6 +372,7 @@ final class _ScriptOptions {
   final String? brandIconsSourcePath;
   final String? supplementalManifestPath;
   final String? unresolvedOutputPath;
+  final String? unresolvedBaselineOutputPath;
   final String? supplementalManifestOutputPath;
   final String? unresolvedBaselinePath;
   final int? maxUnresolved;
@@ -386,6 +403,7 @@ final class _ScriptOptions {
     String? brandIconsSourcePath;
     String? supplementalManifestPath;
     String? unresolvedOutputPath;
+    String? unresolvedBaselineOutputPath;
     String? supplementalManifestOutputPath;
     String? unresolvedBaselinePath;
     int? maxUnresolved;
@@ -468,6 +486,8 @@ final class _ScriptOptions {
           supplementalManifestPath = value;
         case '--unresolved-output':
           unresolvedOutputPath = value;
+        case '--unresolved-baseline-output':
+          unresolvedBaselineOutputPath = value;
         case '--supplemental-manifest-output':
           supplementalManifestOutputPath = value;
         case '--unresolved-baseline':
@@ -519,6 +539,7 @@ final class _ScriptOptions {
       brandIconsSourcePath: brandIconsSourcePath,
       supplementalManifestPath: supplementalManifestPath,
       unresolvedOutputPath: unresolvedOutputPath,
+      unresolvedBaselineOutputPath: unresolvedBaselineOutputPath,
       supplementalManifestOutputPath: supplementalManifestOutputPath,
       unresolvedBaselinePath: unresolvedBaselinePath,
       maxUnresolved: maxUnresolved,
@@ -1467,26 +1488,14 @@ String _renderUnresolvedReportJson({
     'kit': kit,
     'resolvedCount': resolvedCount,
     'unresolvedCount': unresolved.length,
-    'unresolved': unresolved
-        .map(
-          (item) => <String, Object>{
-            'codePoint': '0x${item.codePoint.toRadixString(16)}',
-            'identifiers': item.identifiers,
-          },
-        )
-        .toList(growable: false),
+    'unresolved': unresolved.map(_unresolvedIconJson).toList(growable: false),
     if (baselineUnresolvedCount != null) ...<String, Object>{
       'baselineUnresolvedCount': baselineUnresolvedCount,
     },
     if (newUnresolved != null) ...<String, Object>{
       'newUnresolvedCount': newUnresolved.length,
       'newUnresolved': newUnresolved
-          .map(
-            (item) => <String, Object>{
-              'codePoint': '0x${item.codePoint.toRadixString(16)}',
-              'identifiers': item.identifiers,
-            },
-          )
+          .map(_unresolvedIconJson)
           .toList(growable: false),
     },
     if (resolvedSinceBaseline != null) ...<String, Object>{
@@ -1498,6 +1507,36 @@ String _renderUnresolvedReportJson({
   };
 
   return const JsonEncoder.withIndent('  ').convert(report);
+}
+
+Map<String, Object> _unresolvedIconJson(_UnresolvedIcon item) {
+  return <String, Object>{
+    'codePoint': '0x${item.codePoint.toRadixString(16)}',
+    'identifiers': item.identifiers,
+  };
+}
+
+String _renderUnresolvedBaselineJson({
+  required List<_UnresolvedIcon> unresolved,
+}) {
+  final sortedUnresolved = [...unresolved]
+    ..sort((a, b) {
+      final byCodePoint = a.codePoint.compareTo(b.codePoint);
+      if (byCodePoint != 0) {
+        return byCodePoint;
+      }
+      final aIdentifier = a.identifiers.isEmpty ? '' : a.identifiers.first;
+      final bIdentifier = b.identifiers.isEmpty ? '' : b.identifiers.first;
+      return aIdentifier.compareTo(bIdentifier);
+    });
+
+  final baseline = <String, Object>{
+    'unresolved': sortedUnresolved
+        .map(_unresolvedIconJson)
+        .toList(growable: false),
+  };
+
+  return const JsonEncoder.withIndent('  ').convert(baseline);
 }
 
 String _renderSupplementalManifestTemplateJson({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,10 +69,10 @@ melos:
         --fail-on-new-unresolved
 
     rough-icons-baseline:
-      description: Refresh unresolved baseline JSON used for rough icon regression gating.
+      description: Refresh normalized unresolved baseline JSON used for rough icon regression gating.
       run: >-
         cd packages/skribble &&
         dart run tool/generate_rough_icons.dart
         --kit flutter-material
         --rough-only
-        --unresolved-output tool/examples/material_rough_icons.unresolved-baseline.json
+        --unresolved-baseline-output tool/examples/material_rough_icons.unresolved-baseline.json


### PR DESCRIPTION
## Summary

Add a dedicated normalized baseline output mode for rough icon unresolved
regression workflows.

### What changed

- Added new CLI option:
  - `--unresolved-baseline-output <path>`
- New output format is intentionally minimal and stable:
  - JSON object with only `unresolved[]` entries (`codePoint`, `identifiers`)
  - deterministic sort by codepoint
- Kept `--unresolved-output` as the richer diagnostics report.
- Updated workspace script:
  - `melos run rough-icons-baseline` now uses
    `--unresolved-baseline-output`.
- Updated committed baseline fixture:
  - `packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`
  - now contains normalized baseline format.
- Added test coverage for baseline output behavior.
- Updated docs/README and added changeset.

## Validation

- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `flutter test test/widgets/wired_icon_catalog_test.dart`
- `dart analyze --fatal-infos .`
- `dart run tool/generate_rough_icons.dart --kit flutter-material --rough-only --unresolved-baseline-output tool/examples/material_rough_icons.unresolved-baseline.json`
