### PR TITLE
feat: improve baseline top-level key error

### DIFF
--- a/.changeset/rough-icon-baseline-top-level-key-error.md
+++ b/.changeset/rough-icon-baseline-top-level-key-error.md
@@ -1,0 +1,7 @@
+---
+skribble: patch
+---
+
+Improve unresolved baseline parser diagnostics when baseline objects omit recognized top-level list keys.
+
+The `FormatException` now includes the keys found in the provided JSON object.

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -1262,6 +1262,86 @@ class Icons {
     );
 
     test(
+      'throws when unresolved baseline object omits recognized top-level list key',
+      () async {
+        final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+          ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+        final materialIconsRoot = Directory(
+          '${tempDirectory.path}/material-icons',
+        )..createSync(recursive: true);
+        final materialSymbolsRoot = Directory(
+          '${tempDirectory.path}/material-symbols',
+        )..createSync(recursive: true);
+        final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+          ..createSync(recursive: true);
+
+        File('${materialIconsRoot.path}/filled/label.svg')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+          );
+
+        final baselineFile = File('${tempDirectory.path}/baseline-invalid.json')
+          ..writeAsStringSync('''
+{
+  "items": [
+    "f04b9"
+  ]
+}
+''');
+        final unresolvedReportFile = File(
+          '${tempDirectory.path}/unresolved_report.json',
+        );
+        final outputFile = File(
+          '${tempDirectory.path}/material_rough_icons.g.dart',
+        );
+
+        await expectLater(
+          tool.runGenerateRoughIcons(<String>[
+            '--kit',
+            'flutter-material',
+            '--flutter-icons',
+            flutterIconsFile.path,
+            '--material-icons-source',
+            materialIconsRoot.path,
+            '--material-symbols-source',
+            materialSymbolsRoot.path,
+            '--brand-icons-source',
+            brandIconsRoot.path,
+            '--unresolved-baseline',
+            baselineFile.path,
+            '--fail-on-new-unresolved',
+            '--unresolved-output',
+            unresolvedReportFile.path,
+            '--output',
+            outputFile.path,
+          ]),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              allOf(
+                contains(
+                  'Expected unresolved baseline JSON to contain either an "unresolved" list',
+                ),
+                contains('Found keys: items'),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
       'throws when unresolved baseline object entry omits codepoint key',
       () async {
         final flutterIconsFile = File('${tempDirectory.path}/icons.dart')

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -1534,6 +1534,11 @@ Set<int>? _loadUnresolvedBaselineCodePoints(String? baselinePath) {
     } else if (codePointsKebabCaseValue is List<Object?>) {
       entries = codePointsKebabCaseValue;
     } else {
+      final availableKeys = decoded.keys.toList(growable: false)..sort();
+      final availableKeysText = availableKeys.isEmpty
+          ? '(none)'
+          : availableKeys.join(', ');
+
       throw FormatException(
         'Expected unresolved baseline JSON to contain either an "unresolved" '
         'list (report format), "icons" list (manifest format), or '
@@ -1541,7 +1546,8 @@ Set<int>? _loadUnresolvedBaselineCodePoints(String? baselinePath) {
         '"unresolved_code_points"/"unresolved_codepoints"/'
         '"unresolved-code-points"/"unresolved-codepoints"/'
         '"codePoints"/"codepoints"/"code_points"/"code-points" '
-        'list (minimal baseline format) at ${baselineFile.path}.',
+        'list (minimal baseline format) at ${baselineFile.path}. '
+        'Found keys: $availableKeysText.',
       );
     }
   } else {


### PR DESCRIPTION
## Summary
- improve unresolved baseline parser diagnostics when a baseline JSON object omits all recognized top-level list keys
- when baseline parsing fails for object shape mismatch, the `FormatException` now includes detected keys via `Found keys: ...`
- add parser test coverage for this failure mode (`throws when unresolved baseline object omits recognized top-level list key`)
- add a changeset for release/docs gate compliance

## Validation
- `git diff --check`
- `dprint check .changeset/rough-icon-baseline-top-level-key-error.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
