### PR TITLE
chore(ci): gate rough icon unresolved regressions

### DIFF
--- a/.changeset/rough-icon-ci-regression-gate.md
+++ b/.changeset/rough-icon-ci-regression-gate.md
@@ -1,0 +1,11 @@
+---
+skribble: patch
+---
+
+Enable rough icon unresolved regression gating in CI.
+
+- Add a dedicated CI job (`rough-icons-regression`) that runs rough icon
+  resolution in `--rough-only` mode against the committed unresolved baseline.
+- The job fails pull requests when new unresolved icon regressions are
+  introduced (`--fail-on-new-unresolved`).
+- Update rough icon docs/README to note the CI enforcement behavior.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,23 @@ jobs:
         run: test:all
         shell: devenv shell -- bash -e {0}
 
+  rough-icons-regression:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: rough icons unresolved regression gate
+        run: >-
+          cd packages/skribble &&
+          dart run tool/generate_rough_icons.dart
+          --kit flutter-material
+          --rough-only
+          --unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json
+          --fail-on-new-unresolved
+        shell: devenv shell -- bash -e {0}
+
   coverage:
     if: github.ref == 'refs/heads/main'
     runs-on: blacksmith-2vcpu-ubuntu-2404

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -170,6 +170,9 @@ Workspace defaults:
 both enforce `--fail-on-new-unresolved` against
 `packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`.
 
+CI also enforces the same unresolved regression gate on pull requests using
+`--rough-only` plus `--unresolved-baseline`.
+
 To refresh that normalized baseline after intentional coverage changes:
 
 ```bash

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -202,7 +202,8 @@ melos run rough-icons-baseline
 `rough-icons` and `rough-icons-font` both enforce unresolved regression gating
 via `--unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json`
 plus `--fail-on-new-unresolved`. Use `rough-icons-baseline` to refresh that
-normalized baseline file after intentional changes.
+normalized baseline file after intentional changes. Pull-request CI also runs
+this gate in `--rough-only` mode.
 
 Useful flags:
 


### PR DESCRIPTION
## Summary

Add CI enforcement for rough icon unresolved regression checks.

### Changes

- Added new CI job in `.github/workflows/ci.yml`:
  - `rough-icons-regression`
  - runs rough icon resolution in `--rough-only` mode
  - compares against committed baseline:
    `packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`
  - fails on newly unresolved icons via `--fail-on-new-unresolved`
- Updated docs:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Added changeset.

## Validation

- `dart run tool/generate_rough_icons.dart --kit flutter-material --rough-only --unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json --fail-on-new-unresolved`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `flutter test test/widgets/wired_icon_catalog_test.dart`
- `dart analyze --fatal-infos .`
