### PR TITLE
feat: add unresolved report active-gates summary

### DIFF
--- a/.changeset/rough-icon-unresolved-report-active-gates-list.md
+++ b/.changeset/rough-icon-unresolved-report-active-gates-list.md
@@ -1,0 +1,9 @@
+---
+skribble: patch
+---
+
+Add `activeGates` to rough icon unresolved report JSON.
+
+- `--unresolved-output` now includes `activeGates[]`, listing which unresolved gates are configured (`unresolved`, `newUnresolved`).
+- `failedGates[]` continues to report only gates that actually failed.
+- Adds parser coverage for inactive, single-gate, and dual-gate configurations.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -126,6 +126,7 @@ The JSON report includes:
 - `unresolvedCount`
 - `wouldFail` (whether configured unresolved gates would fail this run)
 - `unresolvedGateFailed` / `newUnresolvedGateFailed` (per-gate failure booleans)
+- `activeGates[]` summary list (`unresolved`, `newUnresolved`) for configured/enabled gates
 - `failedGates[]` summary list (`unresolved`, `newUnresolved`) for gates that failed
 - `unresolved[]` entries with `codePoint` and `identifiers`
 - `unresolvedCodePoints[]` summary list (hex strings)

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -246,7 +246,7 @@ Useful flags:
 - `--rough-normalize-viewbox 128` to upscale SVG geometry before roughing.
 - `--brand-icons-source <path>` to provide a local `simple-icons` package as fallback for brand identifiers missing in Material SVG packages.
 - `--supplemental-manifest <path>` to provide custom SVGs for unresolved `flutter-material` identifiers/codepoints (workspace defaults use `tool/examples/material_rough_icons.supplemental.manifest.json`).
-- `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring (includes `unresolved[]` plus `unresolvedCodePoints[]`, baseline-diff summary arrays when enabled, gate mode metadata, threshold metadata fields when unresolved gating thresholds are configured, a `wouldFail` summary boolean, per-gate failure booleans, and a `failedGates[]` summary list).
+- `--unresolved-output <path>` to emit unresolved icon codepoints/identifiers as JSON for follow-up manifest authoring (includes `unresolved[]` plus `unresolvedCodePoints[]`, baseline-diff summary arrays when enabled, gate mode metadata, threshold metadata fields when unresolved gating thresholds are configured, a `wouldFail` summary boolean, per-gate failure booleans, an `activeGates[]` configured-gates summary list, and a `failedGates[]` summary list).
 - `--unresolved-baseline-output <path>` to emit a normalized unresolved baseline for regression gating (defaults to `unresolved[]`).
 - `--unresolved-baseline-output-format <unresolved|codepoints>` to choose unresolved baseline output shape (`unresolved[]` or `codePoints[]`; workspace defaults use `codepoints`).
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -474,6 +474,7 @@ class Icons {
       expect(decoded['wouldFail'], isFalse);
       expect(decoded['unresolvedGateFailed'], isFalse);
       expect(decoded['newUnresolvedGateFailed'], isFalse);
+      expect(decoded['activeGates'], <String>[]);
       expect(decoded['failedGates'], <String>[]);
       expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
       expect(decoded['unresolvedThresholdMode'], 'disabled');
@@ -830,6 +831,7 @@ class Icons {
       expect(decoded['wouldFail'], isTrue);
       expect(decoded['unresolvedGateFailed'], isTrue);
       expect(decoded['newUnresolvedGateFailed'], isFalse);
+      expect(decoded['activeGates'], <String>['unresolved']);
       expect(decoded['failedGates'], <String>['unresolved']);
       expect(decoded['unresolvedThresholdMode'], 'strict');
       expect(decoded['newUnresolvedThresholdMode'], 'disabled');
@@ -913,6 +915,7 @@ class Icons {
       expect(decoded['wouldFail'], isFalse);
       expect(decoded['unresolvedGateFailed'], isFalse);
       expect(decoded['newUnresolvedGateFailed'], isFalse);
+      expect(decoded['activeGates'], <String>['unresolved']);
       expect(decoded['failedGates'], <String>[]);
       expect(decoded['unresolvedThresholdMode'], 'threshold');
       expect(decoded['newUnresolvedThresholdMode'], 'disabled');
@@ -1484,6 +1487,7 @@ class Icons {
         expect(decoded['wouldFail'], isFalse);
         expect(decoded['unresolvedGateFailed'], isFalse);
         expect(decoded['newUnresolvedGateFailed'], isFalse);
+        expect(decoded['activeGates'], <String>['newUnresolved']);
         expect(decoded['failedGates'], <String>[]);
         expect(decoded['maxNewUnresolved'], 1);
         expect(decoded['maxNewUnresolvedExceeded'], isFalse);
@@ -1565,6 +1569,7 @@ class Icons {
       expect(decoded['wouldFail'], isTrue);
       expect(decoded['unresolvedGateFailed'], isFalse);
       expect(decoded['newUnresolvedGateFailed'], isTrue);
+      expect(decoded['activeGates'], <String>['newUnresolved']);
       expect(decoded['failedGates'], <String>['newUnresolved']);
       expect(decoded['maxNewUnresolved'], 0);
       expect(decoded['maxNewUnresolvedExceeded'], isTrue);
@@ -1646,6 +1651,7 @@ class Icons {
         expect(decoded['wouldFail'], isTrue);
         expect(decoded['unresolvedGateFailed'], isTrue);
         expect(decoded['newUnresolvedGateFailed'], isTrue);
+        expect(decoded['activeGates'], <String>['unresolved', 'newUnresolved']);
         expect(decoded['failedGates'], <String>['unresolved', 'newUnresolved']);
         expect(decoded['maxUnresolvedExceeded'], isTrue);
         expect(decoded['maxNewUnresolvedExceeded'], isTrue);
@@ -1727,6 +1733,7 @@ class Icons {
       expect(decoded['wouldFail'], isTrue);
       expect(decoded['unresolvedGateFailed'], isFalse);
       expect(decoded['newUnresolvedGateFailed'], isTrue);
+      expect(decoded['activeGates'], <String>['newUnresolved']);
       expect(decoded['failedGates'], <String>['newUnresolved']);
       expect(decoded['maxNewUnresolved'], 0);
       expect(decoded['maxNewUnresolvedExceeded'], isTrue);

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -1635,6 +1635,10 @@ String _renderUnresolvedReportJson({
   required bool newUnresolvedGateFailed,
   required bool wouldFail,
 }) {
+  final activeGates = <String>[
+    if (unresolvedThreshold != null) 'unresolved',
+    if (newUnresolvedThreshold != null) 'newUnresolved',
+  ];
   final failedGates = <String>[
     if (unresolvedGateFailed) 'unresolved',
     if (newUnresolvedGateFailed) 'newUnresolved',
@@ -1647,6 +1651,7 @@ String _renderUnresolvedReportJson({
     'wouldFail': wouldFail,
     'unresolvedGateFailed': unresolvedGateFailed,
     'newUnresolvedGateFailed': newUnresolvedGateFailed,
+    'activeGates': activeGates,
     'failedGates': failedGates,
     'unresolved': unresolved.map(_unresolvedIconJson).toList(growable: false),
     'unresolvedCodePoints': _unresolvedCodePointsJson(unresolved),


### PR DESCRIPTION
## Summary
- extend rough icon unresolved report JSON with `activeGates[]`, a summary list of configured gate categories:
  - `unresolved`
  - `newUnresolved`
- keep existing gate result fields unchanged (`wouldFail`, `unresolvedGateFailed`, `newUnresolvedGateFailed`, `failedGates[]`)
- add parser test assertions for:
  - no gates configured (`activeGates: []`)
  - unresolved-only gates
  - new-unresolved-only gates
  - both gates configured
- document `activeGates[]` in rough icon pipeline docs and package README
- add a changeset for release/docs gate compliance

## Validation
- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md .changeset/rough-icon-unresolved-report-active-gates-list.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
