### PR TITLE
ci: share rough icon checks via script

### DIFF
--- a/.changeset/rough-icon-ci-check-script-shortcut.md
+++ b/.changeset/rough-icon-ci-check-script-shortcut.md
@@ -1,0 +1,12 @@
+---
+skribble: patch
+---
+
+Improve rough icon CI/local parity ergonomics with reusable check scripts.
+
+- Add `scripts/check_rough_icons_ci.sh` with `regression`, `baseline-sync`,
+  `generated-sync`, and `all` modes.
+- Refactor rough icon CI jobs to use this script instead of duplicating command
+  blocks.
+- Add workspace shortcut `melos run rough-icons-ci-check`.
+- Update rough icon docs/README with local CI-equivalent check commands.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,15 +37,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: rough icons unresolved regression gate
-        run: >-
-          cd packages/skribble &&
-          dart run tool/generate_rough_icons.dart
-          --kit flutter-material
-          --rough-only
-          --supplemental-manifest tool/examples/material_rough_icons.supplemental.manifest.json
-          --unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json
-          --unresolved-output unresolved-report.json
-          --fail-on-new-unresolved
+        run: ./scripts/check_rough_icons_ci.sh regression
         shell: devenv shell -- bash -e {0}
       - name: upload rough icons unresolved report
         if: always()
@@ -62,22 +54,8 @@ jobs:
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: regenerate unresolved baseline
-        run: >-
-          cd packages/skribble &&
-          dart run tool/generate_rough_icons.dart
-          --kit flutter-material
-          --rough-only
-          --supplemental-manifest tool/examples/material_rough_icons.supplemental.manifest.json
-          --unresolved-baseline-output tool/examples/material_rough_icons.unresolved-baseline.json
-        shell: devenv shell -- bash -e {0}
-      - name: format regenerated unresolved baseline
-        run: dprint fmt packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
-        shell: devenv shell -- bash -e {0}
-      - name: verify unresolved baseline is up to date
-        run: >-
-          git diff --exit-code --
-          packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
+      - name: run unresolved baseline sync check
+        run: ./scripts/check_rough_icons_ci.sh baseline-sync
         shell: devenv shell -- bash -e {0}
       - name: show unresolved baseline diff on failure
         if: failure()
@@ -107,22 +85,8 @@ jobs:
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: regenerate committed rough icon catalogs
-        run: >-
-          cd packages/skribble &&
-          dart run tool/generate_rough_icons.dart
-          --kit flutter-material
-          --supplemental-manifest tool/examples/material_rough_icons.supplemental.manifest.json
-          --unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json
-          --fail-on-new-unresolved
-          --output lib/src/generated/material_rough_icons.g.dart
-          --font-dart-output lib/src/generated/material_rough_icon_font.g.dart
-        shell: devenv shell -- bash -e {0}
-      - name: verify rough icon catalogs are up to date
-        run: >-
-          git diff --exit-code --
-          packages/skribble/lib/src/generated/material_rough_icons.g.dart
-          packages/skribble/lib/src/generated/material_rough_icon_font.g.dart
+      - name: run rough icon catalog sync check
+        run: ./scripts/check_rough_icons_ci.sh generated-sync
         shell: devenv shell -- bash -e {0}
       - name: show rough icon catalog diff on failure
         if: failure()

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -167,15 +167,26 @@ Baseline input supports either:
 
 This is useful in CI while tightening coverage incrementally.
 
-Workspace defaults:
+Workspace shortcuts:
 
 - `melos run rough-icons`
 - `melos run rough-icons-font`
+- `melos run rough-icons-baseline`
+- `melos run rough-icons-ci-check`
 
-both apply the committed supplemental manifest
-`packages/skribble/tool/examples/material_rough_icons.supplemental.manifest.json`
+`rough-icons` and `rough-icons-font` both apply the committed supplemental
+manifest `packages/skribble/tool/examples/material_rough_icons.supplemental.manifest.json`
 and enforce `--fail-on-new-unresolved` against
 `packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`.
+
+`rough-icons-ci-check` runs the same rough icon regression/sync checks used by
+CI via `./scripts/check_rough_icons_ci.sh all`.
+
+For targeted local debugging, run an individual CI-equivalent check:
+
+- `./scripts/check_rough_icons_ci.sh regression`
+- `./scripts/check_rough_icons_ci.sh baseline-sync`
+- `./scripts/check_rough_icons_ci.sh generated-sync`
 
 CI also enforces the same unresolved regression gate on pull requests using
 `--rough-only`, `--supplemental-manifest`, and `--unresolved-baseline`, and

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -197,6 +197,7 @@ Workspace shortcuts:
 melos run rough-icons
 melos run rough-icons-font
 melos run rough-icons-baseline
+melos run rough-icons-ci-check
 ```
 
 `rough-icons` and `rough-icons-font` both apply the committed supplemental
@@ -204,8 +205,18 @@ manifest (`tool/examples/material_rough_icons.supplemental.manifest.json`) and
 enforce unresolved regression gating via
 `--unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json`
 plus `--fail-on-new-unresolved`. Use `rough-icons-baseline` to refresh that
-normalized baseline file after intentional changes. Pull-request CI also runs
-this gate in `--rough-only` mode, uploads a
+normalized baseline file after intentional changes.
+
+`rough-icons-ci-check` runs the same rough icon regression/sync checks enforced
+by CI via `./scripts/check_rough_icons_ci.sh all`.
+
+For targeted local debugging, run an individual CI-equivalent check:
+
+- `./scripts/check_rough_icons_ci.sh regression`
+- `./scripts/check_rough_icons_ci.sh baseline-sync`
+- `./scripts/check_rough_icons_ci.sh generated-sync`
+
+Pull-request CI also runs the unresolved gate in `--rough-only` mode, uploads a
 `rough-icons-unresolved-report` artifact for diagnostics, verifies the
 committed baseline file is up to date, checks that generated rough icon
 catalog files are committed/synced, and uploads diff artifacts

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,3 +80,7 @@ melos:
         --rough-only
         --supplemental-manifest tool/examples/material_rough_icons.supplemental.manifest.json
         --unresolved-baseline-output tool/examples/material_rough_icons.unresolved-baseline.json
+
+    rough-icons-ci-check:
+      description: Run the same rough icon regression/sync checks enforced by CI.
+      run: ./scripts/check_rough_icons_ci.sh all

--- a/scripts/check_rough_icons_ci.sh
+++ b/scripts/check_rough_icons_ci.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Run rough icon CI parity checks locally or in CI.
+#
+# Usage:
+#   ./scripts/check_rough_icons_ci.sh [regression|baseline-sync|generated-sync|all]
+
+set -euo pipefail
+
+MODE="${1:-all}"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+cd "$REPO_ROOT"
+
+run_regression_check() {
+  (
+    cd packages/skribble
+    dart run tool/generate_rough_icons.dart \
+      --kit flutter-material \
+      --rough-only \
+      --supplemental-manifest tool/examples/material_rough_icons.supplemental.manifest.json \
+      --unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json \
+      --unresolved-output unresolved-report.json \
+      --fail-on-new-unresolved
+  )
+}
+
+run_baseline_sync_check() {
+  (
+    cd packages/skribble
+    dart run tool/generate_rough_icons.dart \
+      --kit flutter-material \
+      --rough-only \
+      --supplemental-manifest tool/examples/material_rough_icons.supplemental.manifest.json \
+      --unresolved-baseline-output tool/examples/material_rough_icons.unresolved-baseline.json
+  )
+
+  dprint fmt packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
+  git diff --exit-code -- packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
+}
+
+run_generated_sync_check() {
+  (
+    cd packages/skribble
+    dart run tool/generate_rough_icons.dart \
+      --kit flutter-material \
+      --supplemental-manifest tool/examples/material_rough_icons.supplemental.manifest.json \
+      --unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json \
+      --fail-on-new-unresolved \
+      --output lib/src/generated/material_rough_icons.g.dart \
+      --font-dart-output lib/src/generated/material_rough_icon_font.g.dart
+  )
+
+  git diff --exit-code -- \
+    packages/skribble/lib/src/generated/material_rough_icons.g.dart \
+    packages/skribble/lib/src/generated/material_rough_icon_font.g.dart
+}
+
+case "$MODE" in
+  regression)
+    run_regression_check
+    ;;
+  baseline-sync)
+    run_baseline_sync_check
+    ;;
+  generated-sync)
+    run_generated_sync_check
+    ;;
+  all)
+    run_regression_check
+    run_baseline_sync_check
+    run_generated_sync_check
+    ;;
+  *)
+    echo "Unknown mode: $MODE"
+    echo "Usage: ./scripts/check_rough_icons_ci.sh [regression|baseline-sync|generated-sync|all]"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Improve rough icon CI/local parity by extracting check logic into a shared script.

- Add `scripts/check_rough_icons_ci.sh` with modes:
  - `regression`
  - `baseline-sync`
  - `generated-sync`
  - `all`
- Refactor rough icon CI jobs to call this script instead of duplicating long
  command blocks.
- Add workspace shortcut:
  - `melos run rough-icons-ci-check`
- Update rough icon docs:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Add changeset:
  - `.changeset/rough-icon-ci-check-script-shortcut.md`

## Validation

- `git diff --check`
- `dprint check .github/workflows/ci.yml docs/rough-icon-pipeline.md packages/skribble/README.md pubspec.yaml .changeset/rough-icon-ci-check-script-shortcut.md`
- `bash -n scripts/check_rough_icons_ci.sh`
- `./scripts/check_rough_icons_ci.sh regression`
- `./scripts/check_rough_icons_ci.sh baseline-sync`
- `./scripts/check_rough_icons_ci.sh generated-sync`
