### PR TITLE
fix: reject conflicting unresolved threshold flags

### DIFF
--- a/.changeset/rough-icon-strict-threshold-flags-exclusive.md
+++ b/.changeset/rough-icon-strict-threshold-flags-exclusive.md
@@ -1,0 +1,10 @@
+---
+skribble: patch
+---
+
+Clarify and enforce unresolved failure mode flag usage.
+
+- `--fail-on-unresolved` and `--max-unresolved` are now mutually exclusive.
+- Running with both flags now fails fast with an `ArgumentError`.
+- Add parser test coverage for the conflicting-flag case.
+- Update rough icon docs/README and CLI help text to document exclusivity.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -163,6 +163,8 @@ To control failure behavior for unresolved icons:
 - `--fail-on-unresolved` (strict; equivalent to allowing 0 unresolved)
 - `--max-unresolved <int>` (bounded; fail only when unresolved count exceeds threshold)
 
+Use either strict mode or threshold mode (these flags are mutually exclusive).
+
 To detect only regressions relative to an existing unresolved baseline:
 
 - `--unresolved-baseline <path>`

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -245,7 +245,7 @@ Useful flags:
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.
 - `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`), manifest (`icons[]`), or minimal baseline (`codePoints[]`, also accepts `codepoints[]`), including `newUnresolved` and `resolvedSinceBaseline` report fields. String code points accept decimal, `0x` hex, bare hex, and `U+` hex forms.
 - `--max-unresolved <int>` to allow a bounded unresolved count before failing.
-- `--fail-on-unresolved` to make the command exit non-zero if unresolved icons remain.
+- `--fail-on-unresolved` to make the command exit non-zero if unresolved icons remain (cannot be combined with `--max-unresolved`).
 - `--fail-on-new-unresolved` to fail only when unresolved entries regress versus baseline.
 - `--font-name skribble_rough_icons` to customize generated font family name.
 - `--font-dart-output <path>` to emit Dart lookup helpers for generated font codepoints.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -746,6 +746,17 @@ class Icons {
       tempDirectory.deleteSync(recursive: true);
     });
 
+    test('rejects combining fail-on-unresolved with max-unresolved', () async {
+      await expectLater(
+        tool.runGenerateRoughIcons(<String>[
+          '--fail-on-unresolved',
+          '--max-unresolved',
+          '1',
+        ]),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
     test('throws StateError when unresolved icons remain', () async {
       final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
         ..writeAsStringSync('''

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -315,7 +315,7 @@ Options:
   --unresolved-baseline <path>     Baseline unresolved report/manifest/codePoints JSON for diffing.
                                    Accepts codePoints/codepoints key for minimal baseline objects.
   --max-unresolved <int>           Max unresolved icons allowed before failing.
-  --fail-on-unresolved             Exit with error when unresolved icons remain.
+  --fail-on-unresolved             Exit with error when unresolved icons remain (cannot be combined with --max-unresolved).
   --fail-on-new-unresolved         Exit with error on unresolved baseline regressions.
   --output <path>                  Output Dart file.
   --rough-cli <path>               TypeScript script that converts SVG(s) (default: tool/deno/svg2roughjs_cli.ts).
@@ -554,6 +554,11 @@ final class _ScriptOptions {
 
     if (maxUnresolved != null && maxUnresolved < 0) {
       throw ArgumentError('--max-unresolved must be >= 0.');
+    }
+    if (failOnUnresolved && maxUnresolved != null) {
+      throw ArgumentError(
+        '--fail-on-unresolved cannot be combined with --max-unresolved.',
+      );
     }
     if (!_kUnresolvedBaselineOutputFormats.contains(
       unresolvedBaselineOutputFormat,


### PR DESCRIPTION
## Summary

Clarify and enforce unresolved failure mode flag usage.

- `--fail-on-unresolved` and `--max-unresolved` are now mutually exclusive.
- Combining both flags now fails fast with an `ArgumentError`.
- Add parser test coverage for conflicting-flag usage.
- Update rough icon docs/README and CLI usage text to document exclusivity.
- Add changeset:
  - `.changeset/rough-icon-strict-threshold-flags-exclusive.md`

## Validation

- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart packages/skribble/tool/generate_material_rough_icons.dart .changeset/rough-icon-strict-threshold-flags-exclusive.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
