### PR TITLE
feat: improve baseline missing-codepoint error

### DIFF
--- a/.changeset/rough-icon-baseline-codepoint-missing-error.md
+++ b/.changeset/rough-icon-baseline-codepoint-missing-error.md
@@ -1,0 +1,9 @@
+---
+skribble: patch
+---
+
+Improve unresolved baseline parser error messages for object entries missing a codepoint field.
+
+- Baseline object entries in `unresolved[]`/`icons[]` now throw a targeted `FormatException` when none of `codePoint`, `codepoint`, or `code_point` is present.
+- This replaces the previous generic null-value error and clarifies accepted key names.
+- Adds parser test coverage for this failure mode.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -1181,6 +1181,86 @@ class Icons {
       },
     );
 
+    test(
+      'throws when unresolved baseline object entry omits codepoint key',
+      () async {
+        final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+          ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+        final materialIconsRoot = Directory(
+          '${tempDirectory.path}/material-icons',
+        )..createSync(recursive: true);
+        final materialSymbolsRoot = Directory(
+          '${tempDirectory.path}/material-symbols',
+        )..createSync(recursive: true);
+        final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+          ..createSync(recursive: true);
+
+        File('${materialIconsRoot.path}/filled/label.svg')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+          );
+
+        final baselineFile = File('${tempDirectory.path}/baseline-icons.json')
+          ..writeAsStringSync('''
+{
+  "icons": [
+    {
+      "identifier": "adobe",
+      "svgPath": "TODO/adobe.svg"
+    }
+  ]
+}
+''');
+        final unresolvedReportFile = File(
+          '${tempDirectory.path}/unresolved_report.json',
+        );
+        final outputFile = File(
+          '${tempDirectory.path}/material_rough_icons.g.dart',
+        );
+
+        await expectLater(
+          tool.runGenerateRoughIcons(<String>[
+            '--kit',
+            'flutter-material',
+            '--flutter-icons',
+            flutterIconsFile.path,
+            '--material-icons-source',
+            materialIconsRoot.path,
+            '--material-symbols-source',
+            materialSymbolsRoot.path,
+            '--brand-icons-source',
+            brandIconsRoot.path,
+            '--unresolved-baseline',
+            baselineFile.path,
+            '--fail-on-new-unresolved',
+            '--unresolved-output',
+            unresolvedReportFile.path,
+            '--output',
+            outputFile.path,
+          ]),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              contains(
+                'Expected one of "codePoint", "codepoint", or "code_point" keys',
+              ),
+            ),
+          ),
+        );
+      },
+    );
+
     test('accepts codePoints[] format as unresolved baseline', () async {
       final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
         ..writeAsStringSync('''

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -1557,17 +1557,28 @@ Set<int>? _loadUnresolvedBaselineCodePoints(String? baselinePath) {
   return codePoints;
 }
 
-Object? _baselineEntryCodePointValue(Map<Object?, Object?> entry) {
+Object _baselineEntryCodePointValue(Map<Object?, Object?> entry) {
   if (entry.containsKey('codePoint')) {
-    return entry['codePoint'];
+    return entry['codePoint']!;
   }
   if (entry.containsKey('codepoint')) {
-    return entry['codepoint'];
+    return entry['codepoint']!;
   }
   if (entry.containsKey('code_point')) {
-    return entry['code_point'];
+    return entry['code_point']!;
   }
-  return null;
+
+  final availableKeys = entry.keys.whereType<String>().toList(growable: false)
+    ..sort();
+  final availableKeysText = availableKeys.isEmpty
+      ? '(none)'
+      : availableKeys.join(', ');
+
+  throw FormatException(
+    'Invalid codePoint in unresolved baseline entry. Expected one of '
+    '"codePoint", "codepoint", or "code_point" keys; found: '
+    '$availableKeysText.',
+  );
 }
 
 int _parseCodePointValue(Object? value, {required String context}) {


### PR DESCRIPTION
## Summary
- improve unresolved baseline parser diagnostics for object entries missing a codepoint field
- baseline object entries in `unresolved[]` / `icons[]` now emit a targeted `FormatException` when none of these keys is present:
  - `codePoint`
  - `codepoint`
  - `code_point`
- this replaces the previous generic null-value error and clarifies accepted key names
- add parser test coverage for this failure mode
- add a changeset for release/docs gate compliance

## Validation
- `git diff --check`
- `dprint check .changeset/rough-icon-baseline-codepoint-missing-error.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
