### PR TITLE
chore(ci): upload rough icon unresolved report artifact

### DIFF
--- a/.changeset/rough-icon-ci-unresolved-artifact.md
+++ b/.changeset/rough-icon-ci-unresolved-artifact.md
@@ -1,0 +1,11 @@
+---
+skribble: patch
+---
+
+Improve rough icon CI regression diagnostics by publishing unresolved reports.
+
+- Update `rough-icons-regression` CI job to also pass
+  `--unresolved-output` while running `--fail-on-new-unresolved` gating.
+- Upload the generated report as a workflow artifact:
+  `rough-icons-unresolved-report`.
+- Document artifact availability in rough icon pipeline docs and README.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
 
   rough-icons-regression:
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    env:
+      ROUGH_ICONS_UNRESOLVED_REPORT: ${{ runner.temp }}/rough-icons-unresolved-report.json
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/devenv
@@ -43,8 +45,16 @@ jobs:
           --kit flutter-material
           --rough-only
           --unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json
+          --unresolved-output "$ROUGH_ICONS_UNRESOLVED_REPORT"
           --fail-on-new-unresolved
         shell: devenv shell -- bash -e {0}
+      - name: upload rough icons unresolved report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rough-icons-unresolved-report
+          path: ${{ env.ROUGH_ICONS_UNRESOLVED_REPORT }}
+          if-no-files-found: ignore
 
   coverage:
     if: github.ref == 'refs/heads/main'

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -171,7 +171,9 @@ both enforce `--fail-on-new-unresolved` against
 `packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`.
 
 CI also enforces the same unresolved regression gate on pull requests using
-`--rough-only` plus `--unresolved-baseline`.
+`--rough-only` plus `--unresolved-baseline`, and uploads an
+`rough-icons-unresolved-report` artifact (from `--unresolved-output`) to aid
+regression diagnosis.
 
 To refresh that normalized baseline after intentional coverage changes:
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -203,7 +203,8 @@ melos run rough-icons-baseline
 via `--unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json`
 plus `--fail-on-new-unresolved`. Use `rough-icons-baseline` to refresh that
 normalized baseline file after intentional changes. Pull-request CI also runs
-this gate in `--rough-only` mode.
+this gate in `--rough-only` mode and uploads a
+`rough-icons-unresolved-report` artifact for diagnostics.
 
 Useful flags:
 


### PR DESCRIPTION
## Summary

Improve rough icon regression diagnostics in CI by uploading unresolved reports
as workflow artifacts.

### Changes

- Updated `.github/workflows/ci.yml` (`rough-icons-regression` job):
  - keep baseline regression gate (`--fail-on-new-unresolved`)
  - add `--unresolved-output "$ROUGH_ICONS_UNRESOLVED_REPORT"`
  - upload report via `actions/upload-artifact@v4` with name:
    - `rough-icons-unresolved-report`
  - upload step runs with `if: always()` so the report is available when the
    gate fails
- Updated docs:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Added changeset.

## Validation

- `dart run tool/generate_rough_icons.dart --kit flutter-material --rough-only --unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json --unresolved-output /tmp/material_rough_icons_ci_artifact_report.json --fail-on-new-unresolved`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `flutter test test/widgets/wired_icon_catalog_test.dart`
- `dart analyze --fatal-infos .`
