### PR TITLE
feat: add unresolved report failed-gates summary list

### DIFF
--- a/.changeset/rough-icon-unresolved-report-failed-gates-list.md
+++ b/.changeset/rough-icon-unresolved-report-failed-gates-list.md
@@ -1,0 +1,9 @@
+---
+skribble: patch
+---
+
+Add `failedGates` to rough icon unresolved report JSON.
+
+- `--unresolved-output` now includes `failedGates[]`, listing which configured gates failed (`unresolved`, `newUnresolved`).
+- Existing booleans (`wouldFail`, `unresolvedGateFailed`, `newUnresolvedGateFailed`) remain unchanged.
+- Adds parser coverage for single-gate and dual-gate failure scenarios.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -126,6 +126,7 @@ The JSON report includes:
 - `unresolvedCount`
 - `wouldFail` (whether configured unresolved gates would fail this run)
 - `unresolvedGateFailed` / `newUnresolvedGateFailed` (per-gate failure booleans)
+- `failedGates[]` summary list (`unresolved`, `newUnresolved`) for gates that failed
 - `unresolved[]` entries with `codePoint` and `identifiers`
 - `unresolvedCodePoints[]` summary list (hex strings)
 - optional `baselineUnresolvedCount`

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -246,7 +246,7 @@ Useful flags:
 - `--rough-normalize-viewbox 128` to upscale SVG geometry before roughing.
 - `--brand-icons-source <path>` to provide a local `simple-icons` package as fallback for brand identifiers missing in Material SVG packages.
 - `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints (workspace defaults use `tool/examples/material_rough_icons.supplemental.manifest.json`).
-- `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring (includes `unresolved[]` plus `unresolvedCodePoints[]`, baseline-diff summary arrays when enabled, gate mode metadata, threshold metadata fields when unresolved gating thresholds are configured, a `wouldFail` summary boolean, and per-gate failure booleans).
+- `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring (includes `unresolved[]` plus `unresolvedCodePoints[]`, baseline-diff summary arrays when enabled, gate mode metadata, threshold metadata fields when unresolved gating thresholds are configured, a `wouldFail` summary boolean, per-gate failure booleans, and a `failedGates[]` summary list).
 - `--unresolved-baseline-output <path>` to emit a normalized unresolved baseline for regression gating (defaults to `unresolved[]`).
 - `--unresolved-baseline-output-format <unresolved|codepoints>` to choose unresolved baseline output shape (`unresolved[]` or `codePoints[]`; workspace defaults use `codepoints`).
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -474,6 +474,7 @@ class Icons {
       expect(decoded['wouldFail'], isFalse);
       expect(decoded['unresolvedGateFailed'], isFalse);
       expect(decoded['newUnresolvedGateFailed'], isFalse);
+      expect(decoded['failedGates'], <String>[]);
       expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
       expect(decoded['unresolvedThresholdMode'], 'disabled');
       expect(decoded['newUnresolvedThresholdMode'], 'disabled');
@@ -829,6 +830,7 @@ class Icons {
       expect(decoded['wouldFail'], isTrue);
       expect(decoded['unresolvedGateFailed'], isTrue);
       expect(decoded['newUnresolvedGateFailed'], isFalse);
+      expect(decoded['failedGates'], <String>['unresolved']);
       expect(decoded['unresolvedThresholdMode'], 'strict');
       expect(decoded['newUnresolvedThresholdMode'], 'disabled');
       expect(decoded['maxUnresolved'], 0);
@@ -911,6 +913,7 @@ class Icons {
       expect(decoded['wouldFail'], isFalse);
       expect(decoded['unresolvedGateFailed'], isFalse);
       expect(decoded['newUnresolvedGateFailed'], isFalse);
+      expect(decoded['failedGates'], <String>[]);
       expect(decoded['unresolvedThresholdMode'], 'threshold');
       expect(decoded['newUnresolvedThresholdMode'], 'disabled');
     });
@@ -1481,6 +1484,7 @@ class Icons {
         expect(decoded['wouldFail'], isFalse);
         expect(decoded['unresolvedGateFailed'], isFalse);
         expect(decoded['newUnresolvedGateFailed'], isFalse);
+        expect(decoded['failedGates'], <String>[]);
         expect(decoded['maxNewUnresolved'], 1);
         expect(decoded['maxNewUnresolvedExceeded'], isFalse);
         expect(decoded['unresolvedThresholdMode'], 'disabled');
@@ -1561,11 +1565,94 @@ class Icons {
       expect(decoded['wouldFail'], isTrue);
       expect(decoded['unresolvedGateFailed'], isFalse);
       expect(decoded['newUnresolvedGateFailed'], isTrue);
+      expect(decoded['failedGates'], <String>['newUnresolved']);
       expect(decoded['maxNewUnresolved'], 0);
       expect(decoded['maxNewUnresolvedExceeded'], isTrue);
       expect(decoded['unresolvedThresholdMode'], 'disabled');
       expect(decoded['newUnresolvedThresholdMode'], 'threshold');
     });
+
+    test(
+      'reports both failed gates when both thresholds are exceeded',
+      () async {
+        final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+          ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+        final materialIconsRoot = Directory(
+          '${tempDirectory.path}/material-icons',
+        )..createSync(recursive: true);
+        final materialSymbolsRoot = Directory(
+          '${tempDirectory.path}/material-symbols',
+        )..createSync(recursive: true);
+        final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+          ..createSync(recursive: true);
+
+        File('${materialIconsRoot.path}/filled/label.svg')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+          );
+
+        final baselineFile = File('${tempDirectory.path}/baseline-empty.json')
+          ..writeAsStringSync('''
+{
+  "unresolved": []
+}
+''');
+        final unresolvedReportFile = File(
+          '${tempDirectory.path}/unresolved_report.json',
+        );
+        final outputFile = File(
+          '${tempDirectory.path}/material_rough_icons.g.dart',
+        );
+
+        await expectLater(
+          tool.runGenerateRoughIcons(<String>[
+            '--kit',
+            'flutter-material',
+            '--flutter-icons',
+            flutterIconsFile.path,
+            '--material-icons-source',
+            materialIconsRoot.path,
+            '--material-symbols-source',
+            materialSymbolsRoot.path,
+            '--brand-icons-source',
+            brandIconsRoot.path,
+            '--unresolved-baseline',
+            baselineFile.path,
+            '--max-unresolved',
+            '0',
+            '--max-new-unresolved',
+            '0',
+            '--unresolved-output',
+            unresolvedReportFile.path,
+            '--output',
+            outputFile.path,
+          ]),
+          throwsA(isA<StateError>()),
+        );
+
+        final decoded =
+            jsonDecode(unresolvedReportFile.readAsStringSync())
+                as Map<String, dynamic>;
+        expect(decoded['wouldFail'], isTrue);
+        expect(decoded['unresolvedGateFailed'], isTrue);
+        expect(decoded['newUnresolvedGateFailed'], isTrue);
+        expect(decoded['failedGates'], <String>['unresolved', 'newUnresolved']);
+        expect(decoded['maxUnresolvedExceeded'], isTrue);
+        expect(decoded['maxNewUnresolvedExceeded'], isTrue);
+        expect(decoded['unresolvedThresholdMode'], 'threshold');
+        expect(decoded['newUnresolvedThresholdMode'], 'threshold');
+      },
+    );
 
     test('throws when unresolved icons regress against baseline', () async {
       final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
@@ -1640,6 +1727,7 @@ class Icons {
       expect(decoded['wouldFail'], isTrue);
       expect(decoded['unresolvedGateFailed'], isFalse);
       expect(decoded['newUnresolvedGateFailed'], isTrue);
+      expect(decoded['failedGates'], <String>['newUnresolved']);
       expect(decoded['maxNewUnresolved'], 0);
       expect(decoded['maxNewUnresolvedExceeded'], isTrue);
       expect(decoded['unresolvedThresholdMode'], 'disabled');

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -1635,6 +1635,11 @@ String _renderUnresolvedReportJson({
   required bool newUnresolvedGateFailed,
   required bool wouldFail,
 }) {
+  final failedGates = <String>[
+    if (unresolvedGateFailed) 'unresolved',
+    if (newUnresolvedGateFailed) 'newUnresolved',
+  ];
+
   final report = <String, Object>{
     'kit': kit,
     'resolvedCount': resolvedCount,
@@ -1642,6 +1647,7 @@ String _renderUnresolvedReportJson({
     'wouldFail': wouldFail,
     'unresolvedGateFailed': unresolvedGateFailed,
     'newUnresolvedGateFailed': newUnresolvedGateFailed,
+    'failedGates': failedGates,
     'unresolved': unresolved.map(_unresolvedIconJson).toList(growable: false),
     'unresolvedCodePoints': _unresolvedCodePointsJson(unresolved),
     'unresolvedThresholdMode': unresolvedThresholdMode,


### PR DESCRIPTION
## Summary
- extend rough icon unresolved report JSON with `failedGates[]`, a compact summary list of which configured gates failed:
  - `unresolved`
  - `newUnresolved`
- keep existing booleans (`wouldFail`, `unresolvedGateFailed`, `newUnresolvedGateFailed`) unchanged
- add parser coverage for:
  - no gate failures (`failedGates: []`)
  - unresolved gate failure (`['unresolved']`)
  - new-unresolved gate failure (`['newUnresolved']`)
  - dual gate failures when both thresholds are exceeded (`['unresolved', 'newUnresolved']`)
- document the new field in rough icon pipeline docs and package README
- add a changeset for release/docs gate compliance

## Validation
- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md .changeset/rough-icon-unresolved-report-failed-gates-list.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
