### PR TITLE
feat: add high-contrast app parity

### DIFF
--- a/.changeset/wired-material-app-high-contrast-diagnostics.md
+++ b/.changeset/wired-material-app-high-contrast-diagnostics.md
@@ -1,0 +1,9 @@
+---
+skribble: patch
+---
+
+Expand `WiredMaterialApp` and `WiredMaterialApp.router` with high-contrast
+wired theme variants plus more of Flutter's `MaterialApp` diagnostics and
+configuration surface, including navigation notifications, theme animation
+style, performance / semantics debug flags, checkerboard overlays, and the
+remaining shared app bootstrapping options needed for near-drop-in parity.

--- a/docs/ui-snapshots/parity-matrix.md
+++ b/docs/ui-snapshots/parity-matrix.md
@@ -118,6 +118,8 @@ Status meanings:
 | MaterialApp + ThemeData | `WiredMaterialApp` + `WiredThemeData.toThemeData()` |  ✅ |   ✅ | ✅ (`app.dart`) | implemented | Keeps Material theming and `WiredTheme` synchronized                                                                        |
 | MaterialApp.router      | `WiredMaterialApp.router`                           |  ✅ |   ✅ |             n/a | implemented | Router-based app bootstrapping with synced theming                                                                          |
 | MaterialApp config      | shared high-value `MaterialApp` options             |  ✅ |   ✅ |             n/a | implemented | Includes restoration, scroll behavior, locale resolution, shortcuts/actions, generated titles, and theme animation controls |
+| MaterialApp diagnostics | debug and performance overlays / semantics flags    |  ✅ |   ✅ |             n/a | implemented | Covers material grid, semantics debugger, performance overlay, and checkerboard diagnostics                                 |
+| High-contrast themes    | high-contrast wired light/dark app variants         |  ✅ |   ✅ |             n/a | implemented | Keeps `WiredTheme` and Material high-contrast themes aligned                                                                |
 
 ## Summary
 

--- a/packages/skribble/README.md
+++ b/packages/skribble/README.md
@@ -33,7 +33,8 @@ For router-based apps, use `WiredMaterialApp.router(...)` with your
 `RouterConfig`, `routerDelegate`, or `routeInformationParser` setup.
 Both constructors also expose high-value `MaterialApp` bootstrapping options
 like locale resolution callbacks, restoration, scroll behavior, shortcuts /
-actions, generated titles, and theme animation controls.
+actions, generated titles, theme animation controls, high-contrast theme
+variants, and common debug / diagnostics flags.
 
 All wired widget implementations read from the nearest `WiredTheme` ancestor
 and fall back to defaults when no theme is provided. `WiredThemeData`
@@ -165,6 +166,7 @@ text, and Material fallbacks stay aligned with the Skribble palette, while
 | `WiredThemeData.toThemeData()` | Material `ThemeData` bridge for app-level theming    |
 | `WiredMaterialApp`             | Material app wrapper that syncs `WiredTheme` + theme |
 | `WiredMaterialApp.router`      | Router-based app wrapper with the same theme syncing |
+| High-contrast wired themes     | Optional high-contrast light/dark app theme variants |
 
 ## API Patterns
 

--- a/packages/skribble/lib/src/wired_material_app.dart
+++ b/packages/skribble/lib/src/wired_material_app.dart
@@ -11,9 +11,12 @@ class WiredMaterialApp extends HookWidget {
     super.key,
     required this.wiredTheme,
     this.darkWiredTheme,
+    this.highContrastWiredTheme,
+    this.highContrastDarkWiredTheme,
     this.themeMode = ThemeMode.system,
     this.title = '',
     this.onGenerateTitle,
+    this.onNavigationNotification,
     this.color,
     this.home,
     this.routes = const <String, WidgetBuilder>{},
@@ -36,7 +39,19 @@ class WiredMaterialApp extends HookWidget {
     this.actions,
     this.themeAnimationDuration = kThemeAnimationDuration,
     this.themeAnimationCurve = Curves.linear,
+    this.themeAnimationStyle,
+    this.debugShowMaterialGrid = false,
+    this.showPerformanceOverlay = false,
+    this.checkerboardRasterCacheImages = false,
+    this.checkerboardOffscreenLayers = false,
+    this.showSemanticsDebugger = false,
     this.debugShowCheckedModeBanner = false,
+    @Deprecated(
+      'Remove this parameter as it is now ignored. '
+      'MaterialApp never introduces its own MediaQuery; the View widget takes '
+      'care of that. This feature was deprecated after v3.7.0-29.0.pre.',
+    )
+    this.useInheritedMediaQuery = false,
   }) : routeInformationProvider = null,
        routeInformationParser = null,
        routerDelegate = null,
@@ -48,9 +63,12 @@ class WiredMaterialApp extends HookWidget {
     super.key,
     required this.wiredTheme,
     this.darkWiredTheme,
+    this.highContrastWiredTheme,
+    this.highContrastDarkWiredTheme,
     this.themeMode = ThemeMode.system,
     this.title = '',
     this.onGenerateTitle,
+    this.onNavigationNotification,
     this.color,
     this.builder,
     this.locale,
@@ -65,7 +83,19 @@ class WiredMaterialApp extends HookWidget {
     this.actions,
     this.themeAnimationDuration = kThemeAnimationDuration,
     this.themeAnimationCurve = Curves.linear,
+    this.themeAnimationStyle,
+    this.debugShowMaterialGrid = false,
+    this.showPerformanceOverlay = false,
+    this.checkerboardRasterCacheImages = false,
+    this.checkerboardOffscreenLayers = false,
+    this.showSemanticsDebugger = false,
     this.debugShowCheckedModeBanner = false,
+    @Deprecated(
+      'Remove this parameter as it is now ignored. '
+      'MaterialApp never introduces its own MediaQuery; the View widget takes '
+      'care of that. This feature was deprecated after v3.7.0-29.0.pre.',
+    )
+    this.useInheritedMediaQuery = false,
     this.routeInformationProvider,
     this.routeInformationParser,
     this.routerDelegate,
@@ -87,9 +117,13 @@ class WiredMaterialApp extends HookWidget {
 
   final WiredThemeData wiredTheme;
   final WiredThemeData? darkWiredTheme;
+  final WiredThemeData? highContrastWiredTheme;
+  final WiredThemeData? highContrastDarkWiredTheme;
   final ThemeMode themeMode;
   final String title;
   final GenerateAppTitle? onGenerateTitle;
+  final NotificationListenerCallback<NavigationNotification>?
+  onNavigationNotification;
   final Color? color;
   final Widget? home;
   final Map<String, WidgetBuilder> routes;
@@ -112,7 +146,21 @@ class WiredMaterialApp extends HookWidget {
   final Map<Type, Action<Intent>>? actions;
   final Duration themeAnimationDuration;
   final Curve themeAnimationCurve;
+  final AnimationStyle? themeAnimationStyle;
+  final bool debugShowMaterialGrid;
+  final bool showPerformanceOverlay;
+  final bool checkerboardRasterCacheImages;
+  final bool checkerboardOffscreenLayers;
+  final bool showSemanticsDebugger;
   final bool debugShowCheckedModeBanner;
+
+  @Deprecated(
+    'Remove this parameter as it is now ignored. '
+    'MaterialApp never introduces its own MediaQuery; the View widget takes '
+    'care of that. This feature was deprecated after v3.7.0-29.0.pre.',
+  )
+  final bool useInheritedMediaQuery;
+
   final RouteInformationProvider? routeInformationProvider;
   final RouteInformationParser<Object>? routeInformationParser;
   final RouterDelegate<Object>? routerDelegate;
@@ -123,9 +171,21 @@ class WiredMaterialApp extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final effectiveDarkTheme = darkWiredTheme ?? wiredTheme;
-    final effectiveWiredTheme = _resolveWiredTheme(effectiveDarkTheme);
+    final effectiveHighContrastTheme = highContrastWiredTheme ?? wiredTheme;
+    final effectiveHighContrastDarkTheme =
+        highContrastDarkWiredTheme ?? darkWiredTheme ?? wiredTheme;
+    final effectiveWiredTheme = _resolveWiredTheme(
+      context: context,
+      effectiveDarkTheme: effectiveDarkTheme,
+      effectiveHighContrastTheme: effectiveHighContrastTheme,
+      effectiveHighContrastDarkTheme: effectiveHighContrastDarkTheme,
+    );
     final theme = wiredTheme.toThemeData();
     final darkTheme = effectiveDarkTheme.toThemeData(
+      brightness: Brightness.dark,
+    );
+    final highContrastTheme = effectiveHighContrastTheme.toThemeData();
+    final highContrastDarkTheme = effectiveHighContrastDarkTheme.toThemeData(
       brightness: Brightness.dark,
     );
 
@@ -135,12 +195,16 @@ class WiredMaterialApp extends HookWidget {
           ? MaterialApp.router(
               title: title,
               onGenerateTitle: onGenerateTitle,
+              onNavigationNotification: onNavigationNotification,
               color: color,
               theme: theme,
               darkTheme: darkTheme,
+              highContrastTheme: highContrastTheme,
+              highContrastDarkTheme: highContrastDarkTheme,
               themeMode: themeMode,
               themeAnimationDuration: themeAnimationDuration,
               themeAnimationCurve: themeAnimationCurve,
+              themeAnimationStyle: themeAnimationStyle,
               routeInformationProvider: routeInformationProvider,
               routeInformationParser: routeInformationParser,
               routerDelegate: routerDelegate,
@@ -157,17 +221,28 @@ class WiredMaterialApp extends HookWidget {
               restorationScopeId: restorationScopeId,
               shortcuts: shortcuts,
               actions: actions,
+              debugShowMaterialGrid: debugShowMaterialGrid,
+              showPerformanceOverlay: showPerformanceOverlay,
+              checkerboardRasterCacheImages: checkerboardRasterCacheImages,
+              checkerboardOffscreenLayers: checkerboardOffscreenLayers,
+              showSemanticsDebugger: showSemanticsDebugger,
               debugShowCheckedModeBanner: debugShowCheckedModeBanner,
+              // ignore: deprecated_member_use_from_same_package
+              useInheritedMediaQuery: useInheritedMediaQuery,
             )
           : MaterialApp(
               title: title,
               onGenerateTitle: onGenerateTitle,
+              onNavigationNotification: onNavigationNotification,
               color: color,
               theme: theme,
               darkTheme: darkTheme,
+              highContrastTheme: highContrastTheme,
+              highContrastDarkTheme: highContrastDarkTheme,
               themeMode: themeMode,
               themeAnimationDuration: themeAnimationDuration,
               themeAnimationCurve: themeAnimationCurve,
+              themeAnimationStyle: themeAnimationStyle,
               home: home,
               routes: routes,
               initialRoute: initialRoute,
@@ -187,21 +262,43 @@ class WiredMaterialApp extends HookWidget {
               restorationScopeId: restorationScopeId,
               shortcuts: shortcuts,
               actions: actions,
+              debugShowMaterialGrid: debugShowMaterialGrid,
+              showPerformanceOverlay: showPerformanceOverlay,
+              checkerboardRasterCacheImages: checkerboardRasterCacheImages,
+              checkerboardOffscreenLayers: checkerboardOffscreenLayers,
+              showSemanticsDebugger: showSemanticsDebugger,
               debugShowCheckedModeBanner: debugShowCheckedModeBanner,
+              // ignore: deprecated_member_use_from_same_package
+              useInheritedMediaQuery: useInheritedMediaQuery,
             ),
     );
   }
 
-  WiredThemeData _resolveWiredTheme(WiredThemeData effectiveDarkTheme) {
+  WiredThemeData _resolveWiredTheme({
+    required BuildContext context,
+    required WiredThemeData effectiveDarkTheme,
+    required WiredThemeData effectiveHighContrastTheme,
+    required WiredThemeData effectiveHighContrastDarkTheme,
+  }) {
+    final platformDispatcher =
+        View.maybeOf(context)?.platformDispatcher ?? PlatformDispatcher.instance;
+    final isHighContrast = platformDispatcher.accessibilityFeatures.highContrast;
+
     switch (themeMode) {
       case ThemeMode.light:
-        return wiredTheme;
+        return isHighContrast ? effectiveHighContrastTheme : wiredTheme;
       case ThemeMode.dark:
-        return effectiveDarkTheme;
+        return isHighContrast
+            ? effectiveHighContrastDarkTheme
+            : effectiveDarkTheme;
       case ThemeMode.system:
-        return PlatformDispatcher.instance.platformBrightness == Brightness.dark
-            ? effectiveDarkTheme
-            : wiredTheme;
+        final isDark = platformDispatcher.platformBrightness == Brightness.dark;
+        if (isDark) {
+          return isHighContrast
+              ? effectiveHighContrastDarkTheme
+              : effectiveDarkTheme;
+        }
+        return isHighContrast ? effectiveHighContrastTheme : wiredTheme;
     }
   }
 }

--- a/packages/skribble/test/widgets/wired_material_app_test.dart
+++ b/packages/skribble/test/widgets/wired_material_app_test.dart
@@ -101,6 +101,85 @@ void main() {
       expect(capturedTheme.borderColor, darkTheme.borderColor);
     });
 
+    testWidgets('applies high contrast wired theme when accessibility mode is enabled', (
+      tester,
+    ) async {
+      addTearDown(() {
+        tester.platformDispatcher.accessibilityFeaturesTestValue =
+            const FakeAccessibilityFeatures();
+      });
+      tester.platformDispatcher.accessibilityFeaturesTestValue =
+          FakeAccessibilityFeatures.allOn;
+
+      late WiredThemeData capturedTheme;
+      final highContrastTheme = WiredThemeData(
+        borderColor: const Color(0xFF12006B),
+        textColor: const Color(0xFF111111),
+        fillColor: const Color(0xFFFFFFF8),
+      );
+
+      await tester.pumpWidget(
+        WiredMaterialApp(
+          wiredTheme: WiredThemeData(),
+          highContrastWiredTheme: highContrastTheme,
+          home: Builder(
+            builder: (context) {
+              capturedTheme = WiredTheme.of(context);
+              return const Text('High Contrast Home');
+            },
+          ),
+        ),
+      );
+
+      final materialApp = tester.widget<MaterialApp>(find.byType(MaterialApp));
+      expect(capturedTheme.borderColor, highContrastTheme.borderColor);
+      expect(capturedTheme.fillColor, highContrastTheme.fillColor);
+      expect(
+        materialApp.highContrastTheme?.colorScheme.primary,
+        highContrastTheme.borderColor,
+      );
+    });
+
+    testWidgets('applies high contrast dark wired theme in dark mode', (
+      tester,
+    ) async {
+      addTearDown(() {
+        tester.platformDispatcher.accessibilityFeaturesTestValue =
+            const FakeAccessibilityFeatures();
+      });
+      tester.platformDispatcher.accessibilityFeaturesTestValue =
+          FakeAccessibilityFeatures.allOn;
+
+      late WiredThemeData capturedTheme;
+      final highContrastDarkTheme = WiredThemeData(
+        borderColor: const Color(0xFFFFF4C1),
+        textColor: const Color(0xFFFDF9ED),
+        fillColor: const Color(0xFF14110F),
+      );
+
+      await tester.pumpWidget(
+        WiredMaterialApp(
+          wiredTheme: WiredThemeData(),
+          themeMode: ThemeMode.dark,
+          highContrastDarkWiredTheme: highContrastDarkTheme,
+          home: Builder(
+            builder: (context) {
+              capturedTheme = WiredTheme.of(context);
+              return const Text('High Contrast Dark Home');
+            },
+          ),
+        ),
+      );
+
+      final materialApp = tester.widget<MaterialApp>(find.byType(MaterialApp));
+      expect(capturedTheme.borderColor, highContrastDarkTheme.borderColor);
+      expect(capturedTheme.fillColor, highContrastDarkTheme.fillColor);
+      expect(
+        materialApp.highContrastDarkTheme?.colorScheme.primary,
+        highContrastDarkTheme.borderColor,
+      );
+    });
+
     testWidgets('forwards shared MaterialApp configuration', (tester) async {
       Locale localeListCallback(
         List<Locale>? locales,
@@ -110,14 +189,20 @@ void main() {
         Locale? locale,
         Iterable<Locale> supportedLocales,
       ) => const Locale('en', 'US');
+      bool onNavigationNotification(NavigationNotification notification) => true;
       const scrollBehavior = _TestScrollBehavior();
       final action = _TestIntentAction();
       String titleBuilder(BuildContext context) => 'Generated Title';
+      const themeAnimationStyle = AnimationStyle(
+        duration: Duration(milliseconds: 275),
+        curve: Curves.easeInOut,
+      );
 
       await tester.pumpWidget(
         WiredMaterialApp(
           wiredTheme: WiredThemeData(),
           onGenerateTitle: titleBuilder,
+          onNavigationNotification: onNavigationNotification,
           color: const Color(0xFF112233),
           localeListResolutionCallback: localeListCallback,
           localeResolutionCallback: localeCallback,
@@ -129,12 +214,24 @@ void main() {
           actions: <Type, Action<Intent>>{_TestIntent: action},
           themeAnimationDuration: const Duration(milliseconds: 420),
           themeAnimationCurve: Curves.easeInOutCubic,
+          themeAnimationStyle: themeAnimationStyle,
+          debugShowMaterialGrid: true,
+          showPerformanceOverlay: true,
+          checkerboardRasterCacheImages: true,
+          checkerboardOffscreenLayers: true,
+          showSemanticsDebugger: true,
+          // ignore: deprecated_member_use_from_same_package
+          useInheritedMediaQuery: true,
           home: const Text('Config Home'),
         ),
       );
 
       final materialApp = tester.widget<MaterialApp>(find.byType(MaterialApp));
       expect(materialApp.onGenerateTitle, same(titleBuilder));
+      expect(
+        materialApp.onNavigationNotification,
+        same(onNavigationNotification),
+      );
       expect(materialApp.color, const Color(0xFF112233));
       expect(materialApp.localeListResolutionCallback, same(localeListCallback));
       expect(materialApp.localeResolutionCallback, same(localeCallback));
@@ -142,6 +239,13 @@ void main() {
       expect(materialApp.restorationScopeId, 'wired-app');
       expect(materialApp.themeAnimationDuration, const Duration(milliseconds: 420));
       expect(materialApp.themeAnimationCurve, Curves.easeInOutCubic);
+      expect(materialApp.themeAnimationStyle, same(themeAnimationStyle));
+      expect(materialApp.debugShowMaterialGrid, isTrue);
+      expect(materialApp.showPerformanceOverlay, isTrue);
+      expect(materialApp.checkerboardRasterCacheImages, isTrue);
+      expect(materialApp.checkerboardOffscreenLayers, isTrue);
+      expect(materialApp.showSemanticsDebugger, isTrue);
+      expect(materialApp.useInheritedMediaQuery, isTrue);
       expect(materialApp.shortcuts, isNotNull);
       expect(materialApp.actions, isNotNull);
       expect(materialApp.actions![_TestIntent], same(action));
@@ -233,14 +337,20 @@ void main() {
         Locale? locale,
         Iterable<Locale> supportedLocales,
       ) => const Locale('en', 'US');
+      bool onNavigationNotification(NavigationNotification notification) => true;
       const scrollBehavior = _TestScrollBehavior();
       final action = _TestIntentAction();
       String titleBuilder(BuildContext context) => 'Router Title';
+      const themeAnimationStyle = AnimationStyle(
+        duration: Duration(milliseconds: 220),
+        curve: Curves.easeOut,
+      );
 
       await tester.pumpWidget(
         WiredMaterialApp.router(
           wiredTheme: WiredThemeData(),
           onGenerateTitle: titleBuilder,
+          onNavigationNotification: onNavigationNotification,
           color: const Color(0xFF332211),
           localeListResolutionCallback: localeListCallback,
           localeResolutionCallback: localeCallback,
@@ -252,6 +362,14 @@ void main() {
           actions: <Type, Action<Intent>>{_TestIntent: action},
           themeAnimationDuration: const Duration(milliseconds: 360),
           themeAnimationCurve: Curves.easeOutQuart,
+          themeAnimationStyle: themeAnimationStyle,
+          debugShowMaterialGrid: true,
+          showPerformanceOverlay: true,
+          checkerboardRasterCacheImages: true,
+          checkerboardOffscreenLayers: true,
+          showSemanticsDebugger: true,
+          // ignore: deprecated_member_use_from_same_package
+          useInheritedMediaQuery: true,
           routeInformationParser: const _TestRouteInformationParser(),
           routerDelegate: _TestRouterDelegate(
             (_) => const Text('Router Config Home'),
@@ -261,6 +379,10 @@ void main() {
 
       final materialApp = tester.widget<MaterialApp>(find.byType(MaterialApp));
       expect(materialApp.onGenerateTitle, same(titleBuilder));
+      expect(
+        materialApp.onNavigationNotification,
+        same(onNavigationNotification),
+      );
       expect(materialApp.color, const Color(0xFF332211));
       expect(materialApp.localeListResolutionCallback, same(localeListCallback));
       expect(materialApp.localeResolutionCallback, same(localeCallback));
@@ -268,6 +390,13 @@ void main() {
       expect(materialApp.restorationScopeId, 'wired-router-app');
       expect(materialApp.themeAnimationDuration, const Duration(milliseconds: 360));
       expect(materialApp.themeAnimationCurve, Curves.easeOutQuart);
+      expect(materialApp.themeAnimationStyle, same(themeAnimationStyle));
+      expect(materialApp.debugShowMaterialGrid, isTrue);
+      expect(materialApp.showPerformanceOverlay, isTrue);
+      expect(materialApp.checkerboardRasterCacheImages, isTrue);
+      expect(materialApp.checkerboardOffscreenLayers, isTrue);
+      expect(materialApp.showSemanticsDebugger, isTrue);
+      expect(materialApp.useInheritedMediaQuery, isTrue);
       expect(materialApp.shortcuts, isNotNull);
       expect(materialApp.actions, isNotNull);
       expect(materialApp.actions![_TestIntent], same(action));


### PR DESCRIPTION
## Summary
- add high-contrast light/dark app theme variants to `WiredMaterialApp` and `WiredMaterialApp.router`
- expose the remaining high-value `MaterialApp` diagnostics and configuration flags, including navigation notifications, theme animation style, performance / semantics overlays, checkerboard flags, and the deprecated `useInheritedMediaQuery` surface for parity
- add focused tests and docs for the expanded app-level bridge

Closes #95
Refs #85

## Validation
- dprint fmt packages/skribble/README.md docs/ui-snapshots/parity-matrix.md
- dart analyze --fatal-infos .
- flutter test packages/skribble/test/widgets/wired_material_app_test.dart
- ./scripts/check_rough_icons_ci.sh generated-sync
