### PR TITLE
feat: support bare and U+ codePoint strings

### DIFF
--- a/.changeset/rough-icon-codepoint-string-formats.md
+++ b/.changeset/rough-icon-codepoint-string-formats.md
@@ -1,0 +1,13 @@
+---
+skribble: patch
+---
+
+Improve rough icon codepoint parsing ergonomics for manifests and baselines.
+
+- `codePoint` parsing now accepts additional string forms:
+  - bare hex (for example `"e001"`)
+  - `U+`-prefixed hex (for example `"U+E001"`)
+  - existing decimal and `0x`-prefixed formats remain supported
+- `--unresolved-baseline` benefits from the same parsing support.
+- Add parser tests for manifest and baseline codepoint string variants.
+- Update rough icon pipeline docs/README with accepted `codePoint` formats.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -54,7 +54,7 @@ Manifest supports either a top-level list or `{ "icons": [...] }`, where each
 entry includes:
 
 - `identifier` (string, must be unique)
-- `codePoint` (int or hex string like `"0xe001"`, must be unique)
+- `codePoint` (int, decimal string, or hex string like `"0xe001"`, `"e001"`, `"U+E001"`; must be unique)
 - `svgPath` (preferred) or `svg`/`path` alias
 
 Example:
@@ -165,6 +165,9 @@ Baseline input supports:
 - unresolved report JSON (`unresolved[]`)
 - supplemental manifest JSON (`icons[]`)
 - minimal baseline JSON (`codePoints[]`)
+
+When code points are provided as strings, decimal, `0x`-prefixed hex, bare
+hex, and `U+`-prefixed hex forms are accepted.
 
 This is useful in CI while tightening coverage incrementally.
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -234,7 +234,7 @@ those sync checks fail.
 Useful flags:
 
 - `--list-kits` to print available icon-kit providers.
-- `--kit svg-manifest --manifest <path>` to rough non-Material icon sets from JSON manifests (unique `identifier`/`codePoint` required).
+- `--kit svg-manifest --manifest <path>` to rough non-Material icon sets from JSON manifests (unique `identifier`/`codePoint` required; `codePoint` supports int, decimal string, `0x` hex, bare hex, and `U+` hex forms).
 - `--rough-only` to skip Dart map generation and emit rough SVGs only.
 - `--rough-normalize-viewbox 128` to upscale SVG geometry before roughing.
 - `--brand-icons-source <path>` to provide a local `simple-icons` package as fallback for brand identifiers missing in Material SVG packages.
@@ -242,7 +242,7 @@ Useful flags:
 - `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring.
 - `--unresolved-baseline-output <path>` to emit a normalized unresolved baseline (`unresolved[]` only) for regression gating.
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.
-- `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`), manifest (`icons[]`), or minimal baseline (`codePoints[]`), including `newUnresolved` and `resolvedSinceBaseline` report fields.
+- `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`), manifest (`icons[]`), or minimal baseline (`codePoints[]`), including `newUnresolved` and `resolvedSinceBaseline` report fields. String code points accept decimal, `0x` hex, bare hex, and `U+` hex forms.
 - `--max-unresolved <int>` to allow a bounded unresolved count before failing.
 - `--fail-on-unresolved` to make the command exit non-zero if unresolved icons remain.
 - `--fail-on-new-unresolved` to fail only when unresolved entries regress versus baseline.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -1048,7 +1048,7 @@ class Icons {
         ..writeAsStringSync('''
 {
   "codePoints": [
-    "0xf04b9"
+    "f04b9"
   ]
 }
 ''');
@@ -1317,6 +1317,42 @@ class Icons {
       expect(parsed.single.identifier, 'heart');
       expect(parsed.single.codePoint, 0xe001);
       expect(parsed.single.svgPath, heartSvgFile.path);
+    });
+
+    test('parses bare-hex and U+ codePoint string formats', () {
+      final alphaSvgFile = File('${tempDirectory.path}/alpha.svg')
+        ..writeAsStringSync(
+          '<svg viewBox="0 0 24 24"><path d="M2 2h20v20H2z"/></svg>',
+        );
+      final betaSvgFile = File('${tempDirectory.path}/beta.svg')
+        ..writeAsStringSync(
+          '<svg viewBox="0 0 24 24"><path d="M3 3h18v18H3z"/></svg>',
+        );
+
+      final parsed = tool.parseSvgManifestDeclarationsForTest('''
+{
+  "icons": [
+    {
+      "identifier": "alpha",
+      "codePoint": "e001",
+      "svgPath": "alpha.svg"
+    },
+    {
+      "identifier": "beta",
+      "codePoint": "U+E002",
+      "svgPath": "beta.svg"
+    }
+  ]
+}
+''', manifestDirectoryPath: tempDirectory.path);
+
+      expect(parsed, hasLength(2));
+      expect(parsed[0].identifier, 'alpha');
+      expect(parsed[0].codePoint, 0xe001);
+      expect(parsed[0].svgPath, alphaSvgFile.path);
+      expect(parsed[1].identifier, 'beta');
+      expect(parsed[1].codePoint, 0xe002);
+      expect(parsed[1].svgPath, betaSvgFile.path);
     });
 
     test('parses list format and supports svg alias key', () {

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -906,20 +906,9 @@ _ManifestIconEntry _parseManifestIconEntry(
 }
 
 int _parseManifestCodePoint(Object? value, String identifier) {
-  if (value is int) {
-    return value;
-  }
-
-  if (value is String) {
-    final normalized = value.trim().toLowerCase();
-    if (normalized.startsWith('0x')) {
-      return int.parse(normalized.substring(2), radix: 16);
-    }
-    return int.parse(normalized);
-  }
-
-  throw FormatException(
-    'Manifest entry "$identifier" must define codePoint as int or string.',
+  return _parseCodePointValue(
+    value,
+    context: 'manifest entry "$identifier"',
   );
 }
 
@@ -1475,16 +1464,64 @@ int _parseCodePointValue(Object? value, {required String context}) {
   }
 
   if (value is String) {
-    final normalized = value.trim().toLowerCase();
-    if (normalized.startsWith('0x')) {
-      return int.parse(normalized.substring(2), radix: 16);
-    }
-    return int.parse(normalized);
+    return _parseCodePointString(value, context: context);
   }
 
   throw FormatException(
     'Invalid codePoint in $context. Expected int or string, got $value.',
   );
+}
+
+int _parseCodePointString(String value, {required String context}) {
+  final normalized = value.trim().toLowerCase();
+  if (normalized.isEmpty) {
+    throw FormatException(
+      'Invalid codePoint in $context. Expected decimal, 0x-prefixed hex, '
+      'U+-prefixed hex, or bare hex string, got "$value".',
+    );
+  }
+
+  final decimalPattern = RegExp(r'^\d+$');
+  final bareHexPattern = RegExp(r'^[0-9a-f]+$');
+
+  String digits;
+  var radix = 10;
+  if (normalized.startsWith('0x')) {
+    digits = normalized.substring(2);
+    radix = 16;
+  } else if (normalized.startsWith('u+')) {
+    digits = normalized.substring(2);
+    radix = 16;
+  } else if (normalized.startsWith(r'\u')) {
+    digits = normalized.substring(2);
+    radix = 16;
+  } else if (decimalPattern.hasMatch(normalized)) {
+    digits = normalized;
+  } else if (bareHexPattern.hasMatch(normalized)) {
+    digits = normalized;
+    radix = 16;
+  } else {
+    throw FormatException(
+      'Invalid codePoint in $context. Expected decimal, 0x-prefixed hex, '
+      'U+-prefixed hex, or bare hex string, got "$value".',
+    );
+  }
+
+  if (digits.isEmpty) {
+    throw FormatException(
+      'Invalid codePoint in $context. Expected decimal, 0x-prefixed hex, '
+      'U+-prefixed hex, or bare hex string, got "$value".',
+    );
+  }
+
+  try {
+    return int.parse(digits, radix: radix);
+  } on FormatException {
+    throw FormatException(
+      'Invalid codePoint in $context. Expected decimal, 0x-prefixed hex, '
+      'U+-prefixed hex, or bare hex string, got "$value".',
+    );
+  }
 }
 
 String _renderUnresolvedReportJson({


### PR DESCRIPTION
## Summary

Improve rough icon `codePoint` parsing ergonomics for manifests and baselines.

- Extend `codePoint` string parsing to accept:
  - bare hex (e.g. `"e001"`)
  - `U+`-prefixed hex (e.g. `"U+E001"`)
  - existing decimal and `0x`-prefixed forms remain supported
- Reuse the same parser for:
  - `svg-manifest` `codePoint`
  - `--unresolved-baseline` inputs (`unresolved[]`, `icons[]`, `codePoints[]`)
- Add test coverage:
  - manifest parser accepts bare-hex and `U+` strings
  - baseline `codePoints[]` test uses bare-hex format
- Update docs:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Add changeset:
  - `.changeset/rough-icon-codepoint-string-formats.md`

## Validation

- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart packages/skribble/tool/generate_material_rough_icons.dart .changeset/rough-icon-codepoint-string-formats.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
