### PR TITLE
ci: centralize rough icon sync diff output

### DIFF
--- a/.changeset/rough-icon-ci-script-sync-diffs.md
+++ b/.changeset/rough-icon-ci-script-sync-diffs.md
@@ -1,0 +1,15 @@
+---
+skribble: patch
+---
+
+Improve rough icon CI/local check ergonomics by extending the shared check script.
+
+- `scripts/check_rough_icons_ci.sh` now prints and writes sync diffs
+  (`rough-icons-baseline-sync.diff`, `rough-icons-generated-sync.diff`) when
+  baseline/catalog sync checks fail.
+- `rough-icons-regression` local runs now clean up
+  `packages/skribble/unresolved-report.json` on success by default
+  (`ROUGH_ICONS_KEEP_UNRESOLVED_REPORT=1` keeps it).
+- CI workflow now relies on the script for diff generation and keeps only the
+  failure artifact upload steps.
+- Update rough icon docs/README with the script’s diff and report behavior.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,19 +57,6 @@ jobs:
       - name: run unresolved baseline sync check
         run: ./scripts/check_rough_icons_ci.sh baseline-sync
         shell: devenv shell -- bash -e {0}
-      - name: show unresolved baseline diff on failure
-        if: failure()
-        run: >-
-          git --no-pager diff --
-          packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
-        shell: devenv shell -- bash -e {0}
-      - name: save unresolved baseline diff artifact
-        if: failure()
-        run: >-
-          git --no-pager diff --
-          packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
-          > rough-icons-baseline-sync.diff
-        shell: devenv shell -- bash -e {0}
       - name: upload unresolved baseline diff artifact
         if: failure()
         uses: actions/upload-artifact@v4
@@ -87,21 +74,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: run rough icon catalog sync check
         run: ./scripts/check_rough_icons_ci.sh generated-sync
-        shell: devenv shell -- bash -e {0}
-      - name: show rough icon catalog diff on failure
-        if: failure()
-        run: >-
-          git --no-pager diff --
-          packages/skribble/lib/src/generated/material_rough_icons.g.dart
-          packages/skribble/lib/src/generated/material_rough_icon_font.g.dart
-        shell: devenv shell -- bash -e {0}
-      - name: save rough icon catalog diff artifact
-        if: failure()
-        run: >-
-          git --no-pager diff --
-          packages/skribble/lib/src/generated/material_rough_icons.g.dart
-          packages/skribble/lib/src/generated/material_rough_icon_font.g.dart
-          > rough-icons-generated-sync.diff
         shell: devenv shell -- bash -e {0}
       - name: upload rough icon catalog diff artifact
         if: failure()

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -188,6 +188,14 @@ For targeted local debugging, run an individual CI-equivalent check:
 - `./scripts/check_rough_icons_ci.sh baseline-sync`
 - `./scripts/check_rough_icons_ci.sh generated-sync`
 
+On sync-check failures, the script prints `git diff` output and saves it to:
+
+- `rough-icons-baseline-sync.diff`
+- `rough-icons-generated-sync.diff`
+
+`regression` cleans up `packages/skribble/unresolved-report.json` after a
+successful local run. Set `ROUGH_ICONS_KEEP_UNRESOLVED_REPORT=1` to keep it.
+
 CI also enforces the same unresolved regression gate on pull requests using
 `--rough-only`, `--supplemental-manifest`, and `--unresolved-baseline`, and
 uploads an `rough-icons-unresolved-report` artifact (from

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -216,6 +216,14 @@ For targeted local debugging, run an individual CI-equivalent check:
 - `./scripts/check_rough_icons_ci.sh baseline-sync`
 - `./scripts/check_rough_icons_ci.sh generated-sync`
 
+On sync-check failures, the script prints `git diff` output and writes:
+
+- `rough-icons-baseline-sync.diff`
+- `rough-icons-generated-sync.diff`
+
+`regression` cleans up `packages/skribble/unresolved-report.json` after a
+successful local run. Set `ROUGH_ICONS_KEEP_UNRESOLVED_REPORT=1` to keep it.
+
 Pull-request CI also runs the unresolved gate in `--rough-only` mode, uploads a
 `rough-icons-unresolved-report` artifact for diagnostics, verifies the
 committed baseline file is up to date, checks that generated rough icon

--- a/scripts/check_rough_icons_ci.sh
+++ b/scripts/check_rough_icons_ci.sh
@@ -3,6 +3,10 @@
 #
 # Usage:
 #   ./scripts/check_rough_icons_ci.sh [regression|baseline-sync|generated-sync|all]
+#
+# Optional env vars:
+#   ROUGH_ICONS_KEEP_UNRESOLVED_REPORT=1  Keep unresolved-report.json after
+#                                         successful local regression checks.
 
 set -euo pipefail
 
@@ -11,6 +15,30 @@ MODE="${1:-all}"
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 cd "$REPO_ROOT"
+
+UNRESOLVED_REPORT_PATH="packages/skribble/unresolved-report.json"
+BASELINE_SYNC_DIFF_PATH="rough-icons-baseline-sync.diff"
+GENERATED_SYNC_DIFF_PATH="rough-icons-generated-sync.diff"
+
+emit_sync_diff_if_needed() {
+  local diff_output_path="$1"
+  shift
+  local tracked_paths=("$@")
+
+  rm -f "$diff_output_path"
+
+  if git diff --quiet -- "${tracked_paths[@]}"; then
+    return 0
+  fi
+
+  echo "::group::Rough icon sync diff ($diff_output_path)"
+  git --no-pager diff -- "${tracked_paths[@]}"
+  echo "::endgroup::"
+
+  git --no-pager diff -- "${tracked_paths[@]}" > "$diff_output_path"
+  echo "Saved sync diff to $diff_output_path"
+  return 1
+}
 
 run_regression_check() {
   (
@@ -23,6 +51,10 @@ run_regression_check() {
       --unresolved-output unresolved-report.json \
       --fail-on-new-unresolved
   )
+
+  if [[ "${CI:-}" != "true" ]] && [[ "${ROUGH_ICONS_KEEP_UNRESOLVED_REPORT:-0}" != "1" ]]; then
+    rm -f "$UNRESOLVED_REPORT_PATH"
+  fi
 }
 
 run_baseline_sync_check() {
@@ -36,7 +68,10 @@ run_baseline_sync_check() {
   )
 
   dprint fmt packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
-  git diff --exit-code -- packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
+
+  emit_sync_diff_if_needed \
+    "$BASELINE_SYNC_DIFF_PATH" \
+    packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
 }
 
 run_generated_sync_check() {
@@ -51,7 +86,8 @@ run_generated_sync_check() {
       --font-dart-output lib/src/generated/material_rough_icon_font.g.dart
   )
 
-  git diff --exit-code -- \
+  emit_sync_diff_if_needed \
+    "$GENERATED_SYNC_DIFF_PATH" \
     packages/skribble/lib/src/generated/material_rough_icons.g.dart \
     packages/skribble/lib/src/generated/material_rough_icon_font.g.dart
 }


### PR DESCRIPTION
## Summary

Improve rough icon CI check-script ergonomics and reduce CI workflow duplication.

- Extend `scripts/check_rough_icons_ci.sh` so sync checks now:
  - print `git diff` output on failure
  - write failure diffs to:
    - `rough-icons-baseline-sync.diff`
    - `rough-icons-generated-sync.diff`
- Keep CI artifact uploads, but remove redundant "show diff" and "save diff"
  workflow steps from `.github/workflows/ci.yml` (the script now handles both).
- Make local `regression` checks cleaner by removing
  `packages/skribble/unresolved-report.json` on successful local runs by
  default.
  - opt-out via `ROUGH_ICONS_KEEP_UNRESOLVED_REPORT=1`
- Document the script behavior in:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Add changeset:
  - `.changeset/rough-icon-ci-script-sync-diffs.md`

## Validation

- `git diff --check`
- `dprint check .github/workflows/ci.yml docs/rough-icon-pipeline.md packages/skribble/README.md scripts/check_rough_icons_ci.sh .changeset/rough-icon-ci-script-sync-diffs.md`
- `bash -n scripts/check_rough_icons_ci.sh`
- `./scripts/check_rough_icons_ci.sh regression`
- `./scripts/check_rough_icons_ci.sh baseline-sync`
- `./scripts/check_rough_icons_ci.sh generated-sync`
