### PR TITLE
feat: accept unresolvedCodepoints baseline key

### DIFF
--- a/.changeset/rough-icon-baseline-unresolved-codepoints-lowercase-key.md
+++ b/.changeset/rough-icon-baseline-unresolved-codepoints-lowercase-key.md
@@ -1,0 +1,9 @@
+---
+skribble: patch
+---
+
+Allow rough icon unresolved baseline input to use `unresolvedCodepoints[]` (lowercase `p`).
+
+- `--unresolved-baseline` now accepts minimal baseline objects keyed by `unresolvedCodepoints` in addition to `unresolvedCodePoints`, `codePoints`, and `codepoints`.
+- Improves compatibility when baseline JSON uses lowercased key conventions.
+- Update parser tests, CLI help, docs, and README.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -186,7 +186,7 @@ Baseline input supports:
 
 - unresolved report JSON (`unresolved[]`)
 - supplemental manifest JSON (`icons[]`)
-- minimal baseline JSON (`unresolvedCodePoints[]`/`codePoints[]`, also accepts `codepoints[]`)
+- minimal baseline JSON (`unresolvedCodePoints[]`/`unresolvedCodepoints[]`/`codePoints[]`, also accepts `codepoints[]`)
 
 When code points are provided as strings, decimal, `0x`-prefixed hex, bare
 hex, and `U+`-prefixed hex forms are accepted.

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -250,7 +250,7 @@ Useful flags:
 - `--unresolved-baseline-output <path>` to emit a normalized unresolved baseline for regression gating (defaults to `unresolved[]`).
 - `--unresolved-baseline-output-format <unresolved|codepoints>` to choose unresolved baseline output shape (`unresolved[]` or `codePoints[]`; workspace defaults use `codepoints`).
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.
-- `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`), manifest (`icons[]`), or minimal baseline (`unresolvedCodePoints[]`/`codePoints[]`, also accepts `codepoints[]`), including `newUnresolved` and `resolvedSinceBaseline` report fields. String code points accept decimal, `0x` hex, bare hex, and `U+` hex forms.
+- `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`), manifest (`icons[]`), or minimal baseline (`unresolvedCodePoints[]`/`unresolvedCodepoints[]`/`codePoints[]`, also accepts `codepoints[]`), including `newUnresolved` and `resolvedSinceBaseline` report fields. String code points accept decimal, `0x` hex, bare hex, and `U+` hex forms.
 - `--max-unresolved <int>` to allow a bounded unresolved count before failing.
 - `--fail-on-unresolved` to make the command exit non-zero if unresolved icons remain (cannot be combined with `--max-unresolved`).
 - `--max-new-unresolved <int>` to allow a bounded number of newly unresolved entries versus baseline before failing (requires `--unresolved-baseline`).

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -1332,6 +1332,85 @@ class Icons {
     );
 
     test(
+      'accepts unresolvedCodepoints[] format as unresolved baseline',
+      () async {
+        final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+          ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+        final materialIconsRoot = Directory(
+          '${tempDirectory.path}/material-icons',
+        )..createSync(recursive: true);
+        final materialSymbolsRoot = Directory(
+          '${tempDirectory.path}/material-symbols',
+        )..createSync(recursive: true);
+        final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+          ..createSync(recursive: true);
+
+        File('${materialIconsRoot.path}/filled/label.svg')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+          );
+
+        final baselineFile =
+            File(
+              '${tempDirectory.path}/baseline-unresolved-codepoints-lowercase.json',
+            )..writeAsStringSync('''
+{
+  "unresolvedCodepoints": [
+    "f04b9"
+  ]
+}
+''');
+        final unresolvedReportFile = File(
+          '${tempDirectory.path}/unresolved_report.json',
+        );
+        final outputFile = File(
+          '${tempDirectory.path}/material_rough_icons.g.dart',
+        );
+
+        await tool.runGenerateRoughIcons(<String>[
+          '--kit',
+          'flutter-material',
+          '--flutter-icons',
+          flutterIconsFile.path,
+          '--material-icons-source',
+          materialIconsRoot.path,
+          '--material-symbols-source',
+          materialSymbolsRoot.path,
+          '--brand-icons-source',
+          brandIconsRoot.path,
+          '--unresolved-baseline',
+          baselineFile.path,
+          '--fail-on-new-unresolved',
+          '--unresolved-output',
+          unresolvedReportFile.path,
+          '--output',
+          outputFile.path,
+        ]);
+
+        final decoded =
+            jsonDecode(unresolvedReportFile.readAsStringSync())
+                as Map<String, dynamic>;
+        expect(decoded['baselineUnresolvedCount'], 1);
+        expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
+        expect(decoded['newUnresolvedCount'], 0);
+        expect(decoded['newUnresolved'], <dynamic>[]);
+        expect(decoded['newUnresolvedCodePoints'], <dynamic>[]);
+        expect(decoded['resolvedSinceBaselineCount'], 0);
+        expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
+      },
+    );
+
+    test(
       'accepts lowercase codepoints[] format as unresolved baseline',
       () async {
         final flutterIconsFile = File('${tempDirectory.path}/icons.dart')

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -330,7 +330,7 @@ Options:
   --supplemental-manifest-output <path>
                                    Emit supplemental manifest template JSON.
   --unresolved-baseline <path>     Baseline unresolved report/manifest/codePoints JSON for diffing.
-                                   Accepts unresolvedCodePoints/codePoints/codepoints keys for minimal baseline objects.
+                                   Accepts unresolvedCodePoints/unresolvedCodepoints/codePoints/codepoints keys for minimal baseline objects.
   --max-unresolved <int>           Max unresolved icons allowed before failing.
   --fail-on-unresolved             Exit with error when unresolved icons remain (cannot be combined with --max-unresolved).
   --max-new-unresolved <int>       Max newly unresolved icons allowed before failing (requires --unresolved-baseline).
@@ -1496,6 +1496,7 @@ Set<int>? _loadUnresolvedBaselineCodePoints(String? baselinePath) {
     final unresolvedValue = decoded['unresolved'];
     final iconsValue = decoded['icons'];
     final unresolvedCodePointsValue = decoded['unresolvedCodePoints'];
+    final unresolvedCodepointsValue = decoded['unresolvedCodepoints'];
     final codePointsValue = decoded['codePoints'];
     final codepointsValue = decoded['codepoints'];
 
@@ -1505,6 +1506,8 @@ Set<int>? _loadUnresolvedBaselineCodePoints(String? baselinePath) {
       entries = iconsValue;
     } else if (unresolvedCodePointsValue is List<Object?>) {
       entries = unresolvedCodePointsValue;
+    } else if (unresolvedCodepointsValue is List<Object?>) {
+      entries = unresolvedCodepointsValue;
     } else if (codePointsValue is List<Object?>) {
       entries = codePointsValue;
     } else if (codepointsValue is List<Object?>) {
@@ -1513,8 +1516,9 @@ Set<int>? _loadUnresolvedBaselineCodePoints(String? baselinePath) {
       throw FormatException(
         'Expected unresolved baseline JSON to contain either an "unresolved" '
         'list (report format), "icons" list (manifest format), or '
-        '"unresolvedCodePoints"/"codePoints"/"codepoints" list '
-        '(minimal baseline format) at ${baselineFile.path}.',
+        '"unresolvedCodePoints"/"unresolvedCodepoints"/"codePoints"/'
+        '"codepoints" list (minimal baseline format) '
+        'at ${baselineFile.path}.',
       );
     }
   } else {


### PR DESCRIPTION
## Summary
- extend unresolved baseline parsing to accept `unresolvedCodepoints[]` (lowercase `p`) in addition to existing keys
- keep all existing baseline input shapes unchanged (`unresolved[]`, `icons[]`, `unresolvedCodePoints[]`, `codePoints[]`, `codepoints[]`)
- add parser test coverage for `unresolvedCodepoints[]` input
- update CLI help text, rough icon pipeline docs, and package README to document the key alias
- add a changeset for release/docs gate compliance

## Validation
- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md .changeset/rough-icon-baseline-unresolved-codepoints-lowercase-key.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
