### PR TITLE
feat: accept snake_case baseline codepoint keys

### DIFF
--- a/.changeset/rough-icon-baseline-codepoints-snake-case-keys.md
+++ b/.changeset/rough-icon-baseline-codepoints-snake-case-keys.md
@@ -1,0 +1,9 @@
+---
+skribble: patch
+---
+
+Accept snake_case minimal baseline keys for rough icon unresolved regression checks.
+
+- `--unresolved-baseline` now accepts `unresolved_code_points[]` and `code_points[]`.
+- Existing key aliases continue to work (`unresolvedCodePoints`, `unresolvedCodepoints`, `codePoints`, `codepoints`).
+- Adds parser test coverage and updates CLI/docs/README.

--- a/docs/rough-icon-pipeline.md
+++ b/docs/rough-icon-pipeline.md
@@ -186,7 +186,7 @@ Baseline input supports:
 
 - unresolved report JSON (`unresolved[]`)
 - supplemental manifest JSON (`icons[]`)
-- minimal baseline JSON (`unresolvedCodePoints[]`/`unresolvedCodepoints[]`/`codePoints[]`, also accepts `codepoints[]`)
+- minimal baseline JSON (`unresolvedCodePoints[]`/`unresolvedCodepoints[]`/`unresolved_code_points[]`/`codePoints[]`, also accepts `codepoints[]`/`code_points[]`)
 
 When code points are provided as strings, decimal, `0x`-prefixed hex, bare
 hex, and `U+`-prefixed hex forms are accepted.

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -250,7 +250,7 @@ Useful flags:
 - `--unresolved-baseline-output <path>` to emit a normalized unresolved baseline for regression gating (defaults to `unresolved[]`).
 - `--unresolved-baseline-output-format <unresolved|codepoints>` to choose unresolved baseline output shape (`unresolved[]` or `codePoints[]`; workspace defaults use `codepoints`).
 - `--supplemental-manifest-output <path>` to emit a starter supplemental manifest template for unresolved icons.
-- `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`), manifest (`icons[]`), or minimal baseline (`unresolvedCodePoints[]`/`unresolvedCodepoints[]`/`codePoints[]`, also accepts `codepoints[]`), including `newUnresolved` and `resolvedSinceBaseline` report fields. String code points accept decimal, `0x` hex, bare hex, and `U+` hex forms.
+- `--unresolved-baseline <path>` to compare unresolved output against a baseline report (`unresolved[]`), manifest (`icons[]`), or minimal baseline (`unresolvedCodePoints[]`/`unresolvedCodepoints[]`/`unresolved_code_points[]`/`codePoints[]`, also accepts `codepoints[]`/`code_points[]`), including `newUnresolved` and `resolvedSinceBaseline` report fields. String code points accept decimal, `0x` hex, bare hex, and `U+` hex forms.
 - `--max-unresolved <int>` to allow a bounded unresolved count before failing.
 - `--fail-on-unresolved` to make the command exit non-zero if unresolved icons remain (cannot be combined with `--max-unresolved`).
 - `--max-new-unresolved <int>` to allow a bounded number of newly unresolved entries versus baseline before failing (requires `--unresolved-baseline`).

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -1411,6 +1411,160 @@ class Icons {
     );
 
     test(
+      'accepts unresolved_code_points[] format as unresolved baseline',
+      () async {
+        final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+          ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+        final materialIconsRoot = Directory(
+          '${tempDirectory.path}/material-icons',
+        )..createSync(recursive: true);
+        final materialSymbolsRoot = Directory(
+          '${tempDirectory.path}/material-symbols',
+        )..createSync(recursive: true);
+        final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+          ..createSync(recursive: true);
+
+        File('${materialIconsRoot.path}/filled/label.svg')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+          );
+
+        final baselineFile =
+            File(
+              '${tempDirectory.path}/baseline-unresolved-code-points-snake-case.json',
+            )..writeAsStringSync('''
+{
+  "unresolved_code_points": [
+    "f04b9"
+  ]
+}
+''');
+        final unresolvedReportFile = File(
+          '${tempDirectory.path}/unresolved_report.json',
+        );
+        final outputFile = File(
+          '${tempDirectory.path}/material_rough_icons.g.dart',
+        );
+
+        await tool.runGenerateRoughIcons(<String>[
+          '--kit',
+          'flutter-material',
+          '--flutter-icons',
+          flutterIconsFile.path,
+          '--material-icons-source',
+          materialIconsRoot.path,
+          '--material-symbols-source',
+          materialSymbolsRoot.path,
+          '--brand-icons-source',
+          brandIconsRoot.path,
+          '--unresolved-baseline',
+          baselineFile.path,
+          '--fail-on-new-unresolved',
+          '--unresolved-output',
+          unresolvedReportFile.path,
+          '--output',
+          outputFile.path,
+        ]);
+
+        final decoded =
+            jsonDecode(unresolvedReportFile.readAsStringSync())
+                as Map<String, dynamic>;
+        expect(decoded['baselineUnresolvedCount'], 1);
+        expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
+        expect(decoded['newUnresolvedCount'], 0);
+        expect(decoded['newUnresolved'], <dynamic>[]);
+        expect(decoded['newUnresolvedCodePoints'], <dynamic>[]);
+        expect(decoded['resolvedSinceBaselineCount'], 0);
+        expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
+      },
+    );
+
+    test('accepts code_points[] format as unresolved baseline', () async {
+      final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+        ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+      final materialIconsRoot = Directory(
+        '${tempDirectory.path}/material-icons',
+      )..createSync(recursive: true);
+      final materialSymbolsRoot = Directory(
+        '${tempDirectory.path}/material-symbols',
+      )..createSync(recursive: true);
+      final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+        ..createSync(recursive: true);
+
+      File('${materialIconsRoot.path}/filled/label.svg')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(
+          '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+        );
+
+      final baselineFile =
+          File('${tempDirectory.path}/baseline-code-points-snake-case.json')
+            ..writeAsStringSync('''
+{
+  "code_points": [
+    "f04b9"
+  ]
+}
+''');
+      final unresolvedReportFile = File(
+        '${tempDirectory.path}/unresolved_report.json',
+      );
+      final outputFile = File(
+        '${tempDirectory.path}/material_rough_icons.g.dart',
+      );
+
+      await tool.runGenerateRoughIcons(<String>[
+        '--kit',
+        'flutter-material',
+        '--flutter-icons',
+        flutterIconsFile.path,
+        '--material-icons-source',
+        materialIconsRoot.path,
+        '--material-symbols-source',
+        materialSymbolsRoot.path,
+        '--brand-icons-source',
+        brandIconsRoot.path,
+        '--unresolved-baseline',
+        baselineFile.path,
+        '--fail-on-new-unresolved',
+        '--unresolved-output',
+        unresolvedReportFile.path,
+        '--output',
+        outputFile.path,
+      ]);
+
+      final decoded =
+          jsonDecode(unresolvedReportFile.readAsStringSync())
+              as Map<String, dynamic>;
+      expect(decoded['baselineUnresolvedCount'], 1);
+      expect(decoded['unresolvedCodePoints'], <String>['0xf04b9']);
+      expect(decoded['newUnresolvedCount'], 0);
+      expect(decoded['newUnresolved'], <dynamic>[]);
+      expect(decoded['newUnresolvedCodePoints'], <dynamic>[]);
+      expect(decoded['resolvedSinceBaselineCount'], 0);
+      expect(decoded['resolvedSinceBaseline'], <dynamic>[]);
+    });
+
+    test(
       'accepts lowercase codepoints[] format as unresolved baseline',
       () async {
         final flutterIconsFile = File('${tempDirectory.path}/icons.dart')

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -330,7 +330,7 @@ Options:
   --supplemental-manifest-output <path>
                                    Emit supplemental manifest template JSON.
   --unresolved-baseline <path>     Baseline unresolved report/manifest/codePoints JSON for diffing.
-                                   Accepts unresolvedCodePoints/unresolvedCodepoints/codePoints/codepoints keys for minimal baseline objects.
+                                   Accepts unresolvedCodePoints/unresolvedCodepoints/unresolved_code_points/codePoints/codepoints/code_points keys for minimal baseline objects.
   --max-unresolved <int>           Max unresolved icons allowed before failing.
   --fail-on-unresolved             Exit with error when unresolved icons remain (cannot be combined with --max-unresolved).
   --max-new-unresolved <int>       Max newly unresolved icons allowed before failing (requires --unresolved-baseline).
@@ -1497,8 +1497,11 @@ Set<int>? _loadUnresolvedBaselineCodePoints(String? baselinePath) {
     final iconsValue = decoded['icons'];
     final unresolvedCodePointsValue = decoded['unresolvedCodePoints'];
     final unresolvedCodepointsValue = decoded['unresolvedCodepoints'];
+    final unresolvedCodePointsSnakeCaseValue =
+        decoded['unresolved_code_points'];
     final codePointsValue = decoded['codePoints'];
     final codepointsValue = decoded['codepoints'];
+    final codePointsSnakeCaseValue = decoded['code_points'];
 
     if (unresolvedValue is List<Object?>) {
       entries = unresolvedValue;
@@ -1508,16 +1511,21 @@ Set<int>? _loadUnresolvedBaselineCodePoints(String? baselinePath) {
       entries = unresolvedCodePointsValue;
     } else if (unresolvedCodepointsValue is List<Object?>) {
       entries = unresolvedCodepointsValue;
+    } else if (unresolvedCodePointsSnakeCaseValue is List<Object?>) {
+      entries = unresolvedCodePointsSnakeCaseValue;
     } else if (codePointsValue is List<Object?>) {
       entries = codePointsValue;
     } else if (codepointsValue is List<Object?>) {
       entries = codepointsValue;
+    } else if (codePointsSnakeCaseValue is List<Object?>) {
+      entries = codePointsSnakeCaseValue;
     } else {
       throw FormatException(
         'Expected unresolved baseline JSON to contain either an "unresolved" '
         'list (report format), "icons" list (manifest format), or '
-        '"unresolvedCodePoints"/"unresolvedCodepoints"/"codePoints"/'
-        '"codepoints" list (minimal baseline format) '
+        '"unresolvedCodePoints"/"unresolvedCodepoints"/'
+        '"unresolved_code_points"/"codePoints"/"codepoints"/'
+        '"code_points" list (minimal baseline format) '
         'at ${baselineFile.path}.',
       );
     }


### PR DESCRIPTION
## Summary
- extend unresolved baseline parsing to accept snake_case minimal baseline keys:
  - `unresolved_code_points[]`
  - `code_points[]`
- keep existing baseline input shapes and aliases unchanged (`unresolved[]`, `icons[]`, `unresolvedCodePoints[]`, `unresolvedCodepoints[]`, `codePoints[]`, `codepoints[]`)
- add parser test coverage for both new snake_case key variants
- update CLI help text, rough icon pipeline docs, and package README
- add a changeset for release/docs gate compliance

## Validation
- `git diff --check`
- `dprint check docs/rough-icon-pipeline.md packages/skribble/README.md .changeset/rough-icon-baseline-codepoints-snake-case-keys.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
