### PR TITLE
feat: improve baseline key type errors

### DIFF
--- a/.changeset/rough-icon-baseline-key-type-error.md
+++ b/.changeset/rough-icon-baseline-key-type-error.md
@@ -1,0 +1,7 @@
+---
+skribble: patch
+---
+
+Improve unresolved baseline parser diagnostics when recognized baseline keys exist but are not arrays.
+
+The parser now reports which recognized keys have non-list values (for example `codePoints (String)`).

--- a/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
+++ b/packages/skribble/test/tool/generate_material_rough_icons_parser_test.dart
@@ -1342,6 +1342,84 @@ class Icons {
     );
 
     test(
+      'throws when unresolved baseline recognized key value is not a list',
+      () async {
+        final flutterIconsFile = File('${tempDirectory.path}/icons.dart')
+          ..writeAsStringSync('''
+class Icons {
+  /// The material icon named "label outline".
+  static const IconData label_outline = IconData(0xe364, fontFamily: 'MaterialIcons');
+
+  /// The material icon named "adobe".
+  static const IconData adobe = IconData(0xf04b9, fontFamily: 'MaterialIcons');
+}
+''');
+
+        final materialIconsRoot = Directory(
+          '${tempDirectory.path}/material-icons',
+        )..createSync(recursive: true);
+        final materialSymbolsRoot = Directory(
+          '${tempDirectory.path}/material-symbols',
+        )..createSync(recursive: true);
+        final brandIconsRoot = Directory('${tempDirectory.path}/simple-icons')
+          ..createSync(recursive: true);
+
+        File('${materialIconsRoot.path}/filled/label.svg')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '<svg viewBox="0 0 24 24"><path d="M1 1h22v22H1z"/></svg>',
+          );
+
+        final baselineFile = File('${tempDirectory.path}/baseline-invalid.json')
+          ..writeAsStringSync('''
+{
+  "codePoints": "f04b9"
+}
+''');
+        final unresolvedReportFile = File(
+          '${tempDirectory.path}/unresolved_report.json',
+        );
+        final outputFile = File(
+          '${tempDirectory.path}/material_rough_icons.g.dart',
+        );
+
+        await expectLater(
+          tool.runGenerateRoughIcons(<String>[
+            '--kit',
+            'flutter-material',
+            '--flutter-icons',
+            flutterIconsFile.path,
+            '--material-icons-source',
+            materialIconsRoot.path,
+            '--material-symbols-source',
+            materialSymbolsRoot.path,
+            '--brand-icons-source',
+            brandIconsRoot.path,
+            '--unresolved-baseline',
+            baselineFile.path,
+            '--fail-on-new-unresolved',
+            '--unresolved-output',
+            unresolvedReportFile.path,
+            '--output',
+            outputFile.path,
+          ]),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              allOf(
+                contains(
+                  'Expected unresolved baseline recognized list keys to map to arrays',
+                ),
+                contains('Found non-list values: codePoints (String)'),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
       'throws when unresolved baseline object entry omits codepoint key',
       () async {
         final flutterIconsFile = File('${tempDirectory.path}/icons.dart')

--- a/packages/skribble/tool/generate_material_rough_icons.dart
+++ b/packages/skribble/tool/generate_material_rough_icons.dart
@@ -1509,6 +1509,48 @@ Set<int>? _loadUnresolvedBaselineCodePoints(String? baselinePath) {
     final codePointsSnakeCaseValue = decoded['code_points'];
     final codePointsKebabCaseValue = decoded['code-points'];
 
+    final invalidRecognizedListValues = <String>[];
+
+    void addInvalidRecognizedListValue(String key, Object? value) {
+      if (!decoded.containsKey(key) || value is List<Object?>) {
+        return;
+      }
+
+      final valueType = value == null ? 'null' : value.runtimeType.toString();
+      invalidRecognizedListValues.add('$key ($valueType)');
+    }
+
+    addInvalidRecognizedListValue('unresolved', unresolvedValue);
+    addInvalidRecognizedListValue('icons', iconsValue);
+    addInvalidRecognizedListValue(
+      'unresolvedCodePoints',
+      unresolvedCodePointsValue,
+    );
+    addInvalidRecognizedListValue(
+      'unresolvedCodepoints',
+      unresolvedCodepointsValue,
+    );
+    addInvalidRecognizedListValue(
+      'unresolved_code_points',
+      unresolvedCodePointsSnakeCaseValue,
+    );
+    addInvalidRecognizedListValue(
+      'unresolved_codepoints',
+      unresolvedCodepointsSnakeCaseValue,
+    );
+    addInvalidRecognizedListValue(
+      'unresolved-code-points',
+      unresolvedCodePointsKebabCaseValue,
+    );
+    addInvalidRecognizedListValue(
+      'unresolved-codepoints',
+      unresolvedCodepointsKebabCaseValue,
+    );
+    addInvalidRecognizedListValue('codePoints', codePointsValue);
+    addInvalidRecognizedListValue('codepoints', codepointsValue);
+    addInvalidRecognizedListValue('code_points', codePointsSnakeCaseValue);
+    addInvalidRecognizedListValue('code-points', codePointsKebabCaseValue);
+
     if (unresolvedValue is List<Object?>) {
       entries = unresolvedValue;
     } else if (iconsValue is List<Object?>) {
@@ -1534,6 +1576,14 @@ Set<int>? _loadUnresolvedBaselineCodePoints(String? baselinePath) {
     } else if (codePointsKebabCaseValue is List<Object?>) {
       entries = codePointsKebabCaseValue;
     } else {
+      if (invalidRecognizedListValues.isNotEmpty) {
+        throw FormatException(
+          'Expected unresolved baseline recognized list keys to map to arrays '
+          'at ${baselineFile.path}. Found non-list values: '
+          '${invalidRecognizedListValues.join(', ')}.',
+        );
+      }
+
       final availableKeys = decoded.keys.toList(growable: false)..sort();
       final availableKeysText = availableKeys.isEmpty
           ? '(none)'


### PR DESCRIPTION
## Summary
- improve unresolved baseline parser diagnostics when recognized top-level baseline keys are present but not arrays
- add non-list key/type reporting in parser errors (for example: `Found non-list values: codePoints (String)`)
- retain existing missing-key diagnostics for objects that omit all recognized top-level keys
- add parser test coverage for this failure mode
- add a changeset for release/docs gate compliance

## Validation
- `git diff --check`
- `dprint check .changeset/rough-icon-baseline-key-type-error.md`
- `flutter test test/tool/generate_material_rough_icons_parser_test.dart`
- `dart analyze --fatal-infos tool/generate_material_rough_icons.dart test/tool/generate_material_rough_icons_parser_test.dart`
