### PR TITLE
feat: support threshold env override for rough icon CI checks

### DIFF
--- a/.changeset/rough-icon-ci-max-new-unresolved-env.md
+++ b/.changeset/rough-icon-ci-max-new-unresolved-env.md
@@ -1,0 +1,12 @@
+---
+skribble: patch
+---
+
+Add threshold-mode baseline regression gating to the rough icon CI check script.
+
+- `scripts/check_rough_icons_ci.sh` now supports optional env var
+  `ROUGH_ICONS_MAX_NEW_UNRESOLVED=<int>`.
+- When set, regression and generated-sync checks use
+  `--max-new-unresolved <int>` instead of strict `--fail-on-new-unresolved`.
+- Includes validation that the env var is a non-negative integer.
+- Updates rough icon pipeline docs and package README with the new script option.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -213,6 +213,9 @@ On sync-check failures, the script prints `git diff` output and saves it to:
 
 `regression` cleans up `packages/skribble/unresolved-report.json` after a
 successful local run. Set `ROUGH_ICONS_KEEP_UNRESOLVED_REPORT=1` to keep it.
+Set `ROUGH_ICONS_MAX_NEW_UNRESOLVED=<int>` to use threshold mode for
+regression/generated-sync checks (`--max-new-unresolved`) instead of strict
+mode (`--fail-on-new-unresolved`).
 
 CI also enforces the same unresolved regression gate on pull requests using
 `--rough-only`, `--supplemental-manifest`, and `--unresolved-baseline`, and

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -223,6 +223,9 @@ On sync-check failures, the script prints `git diff` output and writes:
 
 `regression` cleans up `packages/skribble/unresolved-report.json` after a
 successful local run. Set `ROUGH_ICONS_KEEP_UNRESOLVED_REPORT=1` to keep it.
+Set `ROUGH_ICONS_MAX_NEW_UNRESOLVED=<int>` to run regression/generated-sync
+checks in threshold mode (`--max-new-unresolved`) instead of strict mode
+(`--fail-on-new-unresolved`).
 
 Pull-request CI also runs the unresolved gate in `--rough-only` mode, uploads a
 `rough-icons-unresolved-report` artifact for diagnostics, verifies the

--- a/scripts/check_rough_icons_ci.sh
+++ b/scripts/check_rough_icons_ci.sh
@@ -7,6 +7,9 @@
 # Optional env vars:
 #   ROUGH_ICONS_KEEP_UNRESOLVED_REPORT=1  Keep unresolved-report.json after
 #                                         successful local regression checks.
+#   ROUGH_ICONS_MAX_NEW_UNRESOLVED=<int>  Allow up to this many newly unresolved
+#                                         baseline regressions before failing
+#                                         (default: strict fail-on-new-unresolved).
 
 set -euo pipefail
 
@@ -19,6 +22,9 @@ cd "$REPO_ROOT"
 UNRESOLVED_REPORT_PATH="packages/skribble/unresolved-report.json"
 BASELINE_SYNC_DIFF_PATH="rough-icons-baseline-sync.diff"
 GENERATED_SYNC_DIFF_PATH="rough-icons-generated-sync.diff"
+
+BASELINE_REGRESSION_ARGS=()
+BASELINE_REGRESSION_MODE_DESCRIPTION=""
 
 emit_sync_diff_if_needed() {
   local diff_output_path="$1"
@@ -40,7 +46,29 @@ emit_sync_diff_if_needed() {
   return 1
 }
 
+build_baseline_regression_args() {
+  local max_new_unresolved="${ROUGH_ICONS_MAX_NEW_UNRESOLVED:-}"
+
+  if [[ -z "$max_new_unresolved" ]]; then
+    BASELINE_REGRESSION_ARGS=(--fail-on-new-unresolved)
+    BASELINE_REGRESSION_MODE_DESCRIPTION="strict (--fail-on-new-unresolved)"
+    return 0
+  fi
+
+  if [[ ! "$max_new_unresolved" =~ ^[0-9]+$ ]]; then
+    echo "ROUGH_ICONS_MAX_NEW_UNRESOLVED must be a non-negative integer." >&2
+    echo "Received: $max_new_unresolved" >&2
+    return 1
+  fi
+
+  BASELINE_REGRESSION_ARGS=(--max-new-unresolved "$max_new_unresolved")
+  BASELINE_REGRESSION_MODE_DESCRIPTION="threshold (--max-new-unresolved $max_new_unresolved)"
+}
+
 run_regression_check() {
+  build_baseline_regression_args
+  echo "Using unresolved baseline regression gate: $BASELINE_REGRESSION_MODE_DESCRIPTION"
+
   (
     cd packages/skribble
     dart run tool/generate_rough_icons.dart \
@@ -49,7 +77,7 @@ run_regression_check() {
       --supplemental-manifest tool/examples/material_rough_icons.supplemental.manifest.json \
       --unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json \
       --unresolved-output unresolved-report.json \
-      --fail-on-new-unresolved
+      "${BASELINE_REGRESSION_ARGS[@]}"
   )
 
   if [[ "${CI:-}" != "true" ]] && [[ "${ROUGH_ICONS_KEEP_UNRESOLVED_REPORT:-0}" != "1" ]]; then
@@ -76,13 +104,16 @@ run_baseline_sync_check() {
 }
 
 run_generated_sync_check() {
+  build_baseline_regression_args
+  echo "Using unresolved baseline regression gate: $BASELINE_REGRESSION_MODE_DESCRIPTION"
+
   (
     cd packages/skribble
     dart run tool/generate_rough_icons.dart \
       --kit flutter-material \
       --supplemental-manifest tool/examples/material_rough_icons.supplemental.manifest.json \
       --unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json \
-      --fail-on-new-unresolved \
+      "${BASELINE_REGRESSION_ARGS[@]}" \
       --output lib/src/generated/material_rough_icons.g.dart \
       --font-dart-output lib/src/generated/material_rough_icon_font.g.dart
   )


### PR DESCRIPTION
## Summary
- add `ROUGH_ICONS_MAX_NEW_UNRESOLVED=<int>` support to `scripts/check_rough_icons_ci.sh`
- allow regression/generated-sync checks to run in threshold mode via `--max-new-unresolved <int>`
  - default behavior remains strict mode via `--fail-on-new-unresolved`
- validate env input as a non-negative integer with a clear error message
- print which unresolved baseline regression gate mode is active during checks
- document the new script env var in:
  - `docs/rough-icon-pipeline.md`
  - `packages/skribble/README.md`
- add changeset for documentation/change tracking gate

## Validation
- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md .changeset/rough-icon-ci-max-new-unresolved-env.md`
- `bash -n scripts/check_rough_icons_ci.sh`
- `ROUGH_ICONS_MAX_NEW_UNRESOLVED=0 ./scripts/check_rough_icons_ci.sh regression`
- `ROUGH_ICONS_MAX_NEW_UNRESOLVED=abc ./scripts/check_rough_icons_ci.sh regression` (expected failure with validation error)
