### PR TITLE
chore: default rough baseline sync to codepoints

### DIFF
--- a/.changeset/rough-icon-baseline-codepoints-default.md
+++ b/.changeset/rough-icon-baseline-codepoints-default.md
@@ -1,0 +1,14 @@
+---
+skribble: patch
+---
+
+Switch rough icon baseline sync defaults to `codePoints[]` baseline output.
+
+- `melos run rough-icons-baseline` now writes baseline JSON using
+  `--unresolved-baseline-output-format codepoints`.
+- CI/local baseline sync script (`scripts/check_rough_icons_ci.sh`) now uses the
+  same `codepoints` baseline output format.
+- Update committed baseline file
+  `packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`
+  to `codePoints[]` shape.
+- Update rough icon docs/README to note the committed baseline format.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -142,6 +142,8 @@ To emit an even smaller baseline with only codepoint strings, pass:
 
 - `--unresolved-baseline-output-format codepoints`
 
+This repo’s committed baseline uses this `codePoints[]` output format.
+
 ## Supplemental manifest template output
 
 To emit a starter supplemental manifest for unresolved icons, pass:
@@ -223,7 +225,8 @@ date by regenerating:
 On generated-sync failures, CI uploads a
 `rough-icons-generated-sync-diff` artifact with catalog diffs.
 
-To refresh that normalized baseline after intentional coverage changes:
+To refresh the committed `codePoints[]` baseline after intentional coverage
+changes:
 
 ```bash
 melos run rough-icons-baseline

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -205,7 +205,7 @@ manifest (`tool/examples/material_rough_icons.supplemental.manifest.json`) and
 enforce unresolved regression gating via
 `--unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json`
 plus `--fail-on-new-unresolved`. Use `rough-icons-baseline` to refresh that
-normalized baseline file after intentional changes.
+committed `codePoints[]` baseline file after intentional changes.
 
 `rough-icons-ci-check` runs the same rough icon regression/sync checks enforced
 by CI via `./scripts/check_rough_icons_ci.sh all`.
@@ -241,7 +241,7 @@ Useful flags:
 - `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints (workspace defaults use `tool/examples/material_rough_icons.supplemental.manifest.json`).
 - `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring.
 - `--unresolved-baseline-output <path>` to emit a normalized unresolved baseline for regression gating (defaults to `unresolved[]`).
-- `--unresolved-baseline-output-format <unresolved|codepoints>` to choose unresolved baseline output shape (`unresolved[]` or `codePoints[]`).
+- `--unresolved-baseline-output-format <unresolved|codepoints>` to choose unresolved baseline output shape (`unresolved[]` or `codePoints[]`; workspace defaults use `codepoints`).
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.
 - `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`), manifest (`icons[]`), or minimal baseline (`codePoints[]`), including `newUnresolved` and `resolvedSinceBaseline` report fields. String code points accept decimal, `0x` hex, bare hex, and `U+` hex forms.
 - `--max-unresolved <int>` to allow a bounded unresolved count before failing.

--- a/packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
+++ b/packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json
@@ -1,3 +1,3 @@
 {
-  "unresolved": []
+  "codePoints": []
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,6 +80,7 @@ melos:
         --rough-only
         --supplemental-manifest tool/examples/material_rough_icons.supplemental.manifest.json
         --unresolved-baseline-output tool/examples/material_rough_icons.unresolved-baseline.json
+        --unresolved-baseline-output-format codepoints
 
     rough-icons-ci-check:
       description: Run the same rough icon regression/sync checks enforced by CI.

--- a/scripts/check_rough_icons_ci.sh
+++ b/scripts/check_rough_icons_ci.sh
@@ -64,7 +64,8 @@ run_baseline_sync_check() {
       --kit flutter-material \
       --rough-only \
       --supplemental-manifest tool/examples/material_rough_icons.supplemental.manifest.json \
-      --unresolved-baseline-output tool/examples/material_rough_icons.unresolved-baseline.json
+      --unresolved-baseline-output tool/examples/material_rough_icons.unresolved-baseline.json \
+      --unresolved-baseline-output-format codepoints
   )
 
   dprint fmt packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json


### PR DESCRIPTION
## Summary

Adopt `codePoints[]` as the committed baseline sync format for rough icon regression checks.

- Update workspace baseline script (`melos run rough-icons-baseline`) to use:
  - `--unresolved-baseline-output-format codepoints`
- Update CI/local baseline sync script (`scripts/check_rough_icons_ci.sh`) to
  generate the same `codePoints[]` baseline format.
- Migrate committed baseline file:
  - `packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`
  - from `unresolved[]` to `codePoints[]`
- Update docs:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- Add changeset:
  - `.changeset/rough-icon-baseline-codepoints-default.md`

## Validation

- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json pubspec.yaml scripts/check_rough_icons_ci.sh .changeset/rough-icon-baseline-codepoints-default.md`
- `bash -n scripts/check_rough_icons_ci.sh`
- `./scripts/check_rough_icons_ci.sh baseline-sync`
