### PR TITLE
chore: use threshold mode in rough icon workspace shortcuts

### DIFF
--- a/.changeset/rough-icon-workspace-threshold-mode.md
+++ b/.changeset/rough-icon-workspace-threshold-mode.md
@@ -1,0 +1,10 @@
+---
+skribble: patch
+---
+
+Switch rough icon workspace shortcuts to explicit threshold-mode regression gating.
+
+- Update `melos run rough-icons` and `melos run rough-icons-font` to use
+  `--max-new-unresolved 0` instead of `--fail-on-new-unresolved`.
+- Preserves strict behavior while matching the threshold-based workflow used in CI.
+- Update rough icon docs/README to describe the strict-equivalent threshold mode.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -194,7 +194,7 @@ Workspace shortcuts:
 
 `rough-icons` and `rough-icons-font` both apply the committed supplemental
 manifest `packages/skribble/tool/examples/material_rough_icons.supplemental.manifest.json`
-and enforce `--fail-on-new-unresolved` against
+and enforce `--max-new-unresolved 0` (strict-mode equivalent) against
 `packages/skribble/tool/examples/material_rough_icons.unresolved-baseline.json`.
 
 `rough-icons-ci-check` runs the same rough icon regression/sync checks used by

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -204,8 +204,9 @@ melos run rough-icons-ci-check
 manifest (`tool/examples/material_rough_icons.supplemental.manifest.json`) and
 enforce unresolved regression gating via
 `--unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json`
-plus `--fail-on-new-unresolved`. Use `rough-icons-baseline` to refresh that
-committed `codePoints[]` baseline file after intentional changes.
+plus `--max-new-unresolved 0` (strict-mode equivalent). Use
+`rough-icons-baseline` to refresh that committed `codePoints[]` baseline file
+after intentional changes.
 
 `rough-icons-ci-check` runs the same rough icon regression/sync checks enforced
 by CI via `./scripts/check_rough_icons_ci.sh all`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,7 +56,7 @@ melos:
         --rough-output-dir tool/icon_exports/rough-svg
         --supplemental-manifest tool/examples/material_rough_icons.supplemental.manifest.json
         --unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json
-        --fail-on-new-unresolved
+        --max-new-unresolved 0
 
     rough-icons-font:
       description: Generate rough Material icon font artifacts (TTF + Dart helpers), applying supplemental sources and failing on unresolved regressions.
@@ -69,7 +69,7 @@ melos:
         --font-dart-output lib/src/generated/material_rough_icon_font.g.dart
         --supplemental-manifest tool/examples/material_rough_icons.supplemental.manifest.json
         --unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json
-        --fail-on-new-unresolved
+        --max-new-unresolved 0
 
     rough-icons-baseline:
       description: Refresh normalized unresolved baseline JSON used for rough icon regression gating.


### PR DESCRIPTION
## Summary
- switch workspace rough icon shortcuts to explicit threshold-mode baseline regression gating
  - `melos run rough-icons` now uses `--max-new-unresolved 0`
  - `melos run rough-icons-font` now uses `--max-new-unresolved 0`
- preserve strict behavior while matching the threshold-based CI/script model
- update rough icon docs/README to describe strict-equivalent threshold mode for workspace shortcuts
- add changeset for CI documentation gate

## Validation
- `git diff --check`
- `dprint check pubspec.yaml docs/rough-icon-pipeline.md packages/skribble/README.md .changeset/rough-icon-workspace-threshold-mode.md`
- `cd packages/skribble && dart run tool/generate_rough_icons.dart --kit flutter-material --rough-only --supplemental-manifest tool/examples/material_rough_icons.supplemental.manifest.json --unresolved-baseline tool/examples/material_rough_icons.unresolved-baseline.json --max-new-unresolved 0`
