### PR TITLE
chore: pin rough icon CI regression threshold env

### DIFF
--- a/.changeset/rough-icon-ci-threshold-env-default.md
+++ b/.changeset/rough-icon-ci-threshold-env-default.md
@@ -1,0 +1,9 @@
+---
+skribble: patch
+---
+
+Wire rough icon CI checks to the new threshold-based regression env option.
+
+- Set `ROUGH_ICONS_MAX_NEW_UNRESOLVED=0` in rough icon regression and generated-sync CI jobs.
+- Keeps CI behavior strict (equivalent to `--fail-on-new-unresolved`) while exposing a single threshold knob in workflow config.
+- Update rough icon docs/README to document the CI default and override path.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
 
   rough-icons-regression:
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    env:
+      ROUGH_ICONS_MAX_NEW_UNRESOLVED: 0
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/devenv
@@ -67,6 +69,8 @@ jobs:
 
   rough-icons-generated-sync:
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    env:
+      ROUGH_ICONS_MAX_NEW_UNRESOLVED: 0
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/devenv

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -217,6 +217,10 @@ Set `ROUGH_ICONS_MAX_NEW_UNRESOLVED=<int>` to use threshold mode for
 regression/generated-sync checks (`--max-new-unresolved`) instead of strict
 mode (`--fail-on-new-unresolved`).
 
+Pull-request CI sets `ROUGH_ICONS_MAX_NEW_UNRESOLVED=0` for those checks,
+which is equivalent to strict mode while keeping one configurable threshold
+knob in workflow configuration.
+
 CI also enforces the same unresolved regression gate on pull requests using
 `--rough-only`, `--supplemental-manifest`, and `--unresolved-baseline`, and
 uploads an `rough-icons-unresolved-report` artifact (from

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -227,6 +227,10 @@ Set `ROUGH_ICONS_MAX_NEW_UNRESOLVED=<int>` to run regression/generated-sync
 checks in threshold mode (`--max-new-unresolved`) instead of strict mode
 (`--fail-on-new-unresolved`).
 
+Pull-request CI sets `ROUGH_ICONS_MAX_NEW_UNRESOLVED=0` for those checks,
+which is strict-mode equivalent and keeps one threshold control in workflow
+configuration.
+
 Pull-request CI also runs the unresolved gate in `--rough-only` mode, uploads a
 `rough-icons-unresolved-report` artifact for diagnostics, verifies the
 committed baseline file is up to date, checks that generated rough icon


### PR DESCRIPTION
## Summary
- set `ROUGH_ICONS_MAX_NEW_UNRESOLVED=0` in rough icon CI regression/generate-sync jobs
- use the new threshold-based script path in CI while preserving strict behavior
  - `0` is strict-equivalent to `--fail-on-new-unresolved`
- document the CI default in rough icon pipeline docs and package README
- add changeset for documentation/release gate

## Validation
- `git diff --check`
- `dprint check .github/workflows/ci.yml docs/rough-icon-pipeline.md packages/skribble/README.md .changeset/rough-icon-ci-threshold-env-default.md`
- `bash -n scripts/check_rough_icons_ci.sh`
- `ROUGH_ICONS_MAX_NEW_UNRESOLVED=0 ./scripts/check_rough_icons_ci.sh regression`
