### PR TITLE
feat: accept lowercase codepoints baseline key

### DIFF
--- a/.changeset/rough-icon-baseline-codepoints-key-alias.md
+++ b/.changeset/rough-icon-baseline-codepoints-key-alias.md
@@ -1,0 +1,11 @@
+---
+skribble: patch
+---
+
+Improve unresolved baseline parser compatibility for minimal baseline objects.
+
+- `--unresolved-baseline` now accepts either `codePoints[]` or `codepoints[]`
+  keys when loading minimal baseline JSON objects.
+- Add parser coverage for lowercase `codepoints[]` baseline input.
+- Update rough icon docs/README and CLI help text to document the accepted key
+  alias.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -170,7 +170,7 @@ Baseline input supports:
 
 - unresolved report JSON (`unresolved[]`)
 - supplemental manifest JSON (`icons[]`)
-- minimal baseline JSON (`codePoints[]`)
+- minimal baseline JSON (`codePoints[]`, also accepts `codepoints[]`)
 
 When code points are provided as strings, decimal, `0x`-prefixed hex, bare
 hex, and `U+`-prefixed hex forms are accepted.

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -243,7 +243,7 @@ Useful flags:
 - `--unresolved-baseline-output <path>` to emit a normalized unresolved baseline for regression gating (defaults to `unresolved[]`).
 - `--unresolved-baseline-output-format <unresolved|codepoints>` to choose unresolved baseline output shape (`unresolved[]` or `codePoints[]`; workspace defaults use `codepoints`).
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.
-- `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`), manifest (`icons[]`), or minimal baseline (`codePoints[]`), including `newUnresolved` and `resolvedSinceBaseline` report fields. String code points accept decimal, `0x` hex, bare hex, and `U+` hex forms.
+- `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`), manifest (`icons[]`), or minimal baseline (`codePoints[]`, also accepts `codepoints[]`), including `newUnresolved` and `resolvedSinceBaseline` report fields. String code points accept decimal, `0x` hex, bare hex, and `U+` hex forms.
 - `--max-unresolved <int>` to allow a bounded unresolved count before failing.
 - `--fail-on-unresolved` to make the command exit non-zero if unresolved icons remain.
 - `--fail-on-new-unresolved` to fail only when unresolved entries regress versus baseline.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -1173,6 +1173,79 @@ class Icons {
       expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
     });
 
+    test('accepts lowercase codepoints[] format as unresolved baseline', () async {
+      final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+        ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+      final materialIconsRoot = Directory('${tempDirectory.path}/material-icons')
+        ..createSync(recursive: true);
+      final materialSymbolsRoot = Directory(
+        '${tempDirectory.path}/material-symbols',
+      )..createSync(recursive: true);
+      final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+        ..createSync(recursive: true);
+
+      File('${materialIconsRoot.path}/filled/label.svg')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(
+          '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+        );
+
+      final baselineFile = File(
+        '${tempDirectory.path}/baseline-codepoints-lowercase.json',
+      )
+        ..writeAsStringSync('''
+{
+  "codepoints": [
+    "f04b9"
+  ]
+}
+''');
+      final unresolvedReportFile = File(
+        '${tempDirectory.path}/unresolved_report.json',
+      );
+      final outputFile = File(
+        '${tempDirectory.path}/material_rough_icons.g.dart',
+      );
+
+      await tool.runGenerateRoughIcons(<String>[
+        '--kit',
+        'flutter-material',
+        '--flutter-icons',
+        flutterIconsFile.path,
+        '--material-icons-source',
+        materialIconsRoot.path,
+        '--material-symbols-source',
+        materialSymbolsRoot.path,
+        '--brand-icons-source',
+        brandIconsRoot.path,
+        '--unresolved-baseline',
+        baselineFile.path,
+        '--fail-on-new-unresolved',
+        '--unresolved-output',
+        unresolvedReportFile.path,
+        '--output',
+        outputFile.path,
+      ]);
+
+      final decoded =
+          jsonDecode(unresolvedReportFile.readAsStringSync())
+              as Map<String, dynamic>;
+      expect(decoded['baselineUnresolvedCount'], 1);
+      expect(decoded['newUnresolvedCount'], 0);
+      expect(decoded['newUnresolved'], <dynamic>[]);
+      expect(decoded['resolvedSinceBaselineCount'], 0);
+      expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
+    });
+
     test(
       'reports resolvedSinceBaseline when baseline entries are now resolved',
       () async {

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -313,6 +313,7 @@ Options:
   --supplemental-manifest-output <path>
                                    Emit supplemental manifest template JSON.
   --unresolved-baseline <path>     Baseline unresolved report/manifest/codePoints JSON for diffing.
+                                   Accepts codePoints/codepoints key for minimal baseline objects.
   --max-unresolved <int>           Max unresolved icons allowed before failing.
   --fail-on-unresolved             Exit with error when unresolved icons remain.
   --fail-on-new-unresolved         Exit with error on unresolved baseline regressions.
@@ -1458,6 +1459,7 @@ Set<int>? _loadUnresolvedBaselineCodePoints(String? baselinePath) {
     final unresolvedValue = decoded['unresolved'];
     final iconsValue = decoded['icons'];
     final codePointsValue = decoded['codePoints'];
+    final codepointsValue = decoded['codepoints'];
 
     if (unresolvedValue is List<Object?>) {
       entries = unresolvedValue;
@@ -1465,11 +1467,13 @@ Set<int>? _loadUnresolvedBaselineCodePoints(String? baselinePath) {
       entries = iconsValue;
     } else if (codePointsValue is List<Object?>) {
       entries = codePointsValue;
+    } else if (codepointsValue is List<Object?>) {
+      entries = codepointsValue;
     } else {
       throw FormatException(
         'Expected unresolved baseline JSON to contain either an '
         '"unresolved" list (report format), "icons" list '
-        '(manifest format), or "codePoints" list '
+        '(manifest format), or "codePoints"/"codepoints" list '
         '(minimal baseline format) at ${baselineFile.path}.',
       );
     }


### PR DESCRIPTION
## Summary

Improve unresolved baseline parser compatibility for minimal baseline objects.

- `--unresolved-baseline` now accepts either key for minimal baseline objects:
  - `codePoints[]`
  - `codepoints[]` (lowercase alias)
- Add parser test coverage for lowercase `codepoints[]` baseline input.
- Update rough icon docs/README and CLI usage help to document accepted key
  alias.
- Add changeset:
  - `.changeset/rough-icon-baseline-codepoints-key-alias.md`

## Validation

- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart packages/skribble/tool/generate_material_rough_icons.dart .changeset/rough-icon-baseline-codepoints-key-alias.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
