### PR TITLE
feat: add unresolved report would-fail summary

### DIFF
--- a/.changeset/rough-icon-unresolved-report-would-fail.md
+++ b/.changeset/rough-icon-unresolved-report-would-fail.md
@@ -1,0 +1,9 @@
+---
+skribble: patch
+---
+
+Add a `wouldFail` summary field to unresolved report JSON output.
+
+- `--unresolved-output` now includes `wouldFail`, indicating whether configured unresolved gates would fail the current run.
+- Works with both unresolved thresholds and baseline-regression thresholds.
+- Update rough icon docs/README and parser test coverage.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -124,6 +124,7 @@ The JSON report includes:
 - `kit`
 - `resolvedCount`
 - `unresolvedCount`
+- `wouldFail` (whether configured unresolved gates would fail this run)
 - `unresolved[]` entries with `codePoint` and `identifiers`
 - `unresolvedCodePoints[]` summary list (hex strings)
 - optional `baselineUnresolvedCount`

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -247,7 +247,7 @@ Useful flags:
 - `--rough-normalize-viewbox 128` to upscale SVG geometry before roughing.
 - `--brand-icons-source <path>` to provide a local `simple-icons` package as fallback for brand identifiers missing in Material SVG packages.
 - `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints (workspace defaults use `tool/examples/material_rough_icons.supplemental.manifest.json`).
-- `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring (includes `unresolved[]` plus `unresolvedCodePoints[]`, baseline-diff summary arrays when enabled, gate mode metadata, and threshold metadata fields when unresolved gating thresholds are configured).
+- `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring (includes `unresolved[]` plus `unresolvedCodePoints[]`, baseline-diff summary arrays when enabled, gate mode metadata, threshold metadata fields when unresolved gating thresholds are configured, and a `wouldFail` summary boolean for configured gates).
 - `--unresolved-baseline-output <path>` to emit a normalized unresolved baseline for regression gating (defaults to `unresolved[]`).
 - `--unresolved-baseline-output-format <unresolved|codepoints>` to choose unresolved baseline output shape (`unresolved[]` or `codePoints[]`; workspace defaults use `codepoints`).
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -471,6 +471,7 @@ class Icons {
       expect(decoded['kit'], 'flutter-material');
       expect(decoded['resolvedCount'], 1);
       expect(decoded['unresolvedCount'], 1);
+      expect(decoded['wouldFail'], isFalse);
       expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
       expect(decoded['unresolvedThresholdMode'], 'disabled');
       expect(decoded['newUnresolvedThresholdMode'], 'disabled');
@@ -823,6 +824,7 @@ class Icons {
           jsonDecode(unresolvedReportFile.readAsStringSync())
               as Map<String, dynamic>;
       expect(decoded['unresolvedCount'], 1);
+      expect(decoded['wouldFail'], isTrue);
       expect(decoded['unresolvedThresholdMode'], 'strict');
       expect(decoded['newUnresolvedThresholdMode'], 'disabled');
       expect(decoded['maxUnresolved'], 0);
@@ -902,6 +904,7 @@ class Icons {
               as Map<String, dynamic>;
       expect(decoded['maxUnresolved'], 1);
       expect(decoded['maxUnresolvedExceeded'], isFalse);
+      expect(decoded['wouldFail'], isFalse);
       expect(decoded['unresolvedThresholdMode'], 'threshold');
       expect(decoded['newUnresolvedThresholdMode'], 'disabled');
     });
@@ -1469,6 +1472,7 @@ class Icons {
         expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
         expect(decoded['newUnresolvedCount'], 1);
         expect(decoded['newUnresolvedCodePoints'], <String>['0xf04b9']);
+        expect(decoded['wouldFail'], isFalse);
         expect(decoded['maxNewUnresolved'], 1);
         expect(decoded['maxNewUnresolvedExceeded'], isFalse);
         expect(decoded['unresolvedThresholdMode'], 'disabled');
@@ -1546,6 +1550,7 @@ class Icons {
       expect(decoded['baselineUnresolvedCount'], 0);
       expect(decoded['newUnresolvedCount'], 1);
       expect(decoded['newUnresolvedCodePoints'], <String>['0xf04b9']);
+      expect(decoded['wouldFail'], isTrue);
       expect(decoded['maxNewUnresolved'], 0);
       expect(decoded['maxNewUnresolvedExceeded'], isTrue);
       expect(decoded['unresolvedThresholdMode'], 'disabled');
@@ -1622,6 +1627,7 @@ class Icons {
       expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
       expect(decoded['newUnresolvedCount'], 1);
       expect(decoded['newUnresolvedCodePoints'], <String>['0xf04b9']);
+      expect(decoded['wouldFail'], isTrue);
       expect(decoded['maxNewUnresolved'], 0);
       expect(decoded['maxNewUnresolvedExceeded'], isTrue);
       expect(decoded['unresolvedThresholdMode'], 'disabled');

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -143,6 +143,13 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
     strictModeEnabled: options.failOnNewUnresolved,
     thresholdOption: options.maxNewUnresolved,
   );
+  final thresholdFailure =
+      unresolvedThreshold != null && unresolved.length > unresolvedThreshold;
+  final newUnresolvedCount = newUnresolved?.length ?? 0;
+  final newUnresolvedThresholdFailure =
+      newUnresolvedThreshold != null &&
+      newUnresolvedCount > newUnresolvedThreshold;
+  final shouldFail = thresholdFailure || newUnresolvedThresholdFailure;
 
   if (options.roughOutputDir != null) {
     await _generateRoughSvgs(options, roughTasks);
@@ -193,6 +200,7 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
         newUnresolvedThreshold: newUnresolvedThreshold,
         unresolvedThresholdMode: unresolvedThresholdMode,
         newUnresolvedThresholdMode: newUnresolvedThresholdMode,
+        wouldFail: shouldFail,
       ),
     );
     stdout.writeln(
@@ -238,14 +246,6 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
   if (unresolved.isEmpty) {
     return;
   }
-
-  final thresholdFailure =
-      unresolvedThreshold != null && unresolved.length > unresolvedThreshold;
-  final newUnresolvedCount = newUnresolved?.length ?? 0;
-  final newUnresolvedThresholdFailure =
-      newUnresolvedThreshold != null &&
-      newUnresolvedCount > newUnresolvedThreshold;
-  final shouldFail = thresholdFailure || newUnresolvedThresholdFailure;
 
   final severityLabel = shouldFail ? 'Error' : 'Warning';
   stderr.writeln(
@@ -1629,11 +1629,13 @@ String _renderUnresolvedReportJson({
   required int? newUnresolvedThreshold,
   required String unresolvedThresholdMode,
   required String newUnresolvedThresholdMode,
+  required bool wouldFail,
 }) {
   final report = <String, Object>{
     'kit': kit,
     'resolvedCount': resolvedCount,
     'unresolvedCount': unresolved.length,
+    'wouldFail': wouldFail,
     'unresolved': unresolved.map(_unresolvedIconJson).toList(growable: false),
     'unresolvedCodePoints': _unresolvedCodePointsJson(unresolved),
     'unresolvedThresholdMode': unresolvedThresholdMode,


### PR DESCRIPTION
## Summary
- add `wouldFail` to `--unresolved-output` JSON to summarize whether configured unresolved gates would fail the run
- compute threshold failure state once and reuse it for both report output and final throw decision
- keep existing detailed gate metadata unchanged (`unresolvedThresholdMode`, `newUnresolvedThresholdMode`, `maxUnresolved*`, `maxNewUnresolved*`)
- add parser test assertions for `wouldFail` across disabled, strict, and threshold gate scenarios
- document `wouldFail` in rough icon pipeline docs and package README
- add changeset for release/docs gate

## Validation
- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md .changeset/rough-icon-unresolved-report-would-fail.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
