### PR TITLE
feat: add unresolved report threshold mode metadata

### DIFF
--- a/.changeset/rough-icon-unresolved-report-threshold-modes.md
+++ b/.changeset/rough-icon-unresolved-report-threshold-modes.md
@@ -1,0 +1,11 @@
+---
+skribble: patch
+---
+
+Add unresolved gate mode metadata to unresolved report JSON output.
+
+- `--unresolved-output` now includes:
+  - `unresolvedThresholdMode` (`disabled|strict|threshold`)
+  - `newUnresolvedThresholdMode` (`disabled|strict|threshold`)
+- Keeps existing threshold fields (`maxUnresolved*`, `maxNewUnresolved*`) unchanged.
+- Adds parser test coverage for strict/threshold/disabled mode reporting and updates docs/README.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -130,6 +130,8 @@ The JSON report includes:
 - optional `newUnresolvedCount` / `newUnresolved[]` when baseline comparison is enabled
 - optional `newUnresolvedCodePoints[]` summary list (hex strings)
 - optional `resolvedSinceBaselineCount` / `resolvedSinceBaseline[]` (codepoint strings)
+- `unresolvedThresholdMode` (`disabled`, `strict`, or `threshold`)
+- `newUnresolvedThresholdMode` (`disabled`, `strict`, or `threshold`)
 - optional `maxUnresolved` / `maxUnresolvedExceeded` when unresolved threshold gating is configured
 - optional `maxNewUnresolved` / `maxNewUnresolvedExceeded` when baseline-regression threshold gating is configured
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -247,7 +247,7 @@ Useful flags:
 - `--rough-normalize-viewbox 128` to upscale SVG geometry before roughing.
 - `--brand-icons-source <path>` to provide a local `simple-icons` package as fallback for brand identifiers missing in Material SVG packages.
 - `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints (workspace defaults use `tool/examples/material_rough_icons.supplemental.manifest.json`).
-- `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring (includes `unresolved[]` plus `unresolvedCodePoints[]`, baseline-diff summary arrays when enabled, and threshold metadata fields when unresolved gating thresholds are configured).
+- `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring (includes `unresolved[]` plus `unresolvedCodePoints[]`, baseline-diff summary arrays when enabled, gate mode metadata, and threshold metadata fields when unresolved gating thresholds are configured).
 - `--unresolved-baseline-output <path>` to emit a normalized unresolved baseline for regression gating (defaults to `unresolved[]`).
 - `--unresolved-baseline-output-format <unresolved|codepoints>` to choose unresolved baseline output shape (`unresolved[]` or `codePoints[]`; workspace defaults use `codepoints`).
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -472,6 +472,8 @@ class Icons {
       expect(decoded['resolvedCount'], 1);
       expect(decoded['unresolvedCount'], 1);
       expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
+      expect(decoded['unresolvedThresholdMode'], 'disabled');
+      expect(decoded['newUnresolvedThresholdMode'], 'disabled');
       expect(decoded.containsKey('maxUnresolved'), isFalse);
       expect(decoded.containsKey('maxUnresolvedExceeded'), isFalse);
       expect(decoded.containsKey('maxNewUnresolved'), isFalse);
@@ -821,6 +823,8 @@ class Icons {
           jsonDecode(unresolvedReportFile.readAsStringSync())
               as Map<String, dynamic>;
       expect(decoded['unresolvedCount'], 1);
+      expect(decoded['unresolvedThresholdMode'], 'strict');
+      expect(decoded['newUnresolvedThresholdMode'], 'disabled');
       expect(decoded['maxUnresolved'], 0);
       expect(decoded['maxUnresolvedExceeded'], isTrue);
     });
@@ -869,6 +873,9 @@ class Icons {
       final outputFile = File(
         '${tempDirectory.path}/material_rough_icons.g.dart',
       );
+      final unresolvedReportFile = File(
+        '${tempDirectory.path}/unresolved_report.json',
+      );
 
       await tool.runGenerateRoughIcons(<String>[
         '--kit',
@@ -883,11 +890,20 @@ class Icons {
         brandIconsRoot.path,
         '--max-unresolved',
         '1',
+        '--unresolved-output',
+        unresolvedReportFile.path,
         '--output',
         outputFile.path,
       ]);
 
       expect(outputFile.existsSync(), isTrue);
+      final decoded =
+          jsonDecode(unresolvedReportFile.readAsStringSync())
+              as Map<String, dynamic>;
+      expect(decoded['maxUnresolved'], 1);
+      expect(decoded['maxUnresolvedExceeded'], isFalse);
+      expect(decoded['unresolvedThresholdMode'], 'threshold');
+      expect(decoded['newUnresolvedThresholdMode'], 'disabled');
     });
 
     test('throws when unresolved count exceeds threshold', () async {
@@ -1455,6 +1471,8 @@ class Icons {
         expect(decoded['newUnresolvedCodePoints'], <String>['0xf04b9']);
         expect(decoded['maxNewUnresolved'], 1);
         expect(decoded['maxNewUnresolvedExceeded'], isFalse);
+        expect(decoded['unresolvedThresholdMode'], 'disabled');
+        expect(decoded['newUnresolvedThresholdMode'], 'threshold');
       },
     );
 
@@ -1530,6 +1548,8 @@ class Icons {
       expect(decoded['newUnresolvedCodePoints'], <String>['0xf04b9']);
       expect(decoded['maxNewUnresolved'], 0);
       expect(decoded['maxNewUnresolvedExceeded'], isTrue);
+      expect(decoded['unresolvedThresholdMode'], 'disabled');
+      expect(decoded['newUnresolvedThresholdMode'], 'threshold');
     });
 
     test('throws when unresolved icons regress against baseline', () async {
@@ -1604,6 +1624,8 @@ class Icons {
       expect(decoded['newUnresolvedCodePoints'], <String>['0xf04b9']);
       expect(decoded['maxNewUnresolved'], 0);
       expect(decoded['maxNewUnresolvedExceeded'], isTrue);
+      expect(decoded['unresolvedThresholdMode'], 'disabled');
+      expect(decoded['newUnresolvedThresholdMode'], 'strict');
       expect(decoded['resolvedSinceBaselineCount'], 0);
       expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
 

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -135,6 +135,14 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
   final newUnresolvedThreshold = options.failOnNewUnresolved
       ? 0
       : options.maxNewUnresolved;
+  final unresolvedThresholdMode = _resolveThresholdMode(
+    strictModeEnabled: options.failOnUnresolved,
+    thresholdOption: options.maxUnresolved,
+  );
+  final newUnresolvedThresholdMode = _resolveThresholdMode(
+    strictModeEnabled: options.failOnNewUnresolved,
+    thresholdOption: options.maxNewUnresolved,
+  );
 
   if (options.roughOutputDir != null) {
     await _generateRoughSvgs(options, roughTasks);
@@ -183,6 +191,8 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
         resolvedSinceBaseline: resolvedSinceBaseline,
         unresolvedThreshold: unresolvedThreshold,
         newUnresolvedThreshold: newUnresolvedThreshold,
+        unresolvedThresholdMode: unresolvedThresholdMode,
+        newUnresolvedThresholdMode: newUnresolvedThresholdMode,
       ),
     );
     stdout.writeln(
@@ -1595,6 +1605,19 @@ int _parseCodePointString(String value, {required String context}) {
   }
 }
 
+String _resolveThresholdMode({
+  required bool strictModeEnabled,
+  required int? thresholdOption,
+}) {
+  if (strictModeEnabled) {
+    return 'strict';
+  }
+  if (thresholdOption != null) {
+    return 'threshold';
+  }
+  return 'disabled';
+}
+
 String _renderUnresolvedReportJson({
   required String kit,
   required int resolvedCount,
@@ -1604,6 +1627,8 @@ String _renderUnresolvedReportJson({
   required List<int>? resolvedSinceBaseline,
   required int? unresolvedThreshold,
   required int? newUnresolvedThreshold,
+  required String unresolvedThresholdMode,
+  required String newUnresolvedThresholdMode,
 }) {
   final report = <String, Object>{
     'kit': kit,
@@ -1611,6 +1636,8 @@ String _renderUnresolvedReportJson({
     'unresolvedCount': unresolved.length,
     'unresolved': unresolved.map(_unresolvedIconJson).toList(growable: false),
     'unresolvedCodePoints': _unresolvedCodePointsJson(unresolved),
+    'unresolvedThresholdMode': unresolvedThresholdMode,
+    'newUnresolvedThresholdMode': newUnresolvedThresholdMode,
     if (unresolvedThreshold != null) ...<String, Object>{
       'maxUnresolved': unresolvedThreshold,
       'maxUnresolvedExceeded': unresolved.length > unresolvedThreshold,


### PR DESCRIPTION
## Summary
- extend `--unresolved-output` JSON with explicit gate mode fields:
  - `unresolvedThresholdMode` (`disabled|strict|threshold`)
  - `newUnresolvedThresholdMode` (`disabled|strict|threshold`)
- keep existing threshold fields (`maxUnresolved*`, `maxNewUnresolved*`) unchanged
- include mode metadata for strict (`--fail-on-*`) and threshold (`--max-*`) gating so consumers can distinguish strict mode from threshold mode even when threshold value is `0`
- update rough icon docs/README and parser tests for new report fields
- add changeset for release/docs gate

## Validation
- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md .changeset/rough-icon-unresolved-report-threshold-modes.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
