### PR TITLE
feat: accept codePoints unresolved baselines

### DIFF
--- a/.changeset/rough-icon-baseline-codepoints-format.md
+++ b/.changeset/rough-icon-baseline-codepoints-format.md
@@ -1,0 +1,11 @@
+---
+skribble: patch
+---
+
+Extend unresolved baseline parsing to accept a minimal `codePoints[]` format.
+
+- `--unresolved-baseline` now accepts JSON objects with a top-level
+  `codePoints` list (int or hex-string entries), in addition to existing
+  `unresolved[]` report and `icons[]` manifest formats.
+- Add parser coverage for the new baseline format.
+- Update rough icon docs/README and CLI usage text accordingly.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -160,10 +160,11 @@ To detect only regressions relative to an existing unresolved baseline:
 - `--unresolved-baseline <path>`
 - `--fail-on-new-unresolved`
 
-Baseline input supports either:
+Baseline input supports:
 
 - unresolved report JSON (`unresolved[]`)
 - supplemental manifest JSON (`icons[]`)
+- minimal baseline JSON (`codePoints[]`)
 
 This is useful in CI while tightening coverage incrementally.
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -242,7 +242,7 @@ Useful flags:
 - `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring.
 - `--unresolved-baseline-output <path>` to emit a normalized unresolved baseline (`unresolved[]` only) for regression gating.
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.
-- `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`) or manifest (`icons[]`), including `newUnresolved` and `resolvedSinceBaseline` report fields.
+- `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`), manifest (`icons[]`), or minimal baseline (`codePoints[]`), including `newUnresolved` and `resolvedSinceBaseline` report fields.
 - `--max-unresolved <int>` to allow a bounded unresolved count before failing.
 - `--fail-on-unresolved` to make the command exit non-zero if unresolved icons remain.
 - `--fail-on-new-unresolved` to fail only when unresolved entries regress versus baseline.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -1018,6 +1018,77 @@ class Icons {
       },
     );
 
+    test('accepts codePoints[] format as unresolved baseline', () async {
+      final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+        ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+      final materialIconsRoot = Directory('${tempDirectory.path}/material-icons')
+        ..createSync(recursive: true);
+      final materialSymbolsRoot = Directory(
+        '${tempDirectory.path}/material-symbols',
+      )..createSync(recursive: true);
+      final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+        ..createSync(recursive: true);
+
+      File('${materialIconsRoot.path}/filled/label.svg')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(
+          '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+        );
+
+      final baselineFile = File('${tempDirectory.path}/baseline-codepoints.json')
+        ..writeAsStringSync('''
+{
+  "codePoints": [
+    "0xf04b9"
+  ]
+}
+''');
+      final unresolvedReportFile = File(
+        '${tempDirectory.path}/unresolved_report.json',
+      );
+      final outputFile = File(
+        '${tempDirectory.path}/material_rough_icons.g.dart',
+      );
+
+      await tool.runGenerateRoughIcons(<String>[
+        '--kit',
+        'flutter-material',
+        '--flutter-icons',
+        flutterIconsFile.path,
+        '--material-icons-source',
+        materialIconsRoot.path,
+        '--material-symbols-source',
+        materialSymbolsRoot.path,
+        '--brand-icons-source',
+        brandIconsRoot.path,
+        '--unresolved-baseline',
+        baselineFile.path,
+        '--fail-on-new-unresolved',
+        '--unresolved-output',
+        unresolvedReportFile.path,
+        '--output',
+        outputFile.path,
+      ]);
+
+      final decoded =
+          jsonDecode(unresolvedReportFile.readAsStringSync())
+              as Map<String, dynamic>;
+      expect(decoded['baselineUnresolvedCount'], 1);
+      expect(decoded['newUnresolvedCount'], 0);
+      expect(decoded['newUnresolved'], <dynamic>[]);
+      expect(decoded['resolvedSinceBaselineCount'], 0);
+      expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
+    });
+
     test(
       'reports resolvedSinceBaseline when baseline entries are now resolved',
       () async {

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -294,7 +294,7 @@ Options:
                                    Emit normalized unresolved baseline JSON.
   --supplemental-manifest-output <path>
                                    Emit supplemental manifest template JSON.
-  --unresolved-baseline <path>     Baseline unresolved report or manifest JSON for diffing.
+  --unresolved-baseline <path>     Baseline unresolved report/manifest/codePoints JSON for diffing.
   --max-unresolved <int>           Max unresolved icons allowed before failing.
   --fail-on-unresolved             Exit with error when unresolved icons remain.
   --fail-on-new-unresolved         Exit with error on unresolved baseline regressions.
@@ -1426,16 +1426,20 @@ Set<int>? _loadUnresolvedBaselineCodePoints(String? baselinePath) {
   } else if (decoded is Map<String, Object?>) {
     final unresolvedValue = decoded['unresolved'];
     final iconsValue = decoded['icons'];
+    final codePointsValue = decoded['codePoints'];
 
     if (unresolvedValue is List<Object?>) {
       entries = unresolvedValue;
     } else if (iconsValue is List<Object?>) {
       entries = iconsValue;
+    } else if (codePointsValue is List<Object?>) {
+      entries = codePointsValue;
     } else {
       throw FormatException(
         'Expected unresolved baseline JSON to contain either an '
-        '"unresolved" list (report format) or "icons" list '
-        '(manifest format) at ${baselineFile.path}.',
+        '"unresolved" list (report format), "icons" list '
+        '(manifest format), or "codePoints" list '
+        '(minimal baseline format) at ${baselineFile.path}.',
       );
     }
   } else {


### PR DESCRIPTION
## Summary

Extend unresolved baseline parsing to support a minimal `codePoints[]` format.

- `--unresolved-baseline` now accepts baseline JSON objects with:
  - `unresolved[]` (existing report format)
  - `icons[]` (existing manifest format)
  - `codePoints[]` (new minimal baseline format)
- Update CLI usage text in generator help.
- Add parser coverage in:
  - `packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart`
- Update docs:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Add changeset:
  - `.changeset/rough-icon-baseline-codepoints-format.md`

## Validation

- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart packages/skribble/tool/generate_material_rough_icons.dart .changeset/rough-icon-baseline-codepoints-format.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
