### PR TITLE
chore(ci): verify rough icon baseline stays in sync

### DIFF
--- a/.changeset/rough-icon-ci-baseline-sync-check.md
+++ b/.changeset/rough-icon-ci-baseline-sync-check.md
@@ -1,0 +1,13 @@
+---
+skribble: patch
+---
+
+Add CI verification that the committed rough icon unresolved baseline file is
+kept in sync.
+
+- Add a new CI job (`rough-icons-baseline-sync`) that regenerates
+  `packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`
+  using the committed supplemental manifest.
+- Fail the job when baseline regeneration leaves a diff, ensuring baseline
+  updates are committed with related icon-pipeline changes.
+- Print the baseline diff in CI logs when the sync check fails.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,37 @@ jobs:
           path: packages/skribble/unresolved-report.json
           if-no-files-found: ignore
 
+  rough-icons-baseline-sync:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: regenerate unresolved baseline
+        run: >-
+          cd packages/skribble &&
+          dart run tool/generate_rough_icons.dart
+          --kit flutter-material
+          --rough-only
+          --supplemental-manifest tool/examples/material_rough_icons.supplemental.manifest.json
+          --unresolved-baseline-output tool/examples/material_rough_icons.unresolved-baseline.json
+        shell: devenv shell -- bash -e {0}
+      - name: format regenerated unresolved baseline
+        run: dprint fmt packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
+        shell: devenv shell -- bash -e {0}
+      - name: verify unresolved baseline is up to date
+        run: >-
+          git diff --exit-code --
+          packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
+        shell: devenv shell -- bash -e {0}
+      - name: show unresolved baseline diff on failure
+        if: failure()
+        run: >-
+          git --no-pager diff --
+          packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
+        shell: devenv shell -- bash -e {0}
+
   coverage:
     if: github.ref == 'refs/heads/main'
     runs-on: blacksmith-2vcpu-ubuntu-2404

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -181,6 +181,10 @@ CI also enforces the same unresolved regression gate on pull requests using
 uploads an `rough-icons-unresolved-report` artifact (from
 `--unresolved-output`) to aid regression diagnosis.
 
+CI also verifies the committed baseline file is up to date by regenerating
+`packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`
+and failing if a diff remains.
+
 To refresh that normalized baseline after intentional coverage changes:
 
 ```bash

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -205,8 +205,9 @@ enforce unresolved regression gating via
 `--unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json`
 plus `--fail-on-new-unresolved`. Use `rough-icons-baseline` to refresh that
 normalized baseline file after intentional changes. Pull-request CI also runs
-this gate in `--rough-only` mode and uploads a
-`rough-icons-unresolved-report` artifact for diagnostics.
+this gate in `--rough-only` mode, uploads a
+`rough-icons-unresolved-report` artifact for diagnostics, and verifies the
+committed baseline file is up to date.
 
 Useful flags:
 


### PR DESCRIPTION
## Summary

Add CI verification that the committed rough-icon unresolved baseline remains
in sync with current generator behavior.

### Changes

- Added new CI job in `.github/workflows/ci.yml`:
  - `rough-icons-baseline-sync`
- Job workflow:
  1. regenerate baseline with committed supplemental manifest
  2. format regenerated baseline JSON with `dprint fmt`
  3. fail if git diff remains for
     `packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`
  4. print diff when failing for easier debugging
- Updated rough-icon docs/README to document this additional CI guard.
- Added changeset.

## Validation

- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `flutter test test/widgets/wired_icon_catalog_test.dart`
- `dart analyze --fatal-infos .`
- `dart run tool/generate_rough_icons.dart --kit flutter-material --rough-only --supplemental-manifest tool/examples/material_rough_icons.supplemental.manifest.json --unresolved-baseline-output tool/examples/material_rough_icons.unresolved-baseline.json`
- `dprint fmt packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`
- `git diff --exit-code -- packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`
