### PR TITLE
feat: add codepoints baseline output format

### DIFF
--- a/.changeset/rough-icon-baseline-output-codepoints-format.md
+++ b/.changeset/rough-icon-baseline-output-codepoints-format.md
@@ -1,0 +1,12 @@
+---
+skribble: patch
+---
+
+Add configurable unresolved baseline output format for rough icon tooling.
+
+- New flag: `--unresolved-baseline-output-format <unresolved|codepoints>`.
+- `--unresolved-baseline-output` defaults to existing `unresolved[]` shape.
+- `codepoints` format emits a minimal top-level `codePoints[]` list.
+- Add validation for unsupported formats and for using custom format without
+  `--unresolved-baseline-output`.
+- Add parser tests and docs/README updates for the new output format.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -131,12 +131,16 @@ The JSON report includes:
 
 ## Normalized unresolved baseline output
 
-To emit a minimal baseline file dedicated to regression checks, pass:
+To emit a baseline file dedicated to regression checks, pass:
 
 - `--unresolved-baseline-output <path>`
 
-This output intentionally contains only an `unresolved[]` list so baseline
+By default, this output contains only an `unresolved[]` list so baseline
 updates are smaller and avoid churn in unrelated report metadata.
+
+To emit an even smaller baseline with only codepoint strings, pass:
+
+- `--unresolved-baseline-output-format codepoints`
 
 ## Supplemental manifest template output
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -240,7 +240,8 @@ Useful flags:
 - `--brand-icons-source <path>` to provide a local `simple-icons` package as fallback for brand identifiers missing in Material SVG packages.
 - `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints (workspace defaults use `tool/examples/material_rough_icons.supplemental.manifest.json`).
 - `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring.
-- `--unresolved-baseline-output <path>` to emit a normalized unresolved baseline (`unresolved[]` only) for regression gating.
+- `--unresolved-baseline-output <path>` to emit a normalized unresolved baseline for regression gating (defaults to `unresolved[]`).
+- `--unresolved-baseline-output-format <unresolved|codepoints>` to choose unresolved baseline output shape (`unresolved[]` or `codePoints[]`).
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.
 - `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`), manifest (`icons[]`), or minimal baseline (`codePoints[]`), including `newUnresolved` and `resolvedSinceBaseline` report fields. String code points accept decimal, `0x` hex, bare hex, and `U+` hex forms.
 - `--max-unresolved <int>` to allow a bounded unresolved count before failing.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -564,6 +564,90 @@ class Icons {
       expect(secondUnresolved['codePoint'], '0xf04b9');
       expect(secondUnresolved['identifiers'], <String>['adobe']);
     });
+
+    test('writes codePoints baseline JSON when requested', () async {
+      final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+        ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "face unlock" (sharp).
+  static const IconData face_unlock_sharp = IconData(0xe951, fontFamily: 'MaterialIcons');
+}
+''');
+
+      final materialIconsRoot = Directory(
+        '${tempDirectory.path}/material-icons',
+      )..createSync(recursive: true);
+      final materialSymbolsRoot = Directory(
+        '${tempDirectory.path}/material-symbols',
+      )..createSync(recursive: true);
+      final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+        ..createSync(recursive: true);
+
+      final outputFile = File(
+        '${tempDirectory.path}/material_rough_icons.g.dart',
+      );
+      final unresolvedBaselineFile = File(
+        '${tempDirectory.path}/unresolved-baseline-codepoints.json',
+      );
+
+      await tool.runGenerateRoughIcons(<String>[
+        '--kit',
+        'flutter-material',
+        '--flutter-icons',
+        flutterIconsFile.path,
+        '--material-icons-source',
+        materialIconsRoot.path,
+        '--material-symbols-source',
+        materialSymbolsRoot.path,
+        '--brand-icons-source',
+        brandIconsRoot.path,
+        '--unresolved-baseline-output',
+        unresolvedBaselineFile.path,
+        '--unresolved-baseline-output-format',
+        'codepoints',
+        '--output',
+        outputFile.path,
+      ]);
+
+      expect(unresolvedBaselineFile.existsSync(), isTrue);
+
+      final decoded =
+          jsonDecode(unresolvedBaselineFile.readAsStringSync())
+              as Map<String, dynamic>;
+      expect(decoded.containsKey('codePoints'), isTrue);
+      expect(decoded.containsKey('unresolved'), isFalse);
+
+      final codePoints = decoded['codePoints'] as List<dynamic>;
+      expect(codePoints, <String>['0xe951', '0xf04b9']);
+    });
+
+    test(
+      'requires baseline output path when output format is customized',
+      () async {
+        await expectLater(
+          tool.runGenerateRoughIcons(<String>[
+            '--unresolved-baseline-output-format',
+            'codepoints',
+          ]),
+          throwsA(isA<ArgumentError>()),
+        );
+      },
+    );
+
+    test('rejects unknown unresolved baseline output format', () async {
+      await expectLater(
+        tool.runGenerateRoughIcons(<String>[
+          '--unresolved-baseline-output',
+          '${tempDirectory.path}/unresolved-baseline.json',
+          '--unresolved-baseline-output-format',
+          'invalid-format',
+        ]),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
   });
 
   group('runGenerateRoughIcons supplemental manifest template output', () {

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -16,6 +16,12 @@ const _kDefaultFontGeneratorExecutable = 'npx';
 const _kDefaultFontGeneratorPackage = 'fantasticon';
 const _kDefaultBrandIconsPackage = 'simple-icons';
 const _kDefaultFontName = 'material_rough_icons';
+const _kUnresolvedBaselineOutputFormatUnresolved = 'unresolved';
+const _kUnresolvedBaselineOutputFormatCodePoints = 'codepoints';
+const _kUnresolvedBaselineOutputFormats = <String>{
+  _kUnresolvedBaselineOutputFormatUnresolved,
+  _kUnresolvedBaselineOutputFormatCodePoints,
+};
 const _kSupportedKitDescriptions = <String, String>{
   _kDefaultKit:
       'Flutter Material Icons (from Flutter icons.dart + Material SVG packages)',
@@ -183,9 +189,19 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
       case final unresolvedBaselineOutputPath?) {
     final unresolvedBaselineOutputFile = File(unresolvedBaselineOutputPath)
       ..createSync(recursive: true);
-    unresolvedBaselineOutputFile.writeAsStringSync(
-      _renderUnresolvedBaselineJson(unresolved: unresolved),
-    );
+    final unresolvedBaselineJson = switch (
+      options.unresolvedBaselineOutputFormat
+    ) {
+      _kUnresolvedBaselineOutputFormatUnresolved =>
+        _renderUnresolvedBaselineJson(unresolved: unresolved),
+      _kUnresolvedBaselineOutputFormatCodePoints =>
+        _renderUnresolvedBaselineCodePointsJson(unresolved: unresolved),
+      _ => throw StateError(
+        'Unsupported unresolved baseline output format: '
+        '${options.unresolvedBaselineOutputFormat}',
+      ),
+    };
+    unresolvedBaselineOutputFile.writeAsStringSync(unresolvedBaselineJson);
     stdout.writeln(
       'Generated unresolved baseline JSON to '
       '${unresolvedBaselineOutputFile.path}',
@@ -292,6 +308,8 @@ Options:
   --unresolved-output <path>       Emit unresolved icon codepoint report as JSON.
   --unresolved-baseline-output <path>
                                    Emit normalized unresolved baseline JSON.
+  --unresolved-baseline-output-format <unresolved|codepoints>
+                                   Baseline JSON shape for --unresolved-baseline-output (default: unresolved).
   --supplemental-manifest-output <path>
                                    Emit supplemental manifest template JSON.
   --unresolved-baseline <path>     Baseline unresolved report/manifest/codePoints JSON for diffing.
@@ -347,6 +365,8 @@ final class _ScriptOptions {
     this.supplementalManifestPath,
     this.unresolvedOutputPath,
     this.unresolvedBaselineOutputPath,
+    this.unresolvedBaselineOutputFormat =
+        _kUnresolvedBaselineOutputFormatUnresolved,
     this.supplementalManifestOutputPath,
     this.unresolvedBaselinePath,
     this.maxUnresolved,
@@ -378,6 +398,7 @@ final class _ScriptOptions {
   final String? supplementalManifestPath;
   final String? unresolvedOutputPath;
   final String? unresolvedBaselineOutputPath;
+  final String unresolvedBaselineOutputFormat;
   final String? supplementalManifestOutputPath;
   final String? unresolvedBaselinePath;
   final int? maxUnresolved;
@@ -409,6 +430,8 @@ final class _ScriptOptions {
     String? supplementalManifestPath;
     String? unresolvedOutputPath;
     String? unresolvedBaselineOutputPath;
+    var unresolvedBaselineOutputFormat =
+        _kUnresolvedBaselineOutputFormatUnresolved;
     String? supplementalManifestOutputPath;
     String? unresolvedBaselinePath;
     int? maxUnresolved;
@@ -493,6 +516,8 @@ final class _ScriptOptions {
           unresolvedOutputPath = value;
         case '--unresolved-baseline-output':
           unresolvedBaselineOutputPath = value;
+        case '--unresolved-baseline-output-format':
+          unresolvedBaselineOutputFormat = value.toLowerCase();
         case '--supplemental-manifest-output':
           supplementalManifestOutputPath = value;
         case '--unresolved-baseline':
@@ -529,6 +554,22 @@ final class _ScriptOptions {
     if (maxUnresolved != null && maxUnresolved < 0) {
       throw ArgumentError('--max-unresolved must be >= 0.');
     }
+    if (!_kUnresolvedBaselineOutputFormats.contains(
+      unresolvedBaselineOutputFormat,
+    )) {
+      throw ArgumentError(
+        '--unresolved-baseline-output-format must be one of: '
+        '${_kUnresolvedBaselineOutputFormats.join(', ')}.',
+      );
+    }
+    if (unresolvedBaselineOutputPath == null &&
+        unresolvedBaselineOutputFormat !=
+            _kUnresolvedBaselineOutputFormatUnresolved) {
+      throw ArgumentError(
+        '--unresolved-baseline-output-format requires '
+        '--unresolved-baseline-output.',
+      );
+    }
     if (failOnNewUnresolved && unresolvedBaselinePath == null) {
       throw ArgumentError(
         '--fail-on-new-unresolved requires --unresolved-baseline.',
@@ -545,6 +586,7 @@ final class _ScriptOptions {
       supplementalManifestPath: supplementalManifestPath,
       unresolvedOutputPath: unresolvedOutputPath,
       unresolvedBaselineOutputPath: unresolvedBaselineOutputPath,
+      unresolvedBaselineOutputFormat: unresolvedBaselineOutputFormat,
       supplementalManifestOutputPath: supplementalManifestOutputPath,
       unresolvedBaselinePath: unresolvedBaselinePath,
       maxUnresolved: maxUnresolved,
@@ -1581,6 +1623,24 @@ String _renderUnresolvedBaselineJson({
   final baseline = <String, Object>{
     'unresolved': sortedUnresolved
         .map(_unresolvedIconJson)
+        .toList(growable: false),
+  };
+
+  return const JsonEncoder.withIndent('  ').convert(baseline);
+}
+
+String _renderUnresolvedBaselineCodePointsJson({
+  required List<_UnresolvedIcon> unresolved,
+}) {
+  final sortedCodePoints = unresolved
+      .map((item) => item.codePoint)
+      .toSet()
+      .toList(growable: false)
+    ..sort();
+
+  final baseline = <String, Object>{
+    'codePoints': sortedCodePoints
+        .map((codePoint) => '0x${codePoint.toRadixString(16)}')
         .toList(growable: false),
   };
 


### PR DESCRIPTION
## Summary

Add configurable unresolved baseline output format for rough icon tooling.

- New flag:
  - `--unresolved-baseline-output-format <unresolved|codepoints>`
- `--unresolved-baseline-output` keeps current default behavior (`unresolved[]`).
- New `codepoints` format emits minimal baseline JSON with top-level
  `codePoints[]`.
- Add argument validation:
  - reject unknown `--unresolved-baseline-output-format` values
  - require `--unresolved-baseline-output` when custom output format is used
- Add parser test coverage:
  - writes `codePoints[]` baseline output
  - validation tests for format flags
- Update docs:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Add changeset:
  - `.changeset/rough-icon-baseline-output-codepoints-format.md`

## Validation

- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart packages/skribble/tool/generate_material_rough_icons.dart .changeset/rough-icon-baseline-output-codepoints-format.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
