### PR TITLE
feat: add max-new-unresolved baseline regression threshold

### DIFF
--- a/.changeset/rough-icon-max-new-unresolved-threshold.md
+++ b/.changeset/rough-icon-max-new-unresolved-threshold.md
@@ -1,0 +1,13 @@
+---
+skribble: patch
+---
+
+Add threshold-based unresolved baseline regression gating.
+
+- Add `--max-new-unresolved <int>` to allow bounded unresolved baseline regressions.
+- Treat `--fail-on-new-unresolved` as strict mode (equivalent to `--max-new-unresolved 0`).
+- Enforce parser validation:
+  - `--max-new-unresolved` must be `>= 0`
+  - `--max-new-unresolved` requires `--unresolved-baseline`
+  - `--fail-on-new-unresolved` and `--max-new-unresolved` are mutually exclusive
+- Update docs/README/CLI help and add parser+behavior tests.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -27,7 +27,7 @@ Compatibility alias (backward compatible):
      including legacy alias identifiers that share resolved codepoints
    - emits unresolved icon reports as JSON (`--unresolved-output`)
    - emits supplemental manifest templates (`--supplemental-manifest-output`)
-   - can fail CI on unresolved icons (`--fail-on-unresolved`, `--max-unresolved`, `--fail-on-new-unresolved`)
+   - can fail CI on unresolved icons (`--fail-on-unresolved`, `--max-unresolved`, `--fail-on-new-unresolved`, `--max-new-unresolved`)
 
 ## Extensibility seam
 
@@ -168,7 +168,11 @@ Use either strict mode or threshold mode (these flags are mutually exclusive).
 To detect only regressions relative to an existing unresolved baseline:
 
 - `--unresolved-baseline <path>`
-- `--fail-on-new-unresolved`
+- `--fail-on-new-unresolved` (strict; equivalent to allowing 0 newly unresolved)
+- `--max-new-unresolved <int>` (bounded; fail only when newly unresolved count exceeds threshold)
+
+Use either strict baseline-regression mode or threshold baseline-regression mode
+(these flags are mutually exclusive).
 
 Baseline input supports:
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -246,7 +246,8 @@ Useful flags:
 - `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`), manifest (`icons[]`), or minimal baseline (`codePoints[]`, also accepts `codepoints[]`), including `newUnresolved` and `resolvedSinceBaseline` report fields. String code points accept decimal, `0x` hex, bare hex, and `U+` hex forms.
 - `--max-unresolved <int>` to allow a bounded unresolved count before failing.
 - `--fail-on-unresolved` to make the command exit non-zero if unresolved icons remain (cannot be combined with `--max-unresolved`).
-- `--fail-on-new-unresolved` to fail only when unresolved entries regress versus baseline.
+- `--max-new-unresolved <int>` to allow a bounded number of newly unresolved entries versus baseline before failing (requires `--unresolved-baseline`).
+- `--fail-on-new-unresolved` to fail only when unresolved entries regress versus baseline (cannot be combined with `--max-new-unresolved`).
 - `--font-name skribble_rough_icons` to customize generated font family name.
 - `--font-dart-output <path>` to emit Dart lookup helpers for generated font codepoints.
 - `CHROME_PATH=/path/to/chrome` if Chromium/Chrome is not in a standard location.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -960,6 +960,29 @@ class Icons {
       },
     );
 
+    test('requires baseline path when max-new-unresolved is enabled', () async {
+      await expectLater(
+        tool.runGenerateRoughIcons(<String>['--max-new-unresolved', '1']),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test(
+      'rejects combining fail-on-new-unresolved with max-new-unresolved',
+      () async {
+        await expectLater(
+          tool.runGenerateRoughIcons(<String>[
+            '--fail-on-new-unresolved',
+            '--max-new-unresolved',
+            '1',
+            '--unresolved-baseline',
+            'baseline.json',
+          ]),
+          throwsA(isA<ArgumentError>()),
+        );
+      },
+    );
+
     test('does not throw when unresolved icons are all in baseline', () async {
       final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
         ..writeAsStringSync('''
@@ -1130,8 +1153,9 @@ class Icons {
 }
 ''');
 
-      final materialIconsRoot = Directory('${tempDirectory.path}/material-icons')
-        ..createSync(recursive: true);
+      final materialIconsRoot = Directory(
+        '${tempDirectory.path}/material-icons',
+      )..createSync(recursive: true);
       final materialSymbolsRoot = Directory(
         '${tempDirectory.path}/material-symbols',
       )..createSync(recursive: true);
@@ -1144,8 +1168,9 @@ class Icons {
           '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
         );
 
-      final baselineFile = File('${tempDirectory.path}/baseline-codepoints.json')
-        ..writeAsStringSync('''
+      final baselineFile =
+          File('${tempDirectory.path}/baseline-codepoints.json')
+            ..writeAsStringSync('''
 {
   "codePoints": [
     "f04b9"
@@ -1191,9 +1216,11 @@ class Icons {
       expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
     });
 
-    test('accepts lowercase codepoints[] format as unresolved baseline', () async {
-      final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
-        ..writeAsStringSync('''
+    test(
+      'accepts lowercase codepoints[] format as unresolved baseline',
+      () async {
+        final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+          ..writeAsStringSync('''
 class Icons {
   /// The material icon named "label outline".
   static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
@@ -1203,68 +1230,69 @@ class Icons {
 }
 ''');
 
-      final materialIconsRoot = Directory('${tempDirectory.path}/material-icons')
-        ..createSync(recursive: true);
-      final materialSymbolsRoot = Directory(
-        '${tempDirectory.path}/material-symbols',
-      )..createSync(recursive: true);
-      final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
-        ..createSync(recursive: true);
+        final materialIconsRoot = Directory(
+          '${tempDirectory.path}/material-icons',
+        )..createSync(recursive: true);
+        final materialSymbolsRoot = Directory(
+          '${tempDirectory.path}/material-symbols',
+        )..createSync(recursive: true);
+        final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+          ..createSync(recursive: true);
 
-      File('${materialIconsRoot.path}/filled/label.svg')
-        ..createSync(recursive: true)
-        ..writeAsStringSync(
-          '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
-        );
+        File('${materialIconsRoot.path}/filled/label.svg')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+          );
 
-      final baselineFile = File(
-        '${tempDirectory.path}/baseline-codepoints-lowercase.json',
-      )
-        ..writeAsStringSync('''
+        final baselineFile =
+            File('${tempDirectory.path}/baseline-codepoints-lowercase.json')
+              ..writeAsStringSync('''
 {
   "codepoints": [
     "f04b9"
   ]
 }
 ''');
-      final unresolvedReportFile = File(
-        '${tempDirectory.path}/unresolved_report.json',
-      );
-      final outputFile = File(
-        '${tempDirectory.path}/material_rough_icons.g.dart',
-      );
+        final unresolvedReportFile = File(
+          '${tempDirectory.path}/unresolved_report.json',
+        );
+        final outputFile = File(
+          '${tempDirectory.path}/material_rough_icons.g.dart',
+        );
 
-      await tool.runGenerateRoughIcons(<String>[
-        '--kit',
-        'flutter-material',
-        '--flutter-icons',
-        flutterIconsFile.path,
-        '--material-icons-source',
-        materialIconsRoot.path,
-        '--material-symbols-source',
-        materialSymbolsRoot.path,
-        '--brand-icons-source',
-        brandIconsRoot.path,
-        '--unresolved-baseline',
-        baselineFile.path,
-        '--fail-on-new-unresolved',
-        '--unresolved-output',
-        unresolvedReportFile.path,
-        '--output',
-        outputFile.path,
-      ]);
+        await tool.runGenerateRoughIcons(<String>[
+          '--kit',
+          'flutter-material',
+          '--flutter-icons',
+          flutterIconsFile.path,
+          '--material-icons-source',
+          materialIconsRoot.path,
+          '--material-symbols-source',
+          materialSymbolsRoot.path,
+          '--brand-icons-source',
+          brandIconsRoot.path,
+          '--unresolved-baseline',
+          baselineFile.path,
+          '--fail-on-new-unresolved',
+          '--unresolved-output',
+          unresolvedReportFile.path,
+          '--output',
+          outputFile.path,
+        ]);
 
-      final decoded =
-          jsonDecode(unresolvedReportFile.readAsStringSync())
-              as Map<String, dynamic>;
-      expect(decoded['baselineUnresolvedCount'], 1);
-      expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
-      expect(decoded['newUnresolvedCount'], 0);
-      expect(decoded['newUnresolved'], <dynamic>[]);
-      expect(decoded['newUnresolvedCodePoints'], <dynamic>[]);
-      expect(decoded['resolvedSinceBaselineCount'], 0);
-      expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
-    });
+        final decoded =
+            jsonDecode(unresolvedReportFile.readAsStringSync())
+                as Map<String, dynamic>;
+        expect(decoded['baselineUnresolvedCount'], 1);
+        expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
+        expect(decoded['newUnresolvedCount'], 0);
+        expect(decoded['newUnresolved'], <dynamic>[]);
+        expect(decoded['newUnresolvedCodePoints'], <dynamic>[]);
+        expect(decoded['resolvedSinceBaselineCount'], 0);
+        expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
+      },
+    );
 
     test(
       'reports resolvedSinceBaseline when baseline entries are now resolved',
@@ -1348,6 +1376,151 @@ class Icons {
         expect(decoded['resolvedSinceBaseline'], <String>['0xe364']);
       },
     );
+
+    test(
+      'does not throw when max-new-unresolved threshold is not exceeded',
+      () async {
+        final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+          ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+        final materialIconsRoot = Directory(
+          '${tempDirectory.path}/material-icons',
+        )..createSync(recursive: true);
+        final materialSymbolsRoot = Directory(
+          '${tempDirectory.path}/material-symbols',
+        )..createSync(recursive: true);
+        final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+          ..createSync(recursive: true);
+
+        File('${materialIconsRoot.path}/filled/label.svg')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+          );
+
+        final baselineFile = File('${tempDirectory.path}/baseline-empty.json')
+          ..writeAsStringSync('''
+{
+  "unresolved": []
+}
+''');
+        final unresolvedReportFile = File(
+          '${tempDirectory.path}/unresolved_report.json',
+        );
+        final outputFile = File(
+          '${tempDirectory.path}/material_rough_icons.g.dart',
+        );
+
+        await tool.runGenerateRoughIcons(<String>[
+          '--kit',
+          'flutter-material',
+          '--flutter-icons',
+          flutterIconsFile.path,
+          '--material-icons-source',
+          materialIconsRoot.path,
+          '--material-symbols-source',
+          materialSymbolsRoot.path,
+          '--brand-icons-source',
+          brandIconsRoot.path,
+          '--unresolved-baseline',
+          baselineFile.path,
+          '--max-new-unresolved',
+          '1',
+          '--unresolved-output',
+          unresolvedReportFile.path,
+          '--output',
+          outputFile.path,
+        ]);
+
+        final decoded =
+            jsonDecode(unresolvedReportFile.readAsStringSync())
+                as Map<String, dynamic>;
+        expect(decoded['baselineUnresolvedCount'], 0);
+        expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
+        expect(decoded['newUnresolvedCount'], 1);
+        expect(decoded['newUnresolvedCodePoints'], <String>['0xf04b9']);
+      },
+    );
+
+    test('throws when max-new-unresolved threshold is exceeded', () async {
+      final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+        ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+      final materialIconsRoot = Directory(
+        '${tempDirectory.path}/material-icons',
+      )..createSync(recursive: true);
+      final materialSymbolsRoot = Directory(
+        '${tempDirectory.path}/material-symbols',
+      )..createSync(recursive: true);
+      final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+        ..createSync(recursive: true);
+
+      File('${materialIconsRoot.path}/filled/label.svg')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(
+          '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+        );
+
+      final baselineFile = File('${tempDirectory.path}/baseline-empty.json')
+        ..writeAsStringSync('''
+{
+  "unresolved": []
+}
+''');
+      final unresolvedReportFile = File(
+        '${tempDirectory.path}/unresolved_report.json',
+      );
+      final outputFile = File(
+        '${tempDirectory.path}/material_rough_icons.g.dart',
+      );
+
+      await expectLater(
+        tool.runGenerateRoughIcons(<String>[
+          '--kit',
+          'flutter-material',
+          '--flutter-icons',
+          flutterIconsFile.path,
+          '--material-icons-source',
+          materialIconsRoot.path,
+          '--material-symbols-source',
+          materialSymbolsRoot.path,
+          '--brand-icons-source',
+          brandIconsRoot.path,
+          '--unresolved-baseline',
+          baselineFile.path,
+          '--max-new-unresolved',
+          '0',
+          '--unresolved-output',
+          unresolvedReportFile.path,
+          '--output',
+          outputFile.path,
+        ]),
+        throwsA(isA<StateError>()),
+      );
+
+      final decoded =
+          jsonDecode(unresolvedReportFile.readAsStringSync())
+              as Map<String, dynamic>;
+      expect(decoded['baselineUnresolvedCount'], 0);
+      expect(decoded['newUnresolvedCount'], 1);
+      expect(decoded['newUnresolvedCodePoints'], <String>['0xf04b9']);
+    });
 
     test('throws when unresolved icons regress against baseline', () async {
       final flutterIconsFile = File('${tempDirectory.path}/icons.dart')

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -148,10 +148,7 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
   if (options.fontDartOutputPath case final outputPath?) {
     final outputFile = File(outputPath)..createSync(recursive: true);
     outputFile.writeAsStringSync(
-      _renderFontCodePointsDart(
-        fontName: options.fontName,
-        glyphs: fontGlyphs,
-      ),
+      _renderFontCodePointsDart(fontName: options.fontName, glyphs: fontGlyphs),
     );
     stdout.writeln('Generated icon font Dart helpers to ${outputFile.path}');
   }
@@ -189,18 +186,17 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
       case final unresolvedBaselineOutputPath?) {
     final unresolvedBaselineOutputFile = File(unresolvedBaselineOutputPath)
       ..createSync(recursive: true);
-    final unresolvedBaselineJson = switch (
-      options.unresolvedBaselineOutputFormat
-    ) {
-      _kUnresolvedBaselineOutputFormatUnresolved =>
-        _renderUnresolvedBaselineJson(unresolved: unresolved),
-      _kUnresolvedBaselineOutputFormatCodePoints =>
-        _renderUnresolvedBaselineCodePointsJson(unresolved: unresolved),
-      _ => throw StateError(
-        'Unsupported unresolved baseline output format: '
-        '${options.unresolvedBaselineOutputFormat}',
-      ),
-    };
+    final unresolvedBaselineJson =
+        switch (options.unresolvedBaselineOutputFormat) {
+          _kUnresolvedBaselineOutputFormatUnresolved =>
+            _renderUnresolvedBaselineJson(unresolved: unresolved),
+          _kUnresolvedBaselineOutputFormatCodePoints =>
+            _renderUnresolvedBaselineCodePointsJson(unresolved: unresolved),
+          _ => throw StateError(
+            'Unsupported unresolved baseline output format: '
+            '${options.unresolvedBaselineOutputFormat}',
+          ),
+        };
     unresolvedBaselineOutputFile.writeAsStringSync(unresolvedBaselineJson);
     stdout.writeln(
       'Generated unresolved baseline JSON to '
@@ -228,9 +224,14 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
   final failureThreshold = options.failOnUnresolved ? 0 : options.maxUnresolved;
   final thresholdFailure =
       failureThreshold != null && unresolved.length > failureThreshold;
-  final newUnresolvedFailure =
-      options.failOnNewUnresolved && (newUnresolved?.isNotEmpty ?? false);
-  final shouldFail = thresholdFailure || newUnresolvedFailure;
+  final newUnresolvedThreshold = options.failOnNewUnresolved
+      ? 0
+      : options.maxNewUnresolved;
+  final newUnresolvedCount = newUnresolved?.length ?? 0;
+  final newUnresolvedThresholdFailure =
+      newUnresolvedThreshold != null &&
+      newUnresolvedCount > newUnresolvedThreshold;
+  final shouldFail = thresholdFailure || newUnresolvedThresholdFailure;
 
   final severityLabel = shouldFail ? 'Error' : 'Warning';
   stderr.writeln(
@@ -245,7 +246,7 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
   }
 
   if (newUnresolved case final baselineDiff?) {
-    final baselineSeverity = newUnresolvedFailure
+    final baselineSeverity = newUnresolvedThresholdFailure
         ? 'Error'
         : (shouldFail ? 'Warning' : 'Info');
     stderr.writeln(
@@ -277,8 +278,8 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
     final details = <String>[
       if (thresholdFailure)
         'found ${unresolved.length}, allowed $failureThreshold',
-      if (newUnresolvedFailure)
-        'new unresolved regression detected (${newUnresolved!.length})',
+      if (newUnresolvedThresholdFailure)
+        'new unresolved regression detected ($newUnresolvedCount, allowed $newUnresolvedThreshold)',
     ].join('; ');
     throw StateError(
       'Unresolved icon codepoints remain for kit "${options.kit}" ($details).',
@@ -316,7 +317,8 @@ Options:
                                    Accepts codePoints/codepoints key for minimal baseline objects.
   --max-unresolved <int>           Max unresolved icons allowed before failing.
   --fail-on-unresolved             Exit with error when unresolved icons remain (cannot be combined with --max-unresolved).
-  --fail-on-new-unresolved         Exit with error on unresolved baseline regressions.
+  --max-new-unresolved <int>       Max newly unresolved icons allowed before failing (requires --unresolved-baseline).
+  --fail-on-new-unresolved         Exit with error on unresolved baseline regressions (cannot be combined with --max-new-unresolved).
   --output <path>                  Output Dart file.
   --rough-cli <path>               TypeScript script that converts SVG(s) (default: tool/deno/svg2roughjs_cli.ts).
   --rough-cli-runner <exe>         Runner executable for --rough-cli (default: deno).
@@ -371,6 +373,7 @@ final class _ScriptOptions {
     this.supplementalManifestOutputPath,
     this.unresolvedBaselinePath,
     this.maxUnresolved,
+    this.maxNewUnresolved,
     this.outputPath,
     this.roughCliPath,
     this.roughCliRunner = _kDefaultRoughCliRunner,
@@ -403,6 +406,7 @@ final class _ScriptOptions {
   final String? supplementalManifestOutputPath;
   final String? unresolvedBaselinePath;
   final int? maxUnresolved;
+  final int? maxNewUnresolved;
   final String? outputPath;
   final String? roughCliPath;
   final String roughCliRunner;
@@ -436,6 +440,7 @@ final class _ScriptOptions {
     String? supplementalManifestOutputPath;
     String? unresolvedBaselinePath;
     int? maxUnresolved;
+    int? maxNewUnresolved;
     String? outputPath;
     String? roughCliPath;
     var roughCliRunner = _kDefaultRoughCliRunner;
@@ -525,6 +530,8 @@ final class _ScriptOptions {
           unresolvedBaselinePath = value;
         case '--max-unresolved':
           maxUnresolved = int.parse(value);
+        case '--max-new-unresolved':
+          maxNewUnresolved = int.parse(value);
         case '--output':
           outputPath = value;
         case '--rough-cli':
@@ -555,9 +562,18 @@ final class _ScriptOptions {
     if (maxUnresolved != null && maxUnresolved < 0) {
       throw ArgumentError('--max-unresolved must be >= 0.');
     }
+    if (maxNewUnresolved != null && maxNewUnresolved < 0) {
+      throw ArgumentError('--max-new-unresolved must be >= 0.');
+    }
     if (failOnUnresolved && maxUnresolved != null) {
       throw ArgumentError(
         '--fail-on-unresolved cannot be combined with --max-unresolved.',
+      );
+    }
+    if (failOnNewUnresolved && maxNewUnresolved != null) {
+      throw ArgumentError(
+        '--fail-on-new-unresolved cannot be combined with '
+        '--max-new-unresolved.',
       );
     }
     if (!_kUnresolvedBaselineOutputFormats.contains(
@@ -576,9 +592,11 @@ final class _ScriptOptions {
         '--unresolved-baseline-output.',
       );
     }
-    if (failOnNewUnresolved && unresolvedBaselinePath == null) {
+    if ((failOnNewUnresolved || maxNewUnresolved != null) &&
+        unresolvedBaselinePath == null) {
       throw ArgumentError(
-        '--fail-on-new-unresolved requires --unresolved-baseline.',
+        '--fail-on-new-unresolved and --max-new-unresolved require '
+        '--unresolved-baseline.',
       );
     }
 
@@ -596,6 +614,7 @@ final class _ScriptOptions {
       supplementalManifestOutputPath: supplementalManifestOutputPath,
       unresolvedBaselinePath: unresolvedBaselinePath,
       maxUnresolved: maxUnresolved,
+      maxNewUnresolved: maxNewUnresolved,
       outputPath: outputPath,
       roughCliPath: roughCliPath,
       roughCliRunner: roughCliRunner,
@@ -954,10 +973,7 @@ _ManifestIconEntry _parseManifestIconEntry(
 }
 
 int _parseManifestCodePoint(Object? value, String identifier) {
-  return _parseCodePointValue(
-    value,
-    context: 'manifest entry "$identifier"',
-  );
+  return _parseCodePointValue(value, context: 'manifest entry "$identifier"');
 }
 
 File _resolveManifestSvgFile(
@@ -1649,11 +1665,9 @@ String _renderUnresolvedBaselineJson({
 String _renderUnresolvedBaselineCodePointsJson({
   required List<_UnresolvedIcon> unresolved,
 }) {
-  final sortedCodePoints = unresolved
-      .map((item) => item.codePoint)
-      .toSet()
-      .toList(growable: false)
-    ..sort();
+  final sortedCodePoints =
+      unresolved.map((item) => item.codePoint).toSet().toList(growable: false)
+        ..sort();
 
   final baseline = <String, Object>{
     'codePoints': sortedCodePoints


### PR DESCRIPTION
## Summary
- add `--max-new-unresolved <int>` as a threshold-based alternative to strict baseline regression mode
- treat `--fail-on-new-unresolved` as strict mode (equivalent to threshold `0`) during failure evaluation
- enforce parser validation for the new flag:
  - requires `--unresolved-baseline`
  - must be `>= 0`
  - cannot be combined with `--fail-on-new-unresolved`
- document the new option and exclusivity rules in CLI help, rough-icon pipeline docs, and package README
- add parser/runtime tests for baseline threshold behavior and invalid flag combinations
- add changeset for CI documentation gate

## Validation
- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md .changeset/rough-icon-max-new-unresolved-threshold.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
