### PR TITLE
feat: expand WiredMaterialApp parity

### DIFF
--- a/.changeset/wired-material-app-parity-expansion.md
+++ b/.changeset/wired-material-app-parity-expansion.md
@@ -1,0 +1,8 @@
+---
+skribble: patch
+---
+
+Expand `WiredMaterialApp` and `WiredMaterialApp.router` with more of Flutter's
+high-value `MaterialApp` bootstrapping API, including locale resolution,
+restoration, scroll behavior, shortcuts/actions, generated titles,
+`onGenerateInitialRoutes`, and theme animation controls.

--- a/docs/ui-snapshots/parity-matrix.md
+++ b/docs/ui-snapshots/parity-matrix.md
@@ -113,10 +113,11 @@ Status meanings:
 
 ## App architecture bridges
 
-| Flutter construct       | Skribble mapping                                    | Lib | Test |       Storybook | Status      | Notes                                                |
-| ----------------------- | --------------------------------------------------- | --: | ---: | --------------: | ----------- | ---------------------------------------------------- |
-| MaterialApp + ThemeData | `WiredMaterialApp` + `WiredThemeData.toThemeData()` |  ✅ |   ✅ | ✅ (`app.dart`) | implemented | Keeps Material theming and `WiredTheme` synchronized |
-| MaterialApp.router      | `WiredMaterialApp.router`                           |  ✅ |   ✅ |             n/a | implemented | Router-based app bootstrapping with synced theming   |
+| Flutter construct       | Skribble mapping                                    | Lib | Test |       Storybook | Status      | Notes                                                                                                                       |
+| ----------------------- | --------------------------------------------------- | --: | ---: | --------------: | ----------- | --------------------------------------------------------------------------------------------------------------------------- |
+| MaterialApp + ThemeData | `WiredMaterialApp` + `WiredThemeData.toThemeData()` |  ✅ |   ✅ | ✅ (`app.dart`) | implemented | Keeps Material theming and `WiredTheme` synchronized                                                                        |
+| MaterialApp.router      | `WiredMaterialApp.router`                           |  ✅ |   ✅ |             n/a | implemented | Router-based app bootstrapping with synced theming                                                                          |
+| MaterialApp config      | shared high-value `MaterialApp` options             |  ✅ |   ✅ |             n/a | implemented | Includes restoration, scroll behavior, locale resolution, shortcuts/actions, generated titles, and theme animation controls |
 
 ## Summary
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -31,6 +31,9 @@ WiredMaterialApp(
 
 For router-based apps, use `WiredMaterialApp.router(...)` with your
 `RouterConfig`, `routerDelegate`, or `routeInformationParser` setup.
+Both constructors also expose high-value `MaterialApp` bootstrapping options
+like locale resolution callbacks, restoration, scroll behavior, shortcuts /
+actions, generated titles, and theme animation controls.
 
 All wired widget implementations read from the nearest `WiredTheme` ancestor
 and fall back to defaults when no theme is provided. `WiredThemeData`

--- a/packages/skribble/lib/src/wired_material_app.dart
+++ b/packages/skribble/lib/src/wired_material_app.dart
@@ -13,18 +13,29 @@ class WiredMaterialApp extends HookWidget {
     this.darkWiredTheme,
     this.themeMode = ThemeMode.system,
     this.title = '',
+    this.onGenerateTitle,
+    this.color,
     this.home,
     this.routes = const <String, WidgetBuilder>{},
     this.initialRoute,
     this.onGenerateRoute,
+    this.onGenerateInitialRoutes,
     this.onUnknownRoute,
     this.navigatorKey,
     this.navigatorObservers = const <NavigatorObserver>[],
     this.builder,
     this.locale,
     this.localizationsDelegates,
+    this.localeListResolutionCallback,
+    this.localeResolutionCallback,
     this.supportedLocales = const <Locale>[Locale('en', 'US')],
     this.scaffoldMessengerKey,
+    this.scrollBehavior,
+    this.restorationScopeId,
+    this.shortcuts,
+    this.actions,
+    this.themeAnimationDuration = kThemeAnimationDuration,
+    this.themeAnimationCurve = Curves.linear,
     this.debugShowCheckedModeBanner = false,
   }) : routeInformationProvider = null,
        routeInformationParser = null,
@@ -39,11 +50,21 @@ class WiredMaterialApp extends HookWidget {
     this.darkWiredTheme,
     this.themeMode = ThemeMode.system,
     this.title = '',
+    this.onGenerateTitle,
+    this.color,
     this.builder,
     this.locale,
     this.localizationsDelegates,
+    this.localeListResolutionCallback,
+    this.localeResolutionCallback,
     this.supportedLocales = const <Locale>[Locale('en', 'US')],
     this.scaffoldMessengerKey,
+    this.scrollBehavior,
+    this.restorationScopeId,
+    this.shortcuts,
+    this.actions,
+    this.themeAnimationDuration = kThemeAnimationDuration,
+    this.themeAnimationCurve = Curves.linear,
     this.debugShowCheckedModeBanner = false,
     this.routeInformationProvider,
     this.routeInformationParser,
@@ -54,6 +75,7 @@ class WiredMaterialApp extends HookWidget {
        routes = const <String, WidgetBuilder>{},
        initialRoute = null,
        onGenerateRoute = null,
+       onGenerateInitialRoutes = null,
        onUnknownRoute = null,
        navigatorKey = null,
        navigatorObservers = const <NavigatorObserver>[],
@@ -67,18 +89,29 @@ class WiredMaterialApp extends HookWidget {
   final WiredThemeData? darkWiredTheme;
   final ThemeMode themeMode;
   final String title;
+  final GenerateAppTitle? onGenerateTitle;
+  final Color? color;
   final Widget? home;
   final Map<String, WidgetBuilder> routes;
   final String? initialRoute;
   final RouteFactory? onGenerateRoute;
+  final InitialRouteListFactory? onGenerateInitialRoutes;
   final RouteFactory? onUnknownRoute;
   final GlobalKey<NavigatorState>? navigatorKey;
   final List<NavigatorObserver> navigatorObservers;
   final TransitionBuilder? builder;
   final Locale? locale;
   final Iterable<LocalizationsDelegate<dynamic>>? localizationsDelegates;
+  final LocaleListResolutionCallback? localeListResolutionCallback;
+  final LocaleResolutionCallback? localeResolutionCallback;
   final Iterable<Locale> supportedLocales;
   final GlobalKey<ScaffoldMessengerState>? scaffoldMessengerKey;
+  final ScrollBehavior? scrollBehavior;
+  final String? restorationScopeId;
+  final Map<ShortcutActivator, Intent>? shortcuts;
+  final Map<Type, Action<Intent>>? actions;
+  final Duration themeAnimationDuration;
+  final Curve themeAnimationCurve;
   final bool debugShowCheckedModeBanner;
   final RouteInformationProvider? routeInformationProvider;
   final RouteInformationParser<Object>? routeInformationParser;
@@ -101,9 +134,13 @@ class WiredMaterialApp extends HookWidget {
       child: _useRouter
           ? MaterialApp.router(
               title: title,
+              onGenerateTitle: onGenerateTitle,
+              color: color,
               theme: theme,
               darkTheme: darkTheme,
               themeMode: themeMode,
+              themeAnimationDuration: themeAnimationDuration,
+              themeAnimationCurve: themeAnimationCurve,
               routeInformationProvider: routeInformationProvider,
               routeInformationParser: routeInformationParser,
               routerDelegate: routerDelegate,
@@ -112,27 +149,44 @@ class WiredMaterialApp extends HookWidget {
               builder: builder,
               locale: locale,
               localizationsDelegates: localizationsDelegates,
+              localeListResolutionCallback: localeListResolutionCallback,
+              localeResolutionCallback: localeResolutionCallback,
               supportedLocales: supportedLocales,
               scaffoldMessengerKey: scaffoldMessengerKey,
+              scrollBehavior: scrollBehavior,
+              restorationScopeId: restorationScopeId,
+              shortcuts: shortcuts,
+              actions: actions,
               debugShowCheckedModeBanner: debugShowCheckedModeBanner,
             )
           : MaterialApp(
               title: title,
+              onGenerateTitle: onGenerateTitle,
+              color: color,
               theme: theme,
               darkTheme: darkTheme,
               themeMode: themeMode,
+              themeAnimationDuration: themeAnimationDuration,
+              themeAnimationCurve: themeAnimationCurve,
               home: home,
               routes: routes,
               initialRoute: initialRoute,
               onGenerateRoute: onGenerateRoute,
+              onGenerateInitialRoutes: onGenerateInitialRoutes,
               onUnknownRoute: onUnknownRoute,
               navigatorKey: navigatorKey,
               navigatorObservers: navigatorObservers,
               builder: builder,
               locale: locale,
               localizationsDelegates: localizationsDelegates,
+              localeListResolutionCallback: localeListResolutionCallback,
+              localeResolutionCallback: localeResolutionCallback,
               supportedLocales: supportedLocales,
               scaffoldMessengerKey: scaffoldMessengerKey,
+              scrollBehavior: scrollBehavior,
+              restorationScopeId: restorationScopeId,
+              shortcuts: shortcuts,
+              actions: actions,
               debugShowCheckedModeBanner: debugShowCheckedModeBanner,
             ),
     );

--- a/packages/skribble/test/widgets/wired_material_app_test.dart
+++ b/packages/skribble/test/widgets/wired_material_app_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:skribble/skribble.dart';
 
@@ -45,6 +46,31 @@ void main() {
       expect(find.text('Root'), findsNothing);
     });
 
+    testWidgets('forwards onGenerateInitialRoutes when provided', (
+      tester,
+    ) async {
+      List<Route<dynamic>> onGenerateInitialRoutes(String initialRoute) =>
+          <Route<dynamic>>[
+            MaterialPageRoute<void>(
+              builder: (_) => Text('Generated $initialRoute'),
+            ),
+          ];
+
+      await tester.pumpWidget(
+        WiredMaterialApp(
+          wiredTheme: WiredThemeData(),
+          onGenerateInitialRoutes: onGenerateInitialRoutes,
+          builder: (context, child) => child ?? const SizedBox.shrink(),
+        ),
+      );
+
+      final materialApp = tester.widget<MaterialApp>(find.byType(MaterialApp));
+      expect(
+        materialApp.onGenerateInitialRoutes,
+        same(onGenerateInitialRoutes),
+      );
+    });
+
     testWidgets('applies dark wired theme when themeMode is dark', (
       tester,
     ) async {
@@ -75,6 +101,52 @@ void main() {
       expect(capturedTheme.borderColor, darkTheme.borderColor);
     });
 
+    testWidgets('forwards shared MaterialApp configuration', (tester) async {
+      Locale localeListCallback(
+        List<Locale>? locales,
+        Iterable<Locale> supportedLocales,
+      ) => const Locale('en', 'US');
+      Locale localeCallback(
+        Locale? locale,
+        Iterable<Locale> supportedLocales,
+      ) => const Locale('en', 'US');
+      const scrollBehavior = _TestScrollBehavior();
+      final action = _TestIntentAction();
+      String titleBuilder(BuildContext context) => 'Generated Title';
+
+      await tester.pumpWidget(
+        WiredMaterialApp(
+          wiredTheme: WiredThemeData(),
+          onGenerateTitle: titleBuilder,
+          color: const Color(0xFF112233),
+          localeListResolutionCallback: localeListCallback,
+          localeResolutionCallback: localeCallback,
+          scrollBehavior: scrollBehavior,
+          restorationScopeId: 'wired-app',
+          shortcuts: const <ShortcutActivator, Intent>{
+            SingleActivator(LogicalKeyboardKey.keyK): _TestIntent(),
+          },
+          actions: <Type, Action<Intent>>{_TestIntent: action},
+          themeAnimationDuration: const Duration(milliseconds: 420),
+          themeAnimationCurve: Curves.easeInOutCubic,
+          home: const Text('Config Home'),
+        ),
+      );
+
+      final materialApp = tester.widget<MaterialApp>(find.byType(MaterialApp));
+      expect(materialApp.onGenerateTitle, same(titleBuilder));
+      expect(materialApp.color, const Color(0xFF112233));
+      expect(materialApp.localeListResolutionCallback, same(localeListCallback));
+      expect(materialApp.localeResolutionCallback, same(localeCallback));
+      expect(materialApp.scrollBehavior, same(scrollBehavior));
+      expect(materialApp.restorationScopeId, 'wired-app');
+      expect(materialApp.themeAnimationDuration, const Duration(milliseconds: 420));
+      expect(materialApp.themeAnimationCurve, Curves.easeInOutCubic);
+      expect(materialApp.shortcuts, isNotNull);
+      expect(materialApp.actions, isNotNull);
+      expect(materialApp.actions![_TestIntent], same(action));
+    });
+
     testWidgets('router constructor renders routerConfig child', (
       tester,
     ) async {
@@ -89,9 +161,7 @@ void main() {
           wiredTheme: wiredTheme,
           routerConfig: RouterConfig<Object>(
             routeInformationProvider: PlatformRouteInformationProvider(
-              initialRouteInformation: RouteInformation(
-                uri: Uri(path: '/'),
-              ),
+              initialRouteInformation: RouteInformation(uri: Uri(path: '/')),
             ),
             routeInformationParser: const _TestRouteInformationParser(),
             routerDelegate: _TestRouterDelegate((context) {
@@ -151,6 +221,57 @@ void main() {
       expect(capturedTheme.fillColor, darkTheme.fillColor);
       expect(capturedTheme.borderColor, darkTheme.borderColor);
     });
+
+    testWidgets('router constructor forwards shared MaterialApp configuration', (
+      tester,
+    ) async {
+      Locale localeListCallback(
+        List<Locale>? locales,
+        Iterable<Locale> supportedLocales,
+      ) => const Locale('en', 'US');
+      Locale localeCallback(
+        Locale? locale,
+        Iterable<Locale> supportedLocales,
+      ) => const Locale('en', 'US');
+      const scrollBehavior = _TestScrollBehavior();
+      final action = _TestIntentAction();
+      String titleBuilder(BuildContext context) => 'Router Title';
+
+      await tester.pumpWidget(
+        WiredMaterialApp.router(
+          wiredTheme: WiredThemeData(),
+          onGenerateTitle: titleBuilder,
+          color: const Color(0xFF332211),
+          localeListResolutionCallback: localeListCallback,
+          localeResolutionCallback: localeCallback,
+          scrollBehavior: scrollBehavior,
+          restorationScopeId: 'wired-router-app',
+          shortcuts: const <ShortcutActivator, Intent>{
+            SingleActivator(LogicalKeyboardKey.keyR): _TestIntent(),
+          },
+          actions: <Type, Action<Intent>>{_TestIntent: action},
+          themeAnimationDuration: const Duration(milliseconds: 360),
+          themeAnimationCurve: Curves.easeOutQuart,
+          routeInformationParser: const _TestRouteInformationParser(),
+          routerDelegate: _TestRouterDelegate(
+            (_) => const Text('Router Config Home'),
+          ),
+        ),
+      );
+
+      final materialApp = tester.widget<MaterialApp>(find.byType(MaterialApp));
+      expect(materialApp.onGenerateTitle, same(titleBuilder));
+      expect(materialApp.color, const Color(0xFF332211));
+      expect(materialApp.localeListResolutionCallback, same(localeListCallback));
+      expect(materialApp.localeResolutionCallback, same(localeCallback));
+      expect(materialApp.scrollBehavior, same(scrollBehavior));
+      expect(materialApp.restorationScopeId, 'wired-router-app');
+      expect(materialApp.themeAnimationDuration, const Duration(milliseconds: 360));
+      expect(materialApp.themeAnimationCurve, Curves.easeOutQuart);
+      expect(materialApp.shortcuts, isNotNull);
+      expect(materialApp.actions, isNotNull);
+      expect(materialApp.actions![_TestIntent], same(action));
+    });
   });
 }
 
@@ -179,4 +300,17 @@ class _TestRouterDelegate extends RouterDelegate<Object> with ChangeNotifier {
 
   @override
   Future<void> setNewRoutePath(Object configuration) async {}
+}
+
+class _TestScrollBehavior extends MaterialScrollBehavior {
+  const _TestScrollBehavior();
+}
+
+class _TestIntent extends Intent {
+  const _TestIntent();
+}
+
+class _TestIntentAction extends Action<_TestIntent> {
+  @override
+  Object? invoke(_TestIntent intent) => null;
 }


### PR DESCRIPTION
## Summary
- expose more high-value `MaterialApp` bootstrapping options on `WiredMaterialApp` and `WiredMaterialApp.router`
- add focused tests for generated titles, locale resolution, restoration, scroll behavior, shortcuts/actions, theme animation, and `onGenerateInitialRoutes` forwarding
- update docs for the expanded app-level Material bridge

Closes #93
Refs #85

## Validation
- dprint fmt packages/skribble/README.md docs/ui-snapshots/parity-matrix.md
- dart analyze --fatal-infos .
- flutter test packages/skribble/test/widgets/wired_material_app_test.dart
- ./scripts/check_rough_icons_ci.sh generated-sync
