### PR TITLE
ci: upload rough icon sync diffs as artifacts

### DIFF
--- a/.changeset/rough-icon-ci-sync-diff-artifacts.md
+++ b/.changeset/rough-icon-ci-sync-diff-artifacts.md
@@ -1,0 +1,13 @@
+---
+skribble: patch
+---
+
+Improve rough icon CI failure diagnostics for sync checks.
+
+- `rough-icons-baseline-sync` now saves and uploads a
+  `rough-icons-baseline-sync-diff` artifact when the regenerated baseline file
+  differs from committed output.
+- `rough-icons-generated-sync` now saves and uploads a
+  `rough-icons-generated-sync-diff` artifact when regenerated rough icon
+  catalogs differ from committed files.
+- Update rough icon docs/README to describe these failure artifacts.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,20 @@ jobs:
           git --no-pager diff --
           packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
         shell: devenv shell -- bash -e {0}
+      - name: save unresolved baseline diff artifact
+        if: failure()
+        run: >-
+          git --no-pager diff --
+          packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
+          > rough-icons-baseline-sync.diff
+        shell: devenv shell -- bash -e {0}
+      - name: upload unresolved baseline diff artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rough-icons-baseline-sync-diff
+          path: rough-icons-baseline-sync.diff
+          if-no-files-found: ignore
 
   rough-icons-generated-sync:
     runs-on: blacksmith-2vcpu-ubuntu-2404
@@ -117,6 +131,21 @@ jobs:
           packages/skribble/lib/src/generated/material_rough_icons.g.dart
           packages/skribble/lib/src/generated/material_rough_icon_font.g.dart
         shell: devenv shell -- bash -e {0}
+      - name: save rough icon catalog diff artifact
+        if: failure()
+        run: >-
+          git --no-pager diff --
+          packages/skribble/lib/src/generated/material_rough_icons.g.dart
+          packages/skribble/lib/src/generated/material_rough_icon_font.g.dart
+          > rough-icons-generated-sync.diff
+        shell: devenv shell -- bash -e {0}
+      - name: upload rough icon catalog diff artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rough-icons-generated-sync-diff
+          path: rough-icons-generated-sync.diff
+          if-no-files-found: ignore
 
   coverage:
     if: github.ref == 'refs/heads/main'

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -184,13 +184,17 @@ uploads an `rough-icons-unresolved-report` artifact (from
 
 CI also verifies the committed baseline file is up to date by regenerating
 `packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`
-and failing if a diff remains.
+and failing if a diff remains. On failure, CI uploads a
+`rough-icons-baseline-sync-diff` artifact with the baseline diff.
 
 CI additionally verifies generated rough icon catalogs are committed and up to
 date by regenerating:
 
 - `packages/skribble/lib/src/generated/material_rough_icons.g.dart`
 - `packages/skribble/lib/src/generated/material_rough_icon_font.g.dart`
+
+On generated-sync failures, CI uploads a
+`rough-icons-generated-sync-diff` artifact with catalog diffs.
 
 To refresh that normalized baseline after intentional coverage changes:
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -207,8 +207,10 @@ plus `--fail-on-new-unresolved`. Use `rough-icons-baseline` to refresh that
 normalized baseline file after intentional changes. Pull-request CI also runs
 this gate in `--rough-only` mode, uploads a
 `rough-icons-unresolved-report` artifact for diagnostics, verifies the
-committed baseline file is up to date, and checks that generated rough icon
-catalog files are committed/synced.
+committed baseline file is up to date, checks that generated rough icon
+catalog files are committed/synced, and uploads diff artifacts
+(`rough-icons-baseline-sync-diff`, `rough-icons-generated-sync-diff`) when
+those sync checks fail.
 
 Useful flags:
 


### PR DESCRIPTION
## Summary

Improve rough icon sync-check diagnostics in CI.

- Upload `rough-icons-baseline-sync-diff` artifact when baseline-sync check fails.
- Upload `rough-icons-generated-sync-diff` artifact when generated-catalog sync check fails.
- Document the new failure artifacts in:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Add changeset:
  - `.changeset/rough-icon-ci-sync-diff-artifacts.md`

## Validation

- `git diff --check`
- `dprint check .github/workflows/ci.yml docs/rough-icon-pipeline.md packages/skribble/README.md .changeset/rough-icon-ci-sync-diff-artifacts.md`
