### PR TITLE
feat: add per-gate unresolved report failure booleans

### DIFF
--- a/.changeset/rough-icon-unresolved-report-gate-failures.md
+++ b/.changeset/rough-icon-unresolved-report-gate-failures.md
@@ -1,0 +1,9 @@
+---
+skribble: patch
+---
+
+Add per-gate failure booleans to rough icon unresolved report JSON.
+
+- `--unresolved-output` now includes `unresolvedGateFailed` and `newUnresolvedGateFailed`.
+- The existing `wouldFail` field remains as the aggregate failure summary.
+- Update parser tests and rough icon docs/README.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -125,6 +125,7 @@ The JSON report includes:
 - `resolvedCount`
 - `unresolvedCount`
 - `wouldFail` (whether configured unresolved gates would fail this run)
+- `unresolvedGateFailed` / `newUnresolvedGateFailed` (per-gate failure booleans)
 - `unresolved[]` entries with `codePoint` and `identifiers`
 - `unresolvedCodePoints[]` summary list (hex strings)
 - optional `baselineUnresolvedCount`

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -247,7 +247,7 @@ Useful flags:
 - `--rough-normalize-viewbox 128` to upscale SVG geometry before roughing.
 - `--brand-icons-source <path>` to provide a local `simple-icons` package as fallback for brand identifiers missing in Material SVG packages.
 - `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints (workspace defaults use `tool/examples/material_rough_icons.supplemental.manifest.json`).
-- `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring (includes `unresolved[]` plus `unresolvedCodePoints[]`, baseline-diff summary arrays when enabled, gate mode metadata, threshold metadata fields when unresolved gating thresholds are configured, and a `wouldFail` summary boolean for configured gates).
+- `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring (includes `unresolved[]` plus `unresolvedCodePoints[]`, baseline-diff summary arrays when enabled, gate mode metadata, threshold metadata fields when unresolved gating thresholds are configured, a `wouldFail` summary boolean, and per-gate failure booleans).
 - `--unresolved-baseline-output <path>` to emit a normalized unresolved baseline for regression gating (defaults to `unresolved[]`).
 - `--unresolved-baseline-output-format <unresolved|codepoints>` to choose unresolved baseline output shape (`unresolved[]` or `codePoints[]`; workspace defaults use `codepoints`).
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -472,6 +472,8 @@ class Icons {
       expect(decoded['resolvedCount'], 1);
       expect(decoded['unresolvedCount'], 1);
       expect(decoded['wouldFail'], isFalse);
+      expect(decoded['unresolvedGateFailed'], isFalse);
+      expect(decoded['newUnresolvedGateFailed'], isFalse);
       expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
       expect(decoded['unresolvedThresholdMode'], 'disabled');
       expect(decoded['newUnresolvedThresholdMode'], 'disabled');
@@ -825,6 +827,8 @@ class Icons {
               as Map<String, dynamic>;
       expect(decoded['unresolvedCount'], 1);
       expect(decoded['wouldFail'], isTrue);
+      expect(decoded['unresolvedGateFailed'], isTrue);
+      expect(decoded['newUnresolvedGateFailed'], isFalse);
       expect(decoded['unresolvedThresholdMode'], 'strict');
       expect(decoded['newUnresolvedThresholdMode'], 'disabled');
       expect(decoded['maxUnresolved'], 0);
@@ -905,6 +909,8 @@ class Icons {
       expect(decoded['maxUnresolved'], 1);
       expect(decoded['maxUnresolvedExceeded'], isFalse);
       expect(decoded['wouldFail'], isFalse);
+      expect(decoded['unresolvedGateFailed'], isFalse);
+      expect(decoded['newUnresolvedGateFailed'], isFalse);
       expect(decoded['unresolvedThresholdMode'], 'threshold');
       expect(decoded['newUnresolvedThresholdMode'], 'disabled');
     });
@@ -1473,6 +1479,8 @@ class Icons {
         expect(decoded['newUnresolvedCount'], 1);
         expect(decoded['newUnresolvedCodePoints'], <String>['0xf04b9']);
         expect(decoded['wouldFail'], isFalse);
+        expect(decoded['unresolvedGateFailed'], isFalse);
+        expect(decoded['newUnresolvedGateFailed'], isFalse);
         expect(decoded['maxNewUnresolved'], 1);
         expect(decoded['maxNewUnresolvedExceeded'], isFalse);
         expect(decoded['unresolvedThresholdMode'], 'disabled');
@@ -1551,6 +1559,8 @@ class Icons {
       expect(decoded['newUnresolvedCount'], 1);
       expect(decoded['newUnresolvedCodePoints'], <String>['0xf04b9']);
       expect(decoded['wouldFail'], isTrue);
+      expect(decoded['unresolvedGateFailed'], isFalse);
+      expect(decoded['newUnresolvedGateFailed'], isTrue);
       expect(decoded['maxNewUnresolved'], 0);
       expect(decoded['maxNewUnresolvedExceeded'], isTrue);
       expect(decoded['unresolvedThresholdMode'], 'disabled');
@@ -1628,6 +1638,8 @@ class Icons {
       expect(decoded['newUnresolvedCount'], 1);
       expect(decoded['newUnresolvedCodePoints'], <String>['0xf04b9']);
       expect(decoded['wouldFail'], isTrue);
+      expect(decoded['unresolvedGateFailed'], isFalse);
+      expect(decoded['newUnresolvedGateFailed'], isTrue);
       expect(decoded['maxNewUnresolved'], 0);
       expect(decoded['maxNewUnresolvedExceeded'], isTrue);
       expect(decoded['unresolvedThresholdMode'], 'disabled');

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -200,6 +200,8 @@ Future<void> runGenerateRoughIcons(List<String> args) async {
         newUnresolvedThreshold: newUnresolvedThreshold,
         unresolvedThresholdMode: unresolvedThresholdMode,
         newUnresolvedThresholdMode: newUnresolvedThresholdMode,
+        unresolvedGateFailed: thresholdFailure,
+        newUnresolvedGateFailed: newUnresolvedThresholdFailure,
         wouldFail: shouldFail,
       ),
     );
@@ -1629,6 +1631,8 @@ String _renderUnresolvedReportJson({
   required int? newUnresolvedThreshold,
   required String unresolvedThresholdMode,
   required String newUnresolvedThresholdMode,
+  required bool unresolvedGateFailed,
+  required bool newUnresolvedGateFailed,
   required bool wouldFail,
 }) {
   final report = <String, Object>{
@@ -1636,6 +1640,8 @@ String _renderUnresolvedReportJson({
     'resolvedCount': resolvedCount,
     'unresolvedCount': unresolved.length,
     'wouldFail': wouldFail,
+    'unresolvedGateFailed': unresolvedGateFailed,
+    'newUnresolvedGateFailed': newUnresolvedGateFailed,
     'unresolved': unresolved.map(_unresolvedIconJson).toList(growable: false),
     'unresolvedCodePoints': _unresolvedCodePointsJson(unresolved),
     'unresolvedThresholdMode': unresolvedThresholdMode,


### PR DESCRIPTION
## Summary
- extend rough icon unresolved report JSON with per-gate failure booleans:
  - `unresolvedGateFailed`
  - `newUnresolvedGateFailed`
- keep existing aggregate `wouldFail` field unchanged
- wire gate booleans from the same threshold calculations already used for fail/pass behavior
- add parser-test assertions across disabled, strict, and threshold gate scenarios
- document the new report fields in rough icon pipeline docs and package README
- add a changeset for release/docs gate compliance

## Validation
- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md .changeset/rough-icon-unresolved-report-gate-failures.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
