### PR TITLE
feat: include unresolved threshold metadata in reports

### DIFF
--- a/.changeset/rough-icon-unresolved-report-threshold-metadata.md
+++ b/.changeset/rough-icon-unresolved-report-threshold-metadata.md
@@ -1,0 +1,11 @@
+---
+skribble: patch
+---
+
+Add unresolved gating threshold metadata to unresolved report JSON output.
+
+- `--unresolved-output` reports now include threshold fields when configured:
+  - `maxUnresolved`, `maxUnresolvedExceeded`
+  - `maxNewUnresolved`, `maxNewUnresolvedExceeded`
+- Applies to both strict and threshold modes (`--fail-on-unresolved` / `--max-unresolved`, `--fail-on-new-unresolved` / `--max-new-unresolved`).
+- Update parser tests plus rough icon docs/README.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -130,6 +130,8 @@ The JSON report includes:
 - optional `newUnresolvedCount` / `newUnresolved[]` when baseline comparison is enabled
 - optional `newUnresolvedCodePoints[]` summary list (hex strings)
 - optional `resolvedSinceBaselineCount` / `resolvedSinceBaseline[]` (codepoint strings)
+- optional `maxUnresolved` / `maxUnresolvedExceeded` when unresolved threshold gating is configured
+- optional `maxNewUnresolved` / `maxNewUnresolvedExceeded` when baseline-regression threshold gating is configured
 
 ## Normalized unresolved baseline output
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -247,7 +247,7 @@ Useful flags:
 - `--rough-normalize-viewbox 128` to upscale SVG geometry before roughing.
 - `--brand-icons-source <path>` to provide a local `simple-icons` package as fallback for brand identifiers missing in Material SVG packages.
 - `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints (workspace defaults use `tool/examples/material_rough_icons.supplemental.manifest.json`).
-- `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring (includes `unresolved[]` plus `unresolvedCodePoints[]`, and baseline-diff summary arrays when enabled).
+- `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring (includes `unresolved[]` plus `unresolvedCodePoints[]`, baseline-diff summary arrays when enabled, and threshold metadata fields when unresolved gating thresholds are configured).
 - `--unresolved-baseline-output <path>` to emit a normalized unresolved baseline for regression gating (defaults to `unresolved[]`).
 - `--unresolved-baseline-output-format <unresolved|codepoints>` to choose unresolved baseline output shape (`unresolved[]` or `codePoints[]`; workspace defaults use `codepoints`).
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -472,6 +472,10 @@ class Icons {
       expect(decoded['resolvedCount'], 1);
       expect(decoded['unresolvedCount'], 1);
       expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
+      expect(decoded.containsKey('maxUnresolved'), isFalse);
+      expect(decoded.containsKey('maxUnresolvedExceeded'), isFalse);
+      expect(decoded.containsKey('maxNewUnresolved'), isFalse);
+      expect(decoded.containsKey('maxNewUnresolvedExceeded'), isFalse);
 
       final unresolved = decoded['unresolved'] as List<dynamic>;
       expect(unresolved, hasLength(1));
@@ -817,6 +821,8 @@ class Icons {
           jsonDecode(unresolvedReportFile.readAsStringSync())
               as Map<String, dynamic>;
       expect(decoded['unresolvedCount'], 1);
+      expect(decoded['maxUnresolved'], 0);
+      expect(decoded['maxUnresolvedExceeded'], isTrue);
     });
   });
 
@@ -1447,6 +1453,8 @@ class Icons {
         expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
         expect(decoded['newUnresolvedCount'], 1);
         expect(decoded['newUnresolvedCodePoints'], <String>['0xf04b9']);
+        expect(decoded['maxNewUnresolved'], 1);
+        expect(decoded['maxNewUnresolvedExceeded'], isFalse);
       },
     );
 
@@ -1520,6 +1528,8 @@ class Icons {
       expect(decoded['baselineUnresolvedCount'], 0);
       expect(decoded['newUnresolvedCount'], 1);
       expect(decoded['newUnresolvedCodePoints'], <String>['0xf04b9']);
+      expect(decoded['maxNewUnresolved'], 0);
+      expect(decoded['maxNewUnresolvedExceeded'], isTrue);
     });
 
     test('throws when unresolved icons regress against baseline', () async {
@@ -1592,6 +1602,8 @@ class Icons {
       expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
       expect(decoded['newUnresolvedCount'], 1);
       expect(decoded['newUnresolvedCodePoints'], <String>['0xf04b9']);
+      expect(decoded['maxNewUnresolved'], 0);
+      expect(decoded['maxNewUnresolvedExceeded'], isTrue);
       expect(decoded['resolvedSinceBaselineCount'], 0);
       expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
 

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -129,6 +129,12 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
           resolved.sort();
           return resolved;
         })();
+  final unresolvedThreshold = options.failOnUnresolved
+      ? 0
+      : options.maxUnresolved;
+  final newUnresolvedThreshold = options.failOnNewUnresolved
+      ? 0
+      : options.maxNewUnresolved;
 
   if (options.roughOutputDir != null) {
     await _generateRoughSvgs(options, roughTasks);
@@ -175,6 +181,8 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
         baselineUnresolvedCount: baselineUnresolvedCodePoints?.length,
         newUnresolved: newUnresolved,
         resolvedSinceBaseline: resolvedSinceBaseline,
+        unresolvedThreshold: unresolvedThreshold,
+        newUnresolvedThreshold: newUnresolvedThreshold,
       ),
     );
     stdout.writeln(
@@ -221,12 +229,8 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
     return;
   }
 
-  final failureThreshold = options.failOnUnresolved ? 0 : options.maxUnresolved;
   final thresholdFailure =
-      failureThreshold != null && unresolved.length > failureThreshold;
-  final newUnresolvedThreshold = options.failOnNewUnresolved
-      ? 0
-      : options.maxNewUnresolved;
+      unresolvedThreshold != null && unresolved.length > unresolvedThreshold;
   final newUnresolvedCount = newUnresolved?.length ?? 0;
   final newUnresolvedThresholdFailure =
       newUnresolvedThreshold != null &&
@@ -277,7 +281,7 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
   if (shouldFail) {
     final details = <String>[
       if (thresholdFailure)
-        'found ${unresolved.length}, allowed $failureThreshold',
+        'found ${unresolved.length}, allowed $unresolvedThreshold',
       if (newUnresolvedThresholdFailure)
         'new unresolved regression detected ($newUnresolvedCount, allowed $newUnresolvedThreshold)',
     ].join('; ');
@@ -1598,6 +1602,8 @@ String _renderUnresolvedReportJson({
   required int? baselineUnresolvedCount,
   required List<_UnresolvedIcon>? newUnresolved,
   required List<int>? resolvedSinceBaseline,
+  required int? unresolvedThreshold,
+  required int? newUnresolvedThreshold,
 }) {
   final report = <String, Object>{
     'kit': kit,
@@ -1605,6 +1611,10 @@ String _renderUnresolvedReportJson({
     'unresolvedCount': unresolved.length,
     'unresolved': unresolved.map(_unresolvedIconJson).toList(growable: false),
     'unresolvedCodePoints': _unresolvedCodePointsJson(unresolved),
+    if (unresolvedThreshold != null) ...<String, Object>{
+      'maxUnresolved': unresolvedThreshold,
+      'maxUnresolvedExceeded': unresolved.length > unresolvedThreshold,
+    },
     if (baselineUnresolvedCount != null) ...<String, Object>{
       'baselineUnresolvedCount': baselineUnresolvedCount,
     },
@@ -1614,6 +1624,11 @@ String _renderUnresolvedReportJson({
           .map(_unresolvedIconJson)
           .toList(growable: false),
       'newUnresolvedCodePoints': _unresolvedCodePointsJson(newUnresolved),
+    },
+    if (newUnresolvedThreshold != null) ...<String, Object>{
+      'maxNewUnresolved': newUnresolvedThreshold,
+      'maxNewUnresolvedExceeded':
+          (newUnresolved?.length ?? 0) > newUnresolvedThreshold,
     },
     if (resolvedSinceBaseline != null) ...<String, Object>{
       'resolvedSinceBaselineCount': resolvedSinceBaseline.length,


### PR DESCRIPTION
## Summary
- extend `--unresolved-output` JSON with unresolved-gate threshold metadata when thresholds are configured:
  - `maxUnresolved`, `maxUnresolvedExceeded`
  - `maxNewUnresolved`, `maxNewUnresolvedExceeded`
- include strict-mode thresholds too (`--fail-on-unresolved` / `--fail-on-new-unresolved` map to threshold `0`)
- update docs/README to document the additional unresolved report fields
- add parser test assertions covering new metadata in strict and threshold flows
- add changeset for release/docs gate

## Validation
- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md .changeset/rough-icon-unresolved-report-threshold-metadata.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
