### PR TITLE
feat: add unresolved report codepoint summaries

### DIFF
--- a/.changeset/rough-icon-unresolved-report-codepoint-summaries.md
+++ b/.changeset/rough-icon-unresolved-report-codepoint-summaries.md
@@ -1,0 +1,12 @@
+---
+skribble: patch
+---
+
+Enhance unresolved rough icon report JSON with codepoint summary arrays.
+
+- `--unresolved-output` now includes `unresolvedCodePoints[]` (hex strings)
+  alongside existing `unresolved[]` entries.
+- When baseline comparison is enabled, reports now include
+  `newUnresolvedCodePoints[]` in addition to `newUnresolved[]`.
+- Add parser test coverage for the new summary fields.
+- Update rough icon docs/README to document the report payload additions.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -125,8 +125,10 @@ The JSON report includes:
 - `resolvedCount`
 - `unresolvedCount`
 - `unresolved[]` entries with `codePoint` and `identifiers`
+- `unresolvedCodePoints[]` summary list (hex strings)
 - optional `baselineUnresolvedCount`
 - optional `newUnresolvedCount` / `newUnresolved[]` when baseline comparison is enabled
+- optional `newUnresolvedCodePoints[]` summary list (hex strings)
 - optional `resolvedSinceBaselineCount` / `resolvedSinceBaseline[]` (codepoint strings)
 
 ## Normalized unresolved baseline output

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -239,7 +239,7 @@ Useful flags:
 - `--rough-normalize-viewbox 128` to upscale SVG geometry before roughing.
 - `--brand-icons-source <path>` to provide a local `simple-icons` package as fallback for brand identifiers missing in Material SVG packages.
 - `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints (workspace defaults use `tool/examples/material_rough_icons.supplemental.manifest.json`).
-- `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring.
+- `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring (includes `unresolved[]` plus `unresolvedCodePoints[]`, and baseline-diff summary arrays when enabled).
 - `--unresolved-baseline-output <path>` to emit a normalized unresolved baseline for regression gating (defaults to `unresolved[]`).
 - `--unresolved-baseline-output-format <unresolved|codepoints>` to choose unresolved baseline output shape (`unresolved[]` or `codePoints[]`; workspace defaults use `codepoints`).
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -471,6 +471,7 @@ class Icons {
       expect(decoded['kit'], 'flutter-material');
       expect(decoded['resolvedCount'], 1);
       expect(decoded['unresolvedCount'], 1);
+      expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
 
       final unresolved = decoded['unresolved'] as List<dynamic>;
       expect(unresolved, hasLength(1));
@@ -1017,8 +1018,10 @@ class Icons {
           jsonDecode(unresolvedReportFile.readAsStringSync())
               as Map<String, dynamic>;
       expect(decoded['baselineUnresolvedCount'], 1);
+      expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
       expect(decoded['newUnresolvedCount'], 0);
       expect(decoded['newUnresolved'], <dynamic>[]);
+      expect(decoded['newUnresolvedCodePoints'], <dynamic>[]);
       expect(decoded['resolvedSinceBaselineCount'], 0);
       expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
     });
@@ -1095,8 +1098,10 @@ class Icons {
             jsonDecode(unresolvedReportFile.readAsStringSync())
                 as Map<String, dynamic>;
         expect(decoded['baselineUnresolvedCount'], 1);
+        expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
         expect(decoded['newUnresolvedCount'], 0);
         expect(decoded['newUnresolved'], <dynamic>[]);
+        expect(decoded['newUnresolvedCodePoints'], <dynamic>[]);
         expect(decoded['resolvedSinceBaselineCount'], 0);
         expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
       },
@@ -1167,8 +1172,10 @@ class Icons {
           jsonDecode(unresolvedReportFile.readAsStringSync())
               as Map<String, dynamic>;
       expect(decoded['baselineUnresolvedCount'], 1);
+      expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
       expect(decoded['newUnresolvedCount'], 0);
       expect(decoded['newUnresolved'], <dynamic>[]);
+      expect(decoded['newUnresolvedCodePoints'], <dynamic>[]);
       expect(decoded['resolvedSinceBaselineCount'], 0);
       expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
     });
@@ -1240,8 +1247,10 @@ class Icons {
           jsonDecode(unresolvedReportFile.readAsStringSync())
               as Map<String, dynamic>;
       expect(decoded['baselineUnresolvedCount'], 1);
+      expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
       expect(decoded['newUnresolvedCount'], 0);
       expect(decoded['newUnresolved'], <dynamic>[]);
+      expect(decoded['newUnresolvedCodePoints'], <dynamic>[]);
       expect(decoded['resolvedSinceBaselineCount'], 0);
       expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
     });
@@ -1321,7 +1330,9 @@ class Icons {
             jsonDecode(unresolvedReportFile.readAsStringSync())
                 as Map<String, dynamic>;
         expect(decoded['baselineUnresolvedCount'], 2);
+        expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
         expect(decoded['newUnresolvedCount'], 0);
+        expect(decoded['newUnresolvedCodePoints'], <dynamic>[]);
         expect(decoded['resolvedSinceBaselineCount'], 1);
         expect(decoded['resolvedSinceBaseline'], <String>['0xe364']);
       },
@@ -1394,7 +1405,9 @@ class Icons {
           jsonDecode(unresolvedReportFile.readAsStringSync())
               as Map<String, dynamic>;
       expect(decoded['baselineUnresolvedCount'], 0);
+      expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
       expect(decoded['newUnresolvedCount'], 1);
+      expect(decoded['newUnresolvedCodePoints'], <String>['0xf04b9']);
       expect(decoded['resolvedSinceBaselineCount'], 0);
       expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
 

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -1583,6 +1583,7 @@ String _renderUnresolvedReportJson({
     'resolvedCount': resolvedCount,
     'unresolvedCount': unresolved.length,
     'unresolved': unresolved.map(_unresolvedIconJson).toList(growable: false),
+    'unresolvedCodePoints': _unresolvedCodePointsJson(unresolved),
     if (baselineUnresolvedCount != null) ...<String, Object>{
       'baselineUnresolvedCount': baselineUnresolvedCount,
     },
@@ -1591,6 +1592,7 @@ String _renderUnresolvedReportJson({
       'newUnresolved': newUnresolved
           .map(_unresolvedIconJson)
           .toList(growable: false),
+      'newUnresolvedCodePoints': _unresolvedCodePointsJson(newUnresolved),
     },
     if (resolvedSinceBaseline != null) ...<String, Object>{
       'resolvedSinceBaselineCount': resolvedSinceBaseline.length,
@@ -1608,6 +1610,12 @@ Map<String, Object> _unresolvedIconJson(_UnresolvedIcon item) {
     'codePoint': '0x${item.codePoint.toRadixString(16)}',
     'identifiers': item.identifiers,
   };
+}
+
+List<String> _unresolvedCodePointsJson(List<_UnresolvedIcon> unresolved) {
+  return unresolved
+      .map((item) => '0x${item.codePoint.toRadixString(16)}')
+      .toList(growable: false);
 }
 
 String _renderUnresolvedBaselineJson({


### PR DESCRIPTION
## Summary

Enhance unresolved rough icon report JSON with codepoint summary arrays.

- `--unresolved-output` now always includes:
  - `unresolvedCodePoints[]` (hex string summary of `unresolved[]` entries)
- When baseline comparison is enabled, reports now also include:
  - `newUnresolvedCodePoints[]` (hex string summary of `newUnresolved[]`)
- Add parser test coverage for the new report fields.
- Update rough icon docs/README to document report payload additions.
- Add changeset:
  - `.changeset/rough-icon-unresolved-report-codepoint-summaries.md`

## Validation

- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart packages/skribble/tool/generate_material_rough_icons.dart .changeset/rough-icon-unresolved-report-codepoint-summaries.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
