### PR TITLE
feat: default rough icon CI script to threshold mode

### DIFF
--- a/.changeset/rough-icon-ci-threshold-default-zero.md
+++ b/.changeset/rough-icon-ci-threshold-default-zero.md
@@ -1,0 +1,9 @@
+---
+skribble: patch
+---
+
+Default `scripts/check_rough_icons_ci.sh` to threshold gating mode with a strict-equivalent value.
+
+- Regression and generated-sync checks now default to `--max-new-unresolved 0` when `ROUGH_ICONS_MAX_NEW_UNRESOLVED` is unset.
+- This keeps local script behavior aligned with CI/workspace threshold conventions.
+- Docs and README were updated to reflect the new default.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -219,13 +219,12 @@ On sync-check failures, the script prints `git diff` output and saves it to:
 
 `regression` cleans up `packages/skribble/unresolved-report.json` after a
 successful local run. Set `ROUGH_ICONS_KEEP_UNRESOLVED_REPORT=1` to keep it.
-Set `ROUGH_ICONS_MAX_NEW_UNRESOLVED=<int>` to use threshold mode for
-regression/generated-sync checks (`--max-new-unresolved`) instead of strict
-mode (`--fail-on-new-unresolved`).
+By default, regression/generated-sync checks use
+`--max-new-unresolved 0` (strict-mode equivalent). Set
+`ROUGH_ICONS_MAX_NEW_UNRESOLVED=<int>` to relax or tighten that threshold.
 
-Pull-request CI sets `ROUGH_ICONS_MAX_NEW_UNRESOLVED=0` for those checks,
-which is equivalent to strict mode while keeping one configurable threshold
-knob in workflow configuration.
+Pull-request CI explicitly sets `ROUGH_ICONS_MAX_NEW_UNRESOLVED=0` for those
+checks to keep the workflow configuration aligned with local defaults.
 
 CI also enforces the same unresolved regression gate on pull requests using
 `--rough-only`, `--supplemental-manifest`, and `--unresolved-baseline`, and

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -224,13 +224,12 @@ On sync-check failures, the script prints `git diff` output and writes:
 
 `regression` cleans up `packages/skribble/unresolved-report.json` after a
 successful local run. Set `ROUGH_ICONS_KEEP_UNRESOLVED_REPORT=1` to keep it.
-Set `ROUGH_ICONS_MAX_NEW_UNRESOLVED=<int>` to run regression/generated-sync
-checks in threshold mode (`--max-new-unresolved`) instead of strict mode
-(`--fail-on-new-unresolved`).
+By default, regression/generated-sync checks use
+`--max-new-unresolved 0` (strict-mode equivalent). Set
+`ROUGH_ICONS_MAX_NEW_UNRESOLVED=<int>` to relax or tighten that threshold.
 
-Pull-request CI sets `ROUGH_ICONS_MAX_NEW_UNRESOLVED=0` for those checks,
-which is strict-mode equivalent and keeps one threshold control in workflow
-configuration.
+Pull-request CI explicitly sets `ROUGH_ICONS_MAX_NEW_UNRESOLVED=0` for those
+checks to keep workflow configuration aligned with local defaults.
 
 Pull-request CI also runs the unresolved gate in `--rough-only` mode, uploads a
 `rough-icons-unresolved-report` artifact for diagnostics, verifies the

--- a/scripts/check_rough_icons_ci.sh
+++ b/scripts/check_rough_icons_ci.sh
@@ -9,7 +9,7 @@
 #                                         successful local regression checks.
 #   ROUGH_ICONS_MAX_NEW_UNRESOLVED=<int>  Allow up to this many newly unresolved
 #                                         baseline regressions before failing
-#                                         (default: strict fail-on-new-unresolved).
+#                                         (default: 0 / strict-equivalent threshold).
 
 set -euo pipefail
 
@@ -47,13 +47,7 @@ emit_sync_diff_if_needed() {
 }
 
 build_baseline_regression_args() {
-  local max_new_unresolved="${ROUGH_ICONS_MAX_NEW_UNRESOLVED:-}"
-
-  if [[ -z "$max_new_unresolved" ]]; then
-    BASELINE_REGRESSION_ARGS=(--fail-on-new-unresolved)
-    BASELINE_REGRESSION_MODE_DESCRIPTION="strict (--fail-on-new-unresolved)"
-    return 0
-  fi
+  local max_new_unresolved="${ROUGH_ICONS_MAX_NEW_UNRESOLVED:-0}"
 
   if [[ ! "$max_new_unresolved" =~ ^[0-9]+$ ]]; then
     echo "ROUGH_ICONS_MAX_NEW_UNRESOLVED must be a non-negative integer." >&2


### PR DESCRIPTION
## Summary
- change `scripts/check_rough_icons_ci.sh` to default unresolved baseline regression gating to threshold mode with `--max-new-unresolved 0`
- remove the script's strict-mode default (`--fail-on-new-unresolved`) when `ROUGH_ICONS_MAX_NEW_UNRESOLVED` is unset
- keep `ROUGH_ICONS_MAX_NEW_UNRESOLVED=<int>` as the override knob for relaxing/tightening threshold behavior
- update rough icon pipeline docs and package README to reflect the new default and local/CI alignment
- add a changeset for release/docs gate compliance

## Validation
- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md .changeset/rough-icon-ci-threshold-default-zero.md`
- `bash -n scripts/check_rough_icons_ci.sh`
- `ROUGH_ICONS_KEEP_UNRESOLVED_REPORT=1 ./scripts/check_rough_icons_ci.sh regression`
