### PR TITLE
feat: add Sketch Notes example app demonstrating end-to-end Skribble

### DIFF
--- a/.changeset/skribble-example-app.md
+++ b/.changeset/skribble-example-app.md
@@ -1,0 +1,7 @@
+---
+skribble: patch
+---
+
+Add "Sketch Notes" example app demonstrating end-to-end Skribble usage with
+WiredMaterialApp, WiredScaffold, navigation drawer, search, forms, dismissible
+cards, settings, and about dialog — all using only hand-drawn Wired* widgets.

--- a/apps/skribble_example/analysis_options.yaml
+++ b/apps/skribble_example/analysis_options.yaml
@@ -1,0 +1,18 @@
+include: package:skribble_lints/analysis_options.yaml
+
+linter:
+  rules:
+    # Demo app uses many widget literals
+    prefer_const_constructors: false
+    prefer_const_literals_to_create_immutables: false
+    # Demo code uses relative imports for internal files
+    always_use_package_imports: false
+    # Demo code keeps fields before constructors for readability
+    sort_constructors_first: false
+    # Cascade invocations sometimes read worse in demo code
+    cascade_invocations: false
+
+analyzer:
+  errors:
+    # Deprecated API usage until migration
+    deprecated_member_use: ignore

--- a/apps/skribble_example/lib/app.dart
+++ b/apps/skribble_example/lib/app.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:skribble/skribble.dart';
+
+import 'package:skribble_example/pages/edit_page.dart';
+import 'package:skribble_example/pages/home_page.dart';
+import 'package:skribble_example/pages/settings_page.dart';
+
+/// The root widget for the Sketch Notes app.
+///
+/// Uses [WiredMaterialApp] with a warm sepia theme to give the entire
+/// app a cohesive hand-drawn, parchment-like feel.
+class SketchNotesApp extends HookWidget {
+  const SketchNotesApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final wiredTheme = WiredThemeData(
+      borderColor: const Color(0xFF5C3D2E),
+      textColor: const Color(0xFF2E2E2E),
+      disabledTextColor: const Color(0xFFA89888),
+      fillColor: const Color(0xFFF5ECD7),
+      roughness: 1.2,
+    );
+
+    return WiredMaterialApp(
+      wiredTheme: wiredTheme,
+      title: 'Sketch Notes',
+      initialRoute: '/',
+      routes: {
+        '/': (context) => const HomePage(),
+        '/edit': (context) => const EditPage(),
+        '/settings': (context) => const SettingsPage(),
+      },
+    );
+  }
+}

--- a/apps/skribble_example/lib/main.dart
+++ b/apps/skribble_example/lib/main.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+import 'package:skribble_example/app.dart';
+
+void main() {
+  runApp(const SketchNotesApp());
+}

--- a/apps/skribble_example/lib/models/note.dart
+++ b/apps/skribble_example/lib/models/note.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+/// A simple note model for the Sketch Notes app.
+class Note {
+  Note({
+    required this.id,
+    required this.title,
+    required this.content,
+    required this.color,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  /// Creates a new note with a generated ID based on the current time.
+  factory Note.create({
+    String title = '',
+    String content = '',
+    Color color = const Color(0xFFF5ECD7),
+  }) {
+    final now = DateTime.now();
+    final id =
+        '${now.millisecondsSinceEpoch}-${now.microsecond}';
+    return Note(
+      id: id,
+      title: title,
+      content: content,
+      color: color,
+      createdAt: now,
+      updatedAt: now,
+    );
+  }
+
+  final String id;
+  final String title;
+  final String content;
+  final Color color;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  /// Returns a copy with the given fields replaced.
+  Note copyWith({
+    String? title,
+    String? content,
+    Color? color,
+    DateTime? updatedAt,
+  }) {
+    return Note(
+      id: id,
+      title: title ?? this.title,
+      content: content ?? this.content,
+      color: color ?? this.color,
+      createdAt: createdAt,
+      updatedAt: updatedAt ?? DateTime.now(),
+    );
+  }
+}

--- a/apps/skribble_example/lib/pages/edit_page.dart
+++ b/apps/skribble_example/lib/pages/edit_page.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:skribble/skribble.dart';
+
+import 'package:skribble_example/models/note.dart';
+
+/// Color options available for notes.
+const _colorOptions = <Color>[
+  Color(0xFFF5ECD7), // Parchment (default)
+  Color(0xFFE8F5E9), // Soft green
+  Color(0xFFE3F2FD), // Soft blue
+  Color(0xFFFFF3E0), // Soft orange
+  Color(0xFFF3E5F5), // Soft purple
+];
+
+const _colorLabels = <String>[
+  'Parchment',
+  'Green',
+  'Blue',
+  'Orange',
+  'Purple',
+];
+
+/// The note editing page.
+///
+/// Uses [WiredInput] for the title, [WiredTextArea] for content, and a
+/// row of [WiredChip] widgets for color label selection.
+class EditPage extends HookWidget {
+  const EditPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final existingNote =
+        ModalRoute.of(context)?.settings.arguments as Note?;
+    final isNew = existingNote == null;
+
+    final titleController = useTextEditingController(
+      text: existingNote?.title ?? '',
+    );
+    final contentController = useTextEditingController(
+      text: existingNote?.content ?? '',
+    );
+    final selectedColor = useState(
+      existingNote?.color ?? _colorOptions.first,
+    );
+
+    return WiredScaffold(
+      appBar: WiredAppBar(
+        leading: WiredIconButton(
+          icon: Icons.arrow_back,
+          size: 40,
+          onPressed: () => Navigator.pop(context),
+          semanticLabel: 'Go back',
+        ),
+        title: Text(isNew ? 'New Note' : 'Edit Note'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            WiredInput(
+              controller: titleController,
+              hintText: 'Note title...',
+            ),
+            const SizedBox(height: 16),
+            WiredTextArea(
+              controller: contentController,
+              hintText: 'Write your thoughts...',
+              maxLines: 12,
+              minLines: 6,
+            ),
+            const SizedBox(height: 20),
+            Text(
+              'Label color',
+              style: TextStyle(
+                color: WiredTheme.of(context).textColor,
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: List.generate(_colorOptions.length, (index) {
+                final color = _colorOptions[index];
+                final isSelected = selectedColor.value == color;
+                return GestureDetector(
+                  onTap: () => selectedColor.value = color,
+                  child: WiredChip(
+                    avatar: Container(
+                      width: 14,
+                      height: 14,
+                      decoration: BoxDecoration(
+                        color: color,
+                        shape: BoxShape.circle,
+                        border: Border.all(
+                          color: const Color(0xFF5C3D2E),
+                          width: isSelected ? 2 : 1,
+                        ),
+                      ),
+                    ),
+                    label: Text(
+                      _colorLabels[index],
+                      style: TextStyle(
+                        fontWeight:
+                            isSelected ? FontWeight.bold : FontWeight.normal,
+                      ),
+                    ),
+                  ),
+                );
+              }),
+            ),
+            const SizedBox(height: 24),
+            WiredButton(
+              onPressed: () {
+                final note = isNew
+                    ? Note.create(
+                        title: titleController.text,
+                        content: contentController.text,
+                        color: selectedColor.value,
+                      )
+                    : existingNote.copyWith(
+                        title: titleController.text,
+                        content: contentController.text,
+                        color: selectedColor.value,
+                      );
+                Navigator.pop(context, note);
+              },
+              child: Text(isNew ? 'Create Note' : 'Save Changes'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/skribble_example/lib/pages/home_page.dart
+++ b/apps/skribble_example/lib/pages/home_page.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:skribble/skribble.dart';
+
+import 'package:skribble_example/models/note.dart';
+import 'package:skribble_example/widgets/drawer_menu.dart';
+import 'package:skribble_example/widgets/note_card.dart';
+
+/// The main notes list page.
+///
+/// Displays all notes as [WiredCard] items in a scrollable list with a
+/// [WiredSearchBar] for filtering, a [WiredFloatingActionButton] for
+/// creating new notes, and a [WiredDrawer] accessible via the app bar.
+class HomePage extends HookWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final notes = useState<List<Note>>(_sampleNotes());
+    final searchQuery = useState('');
+    final searchController = useTextEditingController();
+
+    final filteredNotes = useMemoized(
+      () {
+        if (searchQuery.value.isEmpty) return notes.value;
+        final query = searchQuery.value.toLowerCase();
+        return notes.value.where((note) {
+          return note.title.toLowerCase().contains(query) ||
+              note.content.toLowerCase().contains(query);
+        }).toList();
+      },
+      [notes.value, searchQuery.value],
+    );
+
+    return WiredScaffold(
+      appBar: WiredAppBar(
+        leading: Builder(
+          builder: (context) => WiredIconButton(
+            icon: Icons.menu,
+            size: 40,
+            onPressed: () => Scaffold.of(context).openDrawer(),
+            semanticLabel: 'Open menu',
+          ),
+        ),
+        title: const Text('Sketch Notes'),
+      ),
+      drawer: const DrawerMenu(),
+      floatingActionButton: WiredFloatingActionButton(
+        icon: Icons.add,
+        semanticLabel: 'Create new note',
+        onPressed: () async {
+          final result = await Navigator.pushNamed(context, '/edit');
+          if (result is Note) {
+            notes.value = [...notes.value, result];
+          }
+        },
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: WiredSearchBar(
+              controller: searchController,
+              hintText: 'Search notes...',
+              onChanged: (value) => searchQuery.value = value,
+            ),
+          ),
+          Expanded(
+            child: filteredNotes.isEmpty
+                ? Center(
+                    child: Text(
+                      searchQuery.value.isEmpty
+                          ? 'No notes yet. Tap + to create one!'
+                          : 'No notes match your search.',
+                      style: TextStyle(
+                        color: WiredTheme.of(context).disabledTextColor,
+                        fontSize: 16,
+                      ),
+                    ),
+                  )
+                : ListView.separated(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 4,
+                    ),
+                    itemCount: filteredNotes.length,
+                    separatorBuilder: (_, _) => const SizedBox(height: 8),
+                    itemBuilder: (context, index) {
+                      final note = filteredNotes[index];
+                      return WiredDismissible(
+                        dismissKey: ValueKey(note.id),
+                        direction: DismissDirection.endToStart,
+                        onDismissed: (_) {
+                          final removedNote = note;
+                          final removedIndex =
+                              notes.value.indexWhere((n) => n.id == note.id);
+                          notes.value = notes.value
+                              .where((n) => n.id != note.id)
+                              .toList();
+
+                          showWiredSnackBar(
+                            context,
+                            content: WiredSnackBarContent(
+                              action: GestureDetector(
+                                onTap: () {
+                                  final restored =
+                                      List<Note>.from(notes.value);
+                                  if (removedIndex >= 0 &&
+                                      removedIndex <= restored.length) {
+                                    restored.insert(removedIndex, removedNote);
+                                  } else {
+                                    restored.add(removedNote);
+                                  }
+                                  notes.value = restored;
+                                  ScaffoldMessenger.of(context)
+                                      .hideCurrentSnackBar();
+                                },
+                                child: Text(
+                                  'UNDO',
+                                  style: TextStyle(
+                                    color: WiredTheme.of(context).borderColor,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ),
+                              child: const Text('Note deleted'),
+                            ),
+                          );
+                        },
+                        child: NoteCard(
+                          note: note,
+                          onTap: () async {
+                            final result = await Navigator.pushNamed(
+                              context,
+                              '/edit',
+                              arguments: note,
+                            );
+                            if (result is Note) {
+                              notes.value = notes.value
+                                  .map(
+                                    (n) => n.id == result.id ? result : n,
+                                  )
+                                  .toList();
+                            }
+                          },
+                        ),
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+List<Note> _sampleNotes() {
+  return [
+    Note(
+      id: 'sample-1',
+      title: 'Welcome to Sketch Notes',
+      content:
+          'This is a hand-drawn notes app built with the Skribble design '
+          'system. Every element you see has a sketchy, hand-drawn feel!',
+      color: const Color(0xFFF5ECD7),
+      createdAt: DateTime.now().subtract(const Duration(days: 2)),
+      updatedAt: DateTime.now().subtract(const Duration(days: 2)),
+    ),
+    Note(
+      id: 'sample-2',
+      title: 'Shopping List',
+      content: 'Milk, eggs, bread, butter, coffee beans, sketchbook',
+      color: const Color(0xFFE8F5E9),
+      createdAt: DateTime.now().subtract(const Duration(days: 1)),
+      updatedAt: DateTime.now().subtract(const Duration(days: 1)),
+    ),
+    Note(
+      id: 'sample-3',
+      title: 'Project Ideas',
+      content:
+          'Build a weather app with hand-drawn clouds and sunshine '
+          'animations. Use the Skribble canvas for custom drawings.',
+      color: const Color(0xFFE3F2FD),
+      createdAt: DateTime.now().subtract(const Duration(hours: 3)),
+      updatedAt: DateTime.now(),
+    ),
+  ];
+}

--- a/apps/skribble_example/lib/pages/settings_page.dart
+++ b/apps/skribble_example/lib/pages/settings_page.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:skribble/skribble.dart';
+
+/// The settings page for the Sketch Notes app.
+///
+/// Demonstrates [WiredSwitchListTile], [WiredSlider], [WiredDivider],
+/// and [showWiredAboutDialog] in a cohesive settings layout.
+class SettingsPage extends HookWidget {
+  const SettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final darkMode = useState(false);
+    final roughness = useState(1.2);
+
+    return WiredScaffold(
+      appBar: WiredAppBar(
+        leading: WiredIconButton(
+          icon: Icons.arrow_back,
+          size: 40,
+          onPressed: () => Navigator.pop(context),
+          semanticLabel: 'Go back',
+        ),
+        title: const Text('Settings'),
+      ),
+      body: ListView(
+        children: [
+          const SizedBox(height: 8),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Text(
+              'Appearance',
+              style: TextStyle(
+                color: WiredTheme.of(context).borderColor,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 0.5,
+              ),
+            ),
+          ),
+          WiredSwitchListTile(
+            value: darkMode.value,
+            onChanged: (value) => darkMode.value = value,
+            title: const Text('Dark Mode'),
+            subtitle: const Text('Toggle dark theme'),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Roughness: ${roughness.value.toStringAsFixed(1)}',
+                  style: TextStyle(
+                    color: WiredTheme.of(context).textColor,
+                    fontSize: 16,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Adjust the sketchiness of drawn elements',
+                  style: TextStyle(
+                    color: WiredTheme.of(context).disabledTextColor,
+                    fontSize: 14,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                WiredSlider(
+                  value: roughness.value,
+                  min: 0.5,
+                  max: 2.5,
+                  onChanged: (value) {
+                    roughness.value = value;
+                    return true;
+                  },
+                ),
+              ],
+            ),
+          ),
+          const WiredDivider(),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Text(
+              'General',
+              style: TextStyle(
+                color: WiredTheme.of(context).borderColor,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 0.5,
+              ),
+            ),
+          ),
+          WiredListTile(
+            leading: const WiredIcon(
+              icon: Icons.palette,
+              size: 22,
+              strokeWidth: 1.2,
+            ),
+            title: const Text('Theme'),
+            subtitle: const Text('Warm parchment'),
+          ),
+          WiredListTile(
+            leading: const WiredIcon(
+              icon: Icons.text_fields,
+              size: 22,
+              strokeWidth: 1.2,
+            ),
+            title: const Text('Font Size'),
+            subtitle: const Text('Medium'),
+          ),
+          const WiredDivider(),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Text(
+              'Information',
+              style: TextStyle(
+                color: WiredTheme.of(context).borderColor,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 0.5,
+              ),
+            ),
+          ),
+          WiredListTile(
+            leading: const WiredIcon(
+              icon: Icons.info_outline,
+              size: 22,
+              strokeWidth: 1.2,
+            ),
+            title: const Text('About'),
+            subtitle: const Text('Version 1.0.0'),
+            showDivider: false,
+            onTap: () async {
+              await showWiredAboutDialog(
+                context: context,
+                applicationName: 'Sketch Notes',
+                applicationVersion: '1.0.0',
+                applicationLegalese:
+                    'A hand-drawn notes app built with the Skribble '
+                    'design system.\n\nMade with sketchy love.',
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/skribble_example/lib/widgets/drawer_menu.dart
+++ b/apps/skribble_example/lib/widgets/drawer_menu.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:skribble/skribble.dart';
+
+/// The drawer menu for the Sketch Notes app.
+///
+/// Shows a hand-drawn header with the app title and avatar, followed by
+/// navigation items for "All Notes", "Settings", and "About".
+class DrawerMenu extends HookWidget {
+  const DrawerMenu({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return WiredDrawer(
+      child: ListView(
+        padding: EdgeInsets.zero,
+        children: [
+          SizedBox(
+            height: 170,
+            child: WiredDrawerHeader(
+              child: Row(
+                children: [
+                  const WiredAvatar(
+                    radius: 28,
+                    child: WiredIcon(
+                      icon: Icons.edit,
+                      size: 24,
+                      strokeWidth: 1.2,
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Flexible(
+                    child: Text(
+                      'Sketch Notes',
+                      style: TextStyle(
+                        fontSize: 22,
+                        fontWeight: FontWeight.bold,
+                        color: WiredTheme.of(context).textColor,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          WiredListTile(
+            leading: const WiredIcon(
+              icon: Icons.notes,
+              size: 22,
+              strokeWidth: 1.2,
+            ),
+            title: const Text('All Notes'),
+            onTap: () async {
+              Navigator.pop(context);
+              await Navigator.pushReplacementNamed(context, '/');
+            },
+          ),
+          const WiredDivider(),
+          WiredListTile(
+            leading: const WiredIcon(
+              icon: Icons.settings,
+              size: 22,
+              strokeWidth: 1.2,
+            ),
+            title: const Text('Settings'),
+            onTap: () async {
+              Navigator.pop(context);
+              await Navigator.pushNamed(context, '/settings');
+            },
+          ),
+          WiredListTile(
+            leading: const WiredIcon(
+              icon: Icons.info_outline,
+              size: 22,
+              strokeWidth: 1.2,
+            ),
+            title: const Text('About'),
+            showDivider: false,
+            onTap: () async {
+              Navigator.pop(context);
+              await showWiredAboutDialog(
+                context: context,
+                applicationName: 'Sketch Notes',
+                applicationVersion: '1.0.0',
+                applicationLegalese:
+                    'Built with the Skribble hand-drawn design system.',
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/skribble_example/lib/widgets/note_card.dart
+++ b/apps/skribble_example/lib/widgets/note_card.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:skribble/skribble.dart';
+
+import 'package:skribble_example/models/note.dart';
+
+/// A reusable card widget for displaying a note preview in the list.
+///
+/// Shows the note title in bold, a content preview (first 50 characters),
+/// and the date. Displays a [WiredBadge] if the note was updated today.
+class NoteCard extends HookWidget {
+  const NoteCard({
+    required this.note,
+    super.key,
+    this.onTap,
+  });
+
+  final Note note;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final now = DateTime.now();
+    final isUpdatedToday = note.updatedAt.year == now.year &&
+        note.updatedAt.month == now.month &&
+        note.updatedAt.day == now.day;
+
+    final contentPreview = note.content.length > 50
+        ? '${note.content.substring(0, 50)}...'
+        : note.content;
+
+    final dateString =
+        '${note.updatedAt.month}/${note.updatedAt.day}/${note.updatedAt.year}';
+
+    final card = WiredCard(
+      height: null,
+      child: WiredListTile(
+        onTap: onTap,
+        showDivider: false,
+        leading: Container(
+          width: 12,
+          height: 12,
+          decoration: BoxDecoration(
+            color: note.color,
+            shape: BoxShape.circle,
+            border: Border.all(color: const Color(0xFF5C3D2E)),
+          ),
+        ),
+        title: Text(
+          note.title.isEmpty ? 'Untitled' : note.title,
+          style: const TextStyle(fontWeight: FontWeight.bold),
+        ),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (contentPreview.isNotEmpty)
+              Text(
+                contentPreview,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            const SizedBox(height: 4),
+            Text(
+              dateString,
+              style: const TextStyle(fontSize: 12),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    if (isUpdatedToday) {
+      return WiredBadge(label: 'new', child: card);
+    }
+
+    return card;
+  }
+}

--- a/apps/skribble_example/pubspec.yaml
+++ b/apps/skribble_example/pubspec.yaml
@@ -1,0 +1,26 @@
+name: skribble_example
+description: >
+  A hand-drawn notes app demonstrating the Skribble design system.
+publish_to: none
+
+environment:
+  sdk: ^3.11.0
+  flutter: ^3.41.0
+
+resolution: workspace
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_hooks: ^0.21.3
+  skribble:
+    path: ../../packages/skribble
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  skribble_lints:
+    path: ../../packages/skribble_lints
+
+flutter:
+  uses-material-design: true

--- a/apps/skribble_example/test/app_test.dart
+++ b/apps/skribble_example/test/app_test.dart
@@ -1,14 +1,12 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:skribble/skribble.dart';
 
 import 'package:skribble_example/app.dart';
 import 'package:skribble_example/models/note.dart';
 import 'package:skribble_example/pages/edit_page.dart';
-import 'package:skribble_example/pages/settings_page.dart';
 import 'package:skribble_example/widgets/drawer_menu.dart';
 import 'package:skribble_example/widgets/note_card.dart';
 
@@ -23,24 +21,6 @@ Widget _wrapInApp(Widget child) {
       roughness: 1.2,
     ),
     home: child,
-  );
-}
-
-/// Helper to wrap a widget in a [WiredMaterialApp] with routes.
-Widget _wrapInAppWithRoutes({
-  required Widget home,
-  Map<String, WidgetBuilder> routes = const {},
-}) {
-  return WiredMaterialApp(
-    wiredTheme: WiredThemeData(
-      borderColor: const Color(0xFF5C3D2E),
-      textColor: const Color(0xFF2E2E2E),
-      disabledTextColor: const Color(0xFFA89888),
-      fillColor: const Color(0xFFF5ECD7),
-      roughness: 1.2,
-    ),
-    home: home,
-    routes: routes,
   );
 }
 
@@ -306,11 +286,11 @@ void main() {
                   builder: (context) {
                     // Navigate immediately.
                     WidgetsBinding.instance.addPostFrameCallback((_) {
-                      Navigator.pushNamed(
+                      unawaited(Navigator.pushNamed(
                         context,
                         '/edit',
                         arguments: existingNote,
-                      );
+                      ));
                     });
                     return const SizedBox.shrink();
                   },
@@ -353,7 +333,7 @@ void main() {
   group('Settings page', () {
     // Helper: navigate to settings page and return the NavigatorState so
     // the caller can pop back (required to dispose WiredSlider's timer).
-    Future<NavigatorState> _pumpSettings(WidgetTester tester) async {
+    Future<NavigatorState> pumpSettings(WidgetTester tester) async {
       await tester.pumpWidget(const SketchNotesApp());
       await tester.pumpAndSettle();
 
@@ -368,7 +348,7 @@ void main() {
     }
 
     /// Pop the settings page so WiredSlider's pending timer is disposed.
-    Future<void> _popSettings(
+    Future<void> popSettings(
       WidgetTester tester,
       NavigatorState navigator,
     ) async {
@@ -377,16 +357,16 @@ void main() {
     }
 
     testWidgets('dark mode switch is present', (tester) async {
-      final nav = await _pumpSettings(tester);
+      final nav = await pumpSettings(tester);
 
       expect(find.text('Dark Mode'), findsOneWidget);
       expect(find.text('Toggle dark theme'), findsOneWidget);
 
-      await _popSettings(tester, nav);
+      await popSettings(tester, nav);
     });
 
     testWidgets('roughness slider renders with initial value', (tester) async {
-      final nav = await _pumpSettings(tester);
+      final nav = await pumpSettings(tester);
 
       expect(find.text('Roughness: 1.2'), findsOneWidget);
       expect(
@@ -395,11 +375,11 @@ void main() {
       );
       expect(find.byType(WiredSlider), findsOneWidget);
 
-      await _popSettings(tester, nav);
+      await popSettings(tester, nav);
     });
 
     testWidgets('about list tile triggers about dialog', (tester) async {
-      final nav = await _pumpSettings(tester);
+      final nav = await pumpSettings(tester);
 
       expect(find.text('About'), findsOneWidget);
       expect(find.text('Version 1.0.0'), findsOneWidget);
@@ -424,28 +404,28 @@ void main() {
         await tester.pump(const Duration(milliseconds: 50));
       }
 
-      await _popSettings(tester, nav);
+      await popSettings(tester, nav);
     });
 
     testWidgets('renders section headers', (tester) async {
-      final nav = await _pumpSettings(tester);
+      final nav = await pumpSettings(tester);
 
       expect(find.text('Appearance'), findsOneWidget);
       expect(find.text('General'), findsOneWidget);
       expect(find.text('Information'), findsOneWidget);
 
-      await _popSettings(tester, nav);
+      await popSettings(tester, nav);
     });
 
     testWidgets('theme and font size tiles are rendered', (tester) async {
-      final nav = await _pumpSettings(tester);
+      final nav = await pumpSettings(tester);
 
       expect(find.text('Theme'), findsOneWidget);
       expect(find.text('Warm parchment'), findsOneWidget);
       expect(find.text('Font Size'), findsOneWidget);
       expect(find.text('Medium'), findsOneWidget);
 
-      await _popSettings(tester, nav);
+      await popSettings(tester, nav);
     });
   });
 
@@ -518,7 +498,7 @@ void main() {
 
     testWidgets('does not show badge when updated in the past', (tester) async {
       final note = _sampleNote(
-        updatedAt: DateTime(2020, 1, 1), // Far in the past.
+        updatedAt: DateTime(2020), // Far in the past.
       );
       await tester.pumpWidget(_wrapInApp(NoteCard(note: note)));
       await tester.pumpAndSettle();

--- a/apps/skribble_example/test/app_test.dart
+++ b/apps/skribble_example/test/app_test.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:skribble_example/app.dart';
+import 'package:skribble_example/models/note.dart';
+
+void main() {
+  group('SketchNotesApp', () {
+    testWidgets('renders without error', (tester) async {
+      await tester.pumpWidget(const SketchNotesApp());
+      await tester.pumpAndSettle();
+      expect(find.byType(SketchNotesApp), findsOneWidget);
+    });
+
+    testWidgets('home page shows "Sketch Notes" title', (tester) async {
+      await tester.pumpWidget(const SketchNotesApp());
+      await tester.pumpAndSettle();
+      expect(find.text('Sketch Notes'), findsOneWidget);
+    });
+
+    testWidgets('sample notes are visible', (tester) async {
+      await tester.pumpWidget(const SketchNotesApp());
+      await tester.pumpAndSettle();
+      expect(find.text('Welcome to Sketch Notes'), findsOneWidget);
+      expect(find.text('Shopping List'), findsOneWidget);
+      expect(find.text('Project Ideas'), findsOneWidget);
+    });
+
+    testWidgets('FAB is present', (tester) async {
+      await tester.pumpWidget(const SketchNotesApp());
+      await tester.pumpAndSettle();
+      expect(
+        find.bySemanticsLabel('Create new note'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('tapping FAB navigates to edit page', (tester) async {
+      await tester.pumpWidget(const SketchNotesApp());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.bySemanticsLabel('Create new note'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('New Note'), findsOneWidget);
+    });
+
+    testWidgets('settings page renders', (tester) async {
+      await tester.pumpWidget(const SketchNotesApp());
+      await tester.pumpAndSettle();
+
+      // Navigate to settings via the Navigator.
+      final navigator = tester.state<NavigatorState>(
+        find.byType(Navigator),
+      );
+      unawaited(navigator.pushNamed('/settings'));
+      // WiredSlider schedules a zero-duration Future on each build,
+      // so we pump enough frames for the route transition to complete.
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+
+      expect(find.text('Dark Mode'), findsOneWidget);
+
+      // Pop back to home so the WiredSlider's pending timer is
+      // disposed before the test ends.
+      navigator.pop();
+      await tester.pumpAndSettle();
+    });
+  });
+
+  group('Note model', () {
+    test('Note.create generates unique IDs', () {
+      final note1 = Note.create(title: 'A');
+      final note2 = Note.create(title: 'B');
+      expect(note1.id, isNot(equals(note2.id)));
+    });
+
+    test('copyWith updates fields', () {
+      final note = Note.create(title: 'Original', content: 'Content');
+      final updated = note.copyWith(title: 'Updated');
+      expect(updated.title, 'Updated');
+      expect(updated.content, 'Content');
+      expect(updated.id, note.id);
+    });
+  });
+}

--- a/apps/skribble_example/test/app_test.dart
+++ b/apps/skribble_example/test/app_test.dart
@@ -1,10 +1,68 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:skribble/skribble.dart';
 
 import 'package:skribble_example/app.dart';
 import 'package:skribble_example/models/note.dart';
+import 'package:skribble_example/pages/edit_page.dart';
+import 'package:skribble_example/pages/settings_page.dart';
+import 'package:skribble_example/widgets/drawer_menu.dart';
+import 'package:skribble_example/widgets/note_card.dart';
+
+/// Helper to wrap a widget in a [WiredMaterialApp] with a theme.
+Widget _wrapInApp(Widget child) {
+  return WiredMaterialApp(
+    wiredTheme: WiredThemeData(
+      borderColor: const Color(0xFF5C3D2E),
+      textColor: const Color(0xFF2E2E2E),
+      disabledTextColor: const Color(0xFFA89888),
+      fillColor: const Color(0xFFF5ECD7),
+      roughness: 1.2,
+    ),
+    home: child,
+  );
+}
+
+/// Helper to wrap a widget in a [WiredMaterialApp] with routes.
+Widget _wrapInAppWithRoutes({
+  required Widget home,
+  Map<String, WidgetBuilder> routes = const {},
+}) {
+  return WiredMaterialApp(
+    wiredTheme: WiredThemeData(
+      borderColor: const Color(0xFF5C3D2E),
+      textColor: const Color(0xFF2E2E2E),
+      disabledTextColor: const Color(0xFFA89888),
+      fillColor: const Color(0xFFF5ECD7),
+      roughness: 1.2,
+    ),
+    home: home,
+    routes: routes,
+  );
+}
+
+/// Create a sample [Note] for testing purposes.
+Note _sampleNote({
+  String id = 'test-1',
+  String title = 'Test Title',
+  String content = 'Test content for the note.',
+  Color color = const Color(0xFFF5ECD7),
+  DateTime? createdAt,
+  DateTime? updatedAt,
+}) {
+  final now = DateTime.now();
+  return Note(
+    id: id,
+    title: title,
+    content: content,
+    color: color,
+    createdAt: createdAt ?? now,
+    updatedAt: updatedAt ?? now,
+  );
+}
 
 void main() {
   group('SketchNotesApp', () {
@@ -84,6 +142,527 @@ void main() {
       expect(updated.title, 'Updated');
       expect(updated.content, 'Content');
       expect(updated.id, note.id);
+    });
+
+    test('copyWith preserves all unchanged fields', () {
+      final note = Note.create(
+        title: 'Title',
+        content: 'Content',
+        color: const Color(0xFFE8F5E9),
+      );
+      final updated = note.copyWith(content: 'New content');
+      expect(updated.title, 'Title');
+      expect(updated.content, 'New content');
+      expect(updated.color, const Color(0xFFE8F5E9));
+      expect(updated.id, note.id);
+      expect(updated.createdAt, note.createdAt);
+    });
+
+    test('Note.create default color is parchment (0xFFF5ECD7)', () {
+      final note = Note.create(title: 'Default color test');
+      expect(note.color, const Color(0xFFF5ECD7));
+    });
+
+    test('Note.create sets createdAt and updatedAt to now', () {
+      final before = DateTime.now();
+      final note = Note.create(title: 'Time test');
+      final after = DateTime.now();
+      expect(note.createdAt.isAfter(before.subtract(const Duration(seconds: 1))), isTrue);
+      expect(note.createdAt.isBefore(after.add(const Duration(seconds: 1))), isTrue);
+      expect(note.updatedAt.isAfter(before.subtract(const Duration(seconds: 1))), isTrue);
+    });
+
+    test('copyWith with color changes only the color', () {
+      final note = Note.create(title: 'A', content: 'B');
+      final updated = note.copyWith(color: const Color(0xFFE3F2FD));
+      expect(updated.color, const Color(0xFFE3F2FD));
+      expect(updated.title, 'A');
+      expect(updated.content, 'B');
+    });
+  });
+
+  group('Home page', () {
+    testWidgets('search bar is present with hint text', (tester) async {
+      await tester.pumpWidget(const SketchNotesApp());
+      await tester.pumpAndSettle();
+      expect(find.text('Search notes...'), findsOneWidget);
+    });
+
+    testWidgets('search filters notes by title', (tester) async {
+      await tester.pumpWidget(const SketchNotesApp());
+      await tester.pumpAndSettle();
+
+      // All three notes visible initially.
+      expect(find.text('Welcome to Sketch Notes'), findsOneWidget);
+      expect(find.text('Shopping List'), findsOneWidget);
+      expect(find.text('Project Ideas'), findsOneWidget);
+
+      // Type into the search bar. WiredSearchBar wraps a TextField.
+      await tester.enterText(find.byType(TextField).first, 'Shopping');
+      await tester.pumpAndSettle();
+
+      // Only Shopping List should remain visible.
+      expect(find.text('Shopping List'), findsOneWidget);
+      expect(find.text('Welcome to Sketch Notes'), findsNothing);
+      expect(find.text('Project Ideas'), findsNothing);
+    });
+
+    testWidgets('search filtering shows "No notes match" when nothing matches',
+        (tester) async {
+      await tester.pumpWidget(const SketchNotesApp());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byType(TextField).first,
+        'xyznonexistent',
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('No notes match your search.'), findsOneWidget);
+    });
+
+    testWidgets('search filters notes by content', (tester) async {
+      await tester.pumpWidget(const SketchNotesApp());
+      await tester.pumpAndSettle();
+
+      // Search for content present only in the Shopping List note.
+      await tester.enterText(find.byType(TextField).first, 'coffee beans');
+      await tester.pumpAndSettle();
+
+      expect(find.text('Shopping List'), findsOneWidget);
+      expect(find.text('Welcome to Sketch Notes'), findsNothing);
+      expect(find.text('Project Ideas'), findsNothing);
+    });
+
+    testWidgets('drawer opens when tapping menu button', (tester) async {
+      await tester.pumpWidget(const SketchNotesApp());
+      await tester.pumpAndSettle();
+
+      // Tap the menu icon button.
+      await tester.tap(find.bySemanticsLabel('Open menu'));
+      await tester.pumpAndSettle();
+
+      // Drawer should now be visible with its contents.
+      expect(find.text('All Notes'), findsOneWidget);
+      expect(find.text('Settings'), findsOneWidget);
+    });
+  });
+
+  group('Edit page', () {
+    testWidgets('renders title and content input fields for new note',
+        (tester) async {
+      await tester.pumpWidget(_wrapInApp(const EditPage()));
+      await tester.pumpAndSettle();
+
+      // "New Note" title in the app bar.
+      expect(find.text('New Note'), findsOneWidget);
+      // Hint texts for the input fields.
+      expect(find.text('Note title...'), findsOneWidget);
+      expect(find.text('Write your thoughts...'), findsOneWidget);
+    });
+
+    testWidgets('save button shows "Create Note" for new notes',
+        (tester) async {
+      await tester.pumpWidget(_wrapInApp(const EditPage()));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Create Note'), findsOneWidget);
+    });
+
+    testWidgets('color chips are displayed with all labels', (tester) async {
+      await tester.pumpWidget(_wrapInApp(const EditPage()));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Label color'), findsOneWidget);
+      expect(find.text('Parchment'), findsOneWidget);
+      expect(find.text('Green'), findsOneWidget);
+      expect(find.text('Blue'), findsOneWidget);
+      expect(find.text('Orange'), findsOneWidget);
+      expect(find.text('Purple'), findsOneWidget);
+    });
+
+    testWidgets('editing an existing note pre-fills fields and shows Edit title',
+        (tester) async {
+      final existingNote = _sampleNote(
+        title: 'My Existing Note',
+        content: 'Existing content here.',
+      );
+
+      // Build an app that navigates to EditPage with the note as argument.
+      await tester.pumpWidget(
+        WiredMaterialApp(
+          wiredTheme: WiredThemeData(
+            borderColor: const Color(0xFF5C3D2E),
+            textColor: const Color(0xFF2E2E2E),
+            disabledTextColor: const Color(0xFFA89888),
+            fillColor: const Color(0xFFF5ECD7),
+            roughness: 1.2,
+          ),
+          initialRoute: '/',
+          onGenerateRoute: (settings) {
+            if (settings.name == '/') {
+              return MaterialPageRoute(
+                builder: (_) => Builder(
+                  builder: (context) {
+                    // Navigate immediately.
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      Navigator.pushNamed(
+                        context,
+                        '/edit',
+                        arguments: existingNote,
+                      );
+                    });
+                    return const SizedBox.shrink();
+                  },
+                ),
+              );
+            }
+            if (settings.name == '/edit') {
+              return MaterialPageRoute(
+                settings: settings,
+                builder: (_) => const EditPage(),
+              );
+            }
+            return null;
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Edit Note'), findsOneWidget);
+      expect(find.text('Save Changes'), findsOneWidget);
+
+      // Verify the text controllers are pre-filled.
+      final titleField = tester.widgetList<EditableText>(
+        find.byType(EditableText),
+      );
+      // The first EditableText should have the title, the second the content.
+      final texts = titleField.map((e) => e.controller.text).toList();
+      expect(texts, contains('My Existing Note'));
+      expect(texts, contains('Existing content here.'));
+    });
+
+    testWidgets('back button exists with semantic label', (tester) async {
+      await tester.pumpWidget(_wrapInApp(const EditPage()));
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsLabel('Go back'), findsOneWidget);
+    });
+  });
+
+  group('Settings page', () {
+    // Helper: navigate to settings page and return the NavigatorState so
+    // the caller can pop back (required to dispose WiredSlider's timer).
+    Future<NavigatorState> _pumpSettings(WidgetTester tester) async {
+      await tester.pumpWidget(const SketchNotesApp());
+      await tester.pumpAndSettle();
+
+      final navigator = tester.state<NavigatorState>(
+        find.byType(Navigator),
+      );
+      unawaited(navigator.pushNamed('/settings'));
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+      return navigator;
+    }
+
+    /// Pop the settings page so WiredSlider's pending timer is disposed.
+    Future<void> _popSettings(
+      WidgetTester tester,
+      NavigatorState navigator,
+    ) async {
+      navigator.pop();
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('dark mode switch is present', (tester) async {
+      final nav = await _pumpSettings(tester);
+
+      expect(find.text('Dark Mode'), findsOneWidget);
+      expect(find.text('Toggle dark theme'), findsOneWidget);
+
+      await _popSettings(tester, nav);
+    });
+
+    testWidgets('roughness slider renders with initial value', (tester) async {
+      final nav = await _pumpSettings(tester);
+
+      expect(find.text('Roughness: 1.2'), findsOneWidget);
+      expect(
+        find.text('Adjust the sketchiness of drawn elements'),
+        findsOneWidget,
+      );
+      expect(find.byType(WiredSlider), findsOneWidget);
+
+      await _popSettings(tester, nav);
+    });
+
+    testWidgets('about list tile triggers about dialog', (tester) async {
+      final nav = await _pumpSettings(tester);
+
+      expect(find.text('About'), findsOneWidget);
+      expect(find.text('Version 1.0.0'), findsOneWidget);
+
+      // Tap the About tile.
+      await tester.tap(find.text('About'));
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+
+      // The about dialog should be visible.
+      expect(find.text('Sketch Notes'), findsWidgets);
+      expect(
+        find.textContaining('hand-drawn notes app'),
+        findsOneWidget,
+      );
+
+      // Dismiss the dialog first, then pop settings.
+      // The dialog has a close/back button or we can pop it.
+      nav.pop(); // pop dialog
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+
+      await _popSettings(tester, nav);
+    });
+
+    testWidgets('renders section headers', (tester) async {
+      final nav = await _pumpSettings(tester);
+
+      expect(find.text('Appearance'), findsOneWidget);
+      expect(find.text('General'), findsOneWidget);
+      expect(find.text('Information'), findsOneWidget);
+
+      await _popSettings(tester, nav);
+    });
+
+    testWidgets('theme and font size tiles are rendered', (tester) async {
+      final nav = await _pumpSettings(tester);
+
+      expect(find.text('Theme'), findsOneWidget);
+      expect(find.text('Warm parchment'), findsOneWidget);
+      expect(find.text('Font Size'), findsOneWidget);
+      expect(find.text('Medium'), findsOneWidget);
+
+      await _popSettings(tester, nav);
+    });
+  });
+
+  group('NoteCard widget', () {
+    testWidgets('renders note title', (tester) async {
+      final note = _sampleNote(title: 'My Note Title');
+      await tester.pumpWidget(_wrapInApp(NoteCard(note: note)));
+      await tester.pumpAndSettle();
+
+      expect(find.text('My Note Title'), findsOneWidget);
+    });
+
+    testWidgets('shows content preview', (tester) async {
+      final note = _sampleNote(
+        content: 'Short content.',
+      );
+      await tester.pumpWidget(_wrapInApp(NoteCard(note: note)));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Short content.'), findsOneWidget);
+    });
+
+    testWidgets('truncates long content with ellipsis indicator', (tester) async {
+      final longContent = 'A' * 80; // Longer than 50 chars.
+      final note = _sampleNote(content: longContent);
+      await tester.pumpWidget(_wrapInApp(NoteCard(note: note)));
+      await tester.pumpAndSettle();
+
+      // The preview should be first 50 chars + '...'
+      expect(find.text('${'A' * 50}...'), findsOneWidget);
+    });
+
+    testWidgets('shows color indicator circle', (tester) async {
+      final note = _sampleNote(color: const Color(0xFFE8F5E9));
+      await tester.pumpWidget(_wrapInApp(NoteCard(note: note)));
+      await tester.pumpAndSettle();
+
+      // Find the colored circle Container by its decoration.
+      final container = tester.widgetList<Container>(
+        find.byType(Container),
+      ).where((c) {
+        final decoration = c.decoration;
+        if (decoration is BoxDecoration) {
+          return decoration.color == const Color(0xFFE8F5E9) &&
+              decoration.shape == BoxShape.circle;
+        }
+        return false;
+      });
+      expect(container, isNotEmpty);
+    });
+
+    testWidgets('shows "Untitled" when title is empty', (tester) async {
+      final note = _sampleNote(title: '');
+      await tester.pumpWidget(_wrapInApp(NoteCard(note: note)));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Untitled'), findsOneWidget);
+    });
+
+    testWidgets('shows "new" badge when updated today', (tester) async {
+      final note = _sampleNote(
+        updatedAt: DateTime.now(), // Updated today.
+      );
+      await tester.pumpWidget(_wrapInApp(NoteCard(note: note)));
+      await tester.pumpAndSettle();
+
+      // The WiredBadge should show the 'new' label.
+      expect(find.byType(WiredBadge), findsOneWidget);
+    });
+
+    testWidgets('does not show badge when updated in the past', (tester) async {
+      final note = _sampleNote(
+        updatedAt: DateTime(2020, 1, 1), // Far in the past.
+      );
+      await tester.pumpWidget(_wrapInApp(NoteCard(note: note)));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(WiredBadge), findsNothing);
+    });
+
+    testWidgets('displays formatted date', (tester) async {
+      final note = _sampleNote(
+        updatedAt: DateTime(2025, 3, 15),
+      );
+      await tester.pumpWidget(_wrapInApp(NoteCard(note: note)));
+      await tester.pumpAndSettle();
+
+      expect(find.text('3/15/2025'), findsOneWidget);
+    });
+
+    testWidgets('onTap callback fires when tapped', (tester) async {
+      var tapped = false;
+      final note = _sampleNote();
+      await tester.pumpWidget(
+        _wrapInApp(NoteCard(note: note, onTap: () => tapped = true)),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Test Title'));
+      await tester.pumpAndSettle();
+
+      expect(tapped, isTrue);
+    });
+  });
+
+  group('DrawerMenu widget', () {
+    testWidgets('renders "All Notes" item', (tester) async {
+      // DrawerMenu needs to be inside a Scaffold drawer slot.
+      await tester.pumpWidget(
+        _wrapInApp(
+          WiredScaffold(
+            drawer: const DrawerMenu(),
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => Scaffold.of(context).openDrawer(),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Open the drawer.
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('All Notes'), findsOneWidget);
+    });
+
+    testWidgets('renders "Settings" item', (tester) async {
+      await tester.pumpWidget(
+        _wrapInApp(
+          WiredScaffold(
+            drawer: const DrawerMenu(),
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => Scaffold.of(context).openDrawer(),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Settings'), findsOneWidget);
+    });
+
+    testWidgets('renders "About" item', (tester) async {
+      await tester.pumpWidget(
+        _wrapInApp(
+          WiredScaffold(
+            drawer: const DrawerMenu(),
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => Scaffold.of(context).openDrawer(),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('About'), findsOneWidget);
+    });
+
+    testWidgets('renders avatar with edit icon', (tester) async {
+      await tester.pumpWidget(
+        _wrapInApp(
+          WiredScaffold(
+            drawer: const DrawerMenu(),
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => Scaffold.of(context).openDrawer(),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(WiredAvatar), findsOneWidget);
+    });
+
+    testWidgets('drawer header shows "Sketch Notes" text', (tester) async {
+      await tester.pumpWidget(
+        _wrapInApp(
+          WiredScaffold(
+            drawer: const DrawerMenu(),
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => Scaffold.of(context).openDrawer(),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      // "Sketch Notes" appears in the drawer header.
+      expect(find.text('Sketch Notes'), findsOneWidget);
     });
   });
 }

--- a/docs/site/content/core/architecture.md
+++ b/docs/site/content/core/architecture.md
@@ -12,17 +12,17 @@ Skribble is organized as a layered system where each layer builds on the one bel
 The rendering pipeline flows bottom-up through six layers:
 
 ```
-  WiredMaterialApp / WiredCupertinoScaffold   (app shell)
-                    |
-               WiredTheme                      (theme)
-                    |
-          Wired* widgets                       (widgets)
-                    |
-         WiredCanvas / WiredBaseWidget         (canvas)
-                    |
-        WiredPainterBase subclasses            (painters)
-                    |
-    Rough Engine (Generator, Filler, Drawable) (engine)
+WiredMaterialApp / WiredCupertinoScaffold   (app shell)
+                  |
+             WiredTheme                      (theme)
+                  |
+        Wired* widgets                       (widgets)
+                  |
+       WiredCanvas / WiredBaseWidget         (canvas)
+                  |
+      WiredPainterBase subclasses            (painters)
+                  |
+  Rough Engine (Generator, Filler, Drawable) (engine)
 ```
 
 ### 1. Rough Engine
@@ -186,10 +186,12 @@ return buildWiredElement(child: paintedContent);
 Widgets never hardcode colors. They read from `WiredTheme.of(context)` at build time. This makes global rebranding a single `WiredThemeData` change.
 
 <!-- {=docsThemeReadPattern} -->
+
 ```dart
 final theme = WiredTheme.of(context);
 // Use theme.borderColor, theme.fillColor, theme.textColor, etc.
 ```
+
 <!-- {/docsThemeReadPattern} -->
 
 ### Familiar APIs

--- a/docs/site/content/core/hooks.md
+++ b/docs/site/content/core/hooks.md
@@ -277,10 +277,12 @@ The rule is simple: if you need `WidgetRef`, use `HookConsumerWidget`. Otherwise
 Every Wired widget reads the theme at the top of its `build` method:
 
 <!-- {=docsThemeReadPattern} -->
+
 ```dart
 final theme = WiredTheme.of(context);
 // Use theme.borderColor, theme.fillColor, theme.textColor, etc.
 ```
+
 <!-- {/docsThemeReadPattern} -->
 
 This establishes a dependency on the `WiredTheme` `InheritedWidget`, so the widget rebuilds automatically when the theme changes.

--- a/docs/site/content/core/material-bridge.md
+++ b/docs/site/content/core/material-bridge.md
@@ -46,70 +46,70 @@ The `.router()` constructor requires either `routerDelegate` or `routerConfig` -
 
 ### Wired Theme Parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `wiredTheme` | `WiredThemeData` | required | Primary (light) Wired theme |
-| `darkWiredTheme` | `WiredThemeData?` | `null` | Dark mode Wired theme; falls back to `wiredTheme` |
-| `highContrastWiredTheme` | `WiredThemeData?` | `null` | High-contrast light theme; falls back to `wiredTheme` |
-| `highContrastDarkWiredTheme` | `WiredThemeData?` | `null` | High-contrast dark theme; falls back to `darkWiredTheme`, then `wiredTheme` |
-| `themeMode` | `ThemeMode` | `ThemeMode.system` | Which theme variant to use |
+| Parameter                    | Type              | Default            | Description                                                                 |
+| ---------------------------- | ----------------- | ------------------ | --------------------------------------------------------------------------- |
+| `wiredTheme`                 | `WiredThemeData`  | required           | Primary (light) Wired theme                                                 |
+| `darkWiredTheme`             | `WiredThemeData?` | `null`             | Dark mode Wired theme; falls back to `wiredTheme`                           |
+| `highContrastWiredTheme`     | `WiredThemeData?` | `null`             | High-contrast light theme; falls back to `wiredTheme`                       |
+| `highContrastDarkWiredTheme` | `WiredThemeData?` | `null`             | High-contrast dark theme; falls back to `darkWiredTheme`, then `wiredTheme` |
+| `themeMode`                  | `ThemeMode`       | `ThemeMode.system` | Which theme variant to use                                                  |
 
 ### Navigation Parameters (Standard Constructor Only)
 
-| Parameter | Type | Default |
-|---|---|---|
-| `home` | `Widget?` | `null` |
-| `routes` | `Map<String, WidgetBuilder>` | `{}` |
-| `initialRoute` | `String?` | `null` |
-| `onGenerateRoute` | `RouteFactory?` | `null` |
-| `onGenerateInitialRoutes` | `InitialRouteListFactory?` | `null` |
-| `onUnknownRoute` | `RouteFactory?` | `null` |
-| `navigatorKey` | `GlobalKey<NavigatorState>?` | `null` |
-| `navigatorObservers` | `List<NavigatorObserver>` | `[]` |
+| Parameter                 | Type                         | Default |
+| ------------------------- | ---------------------------- | ------- |
+| `home`                    | `Widget?`                    | `null`  |
+| `routes`                  | `Map<String, WidgetBuilder>` | `{}`    |
+| `initialRoute`            | `String?`                    | `null`  |
+| `onGenerateRoute`         | `RouteFactory?`              | `null`  |
+| `onGenerateInitialRoutes` | `InitialRouteListFactory?`   | `null`  |
+| `onUnknownRoute`          | `RouteFactory?`              | `null`  |
+| `navigatorKey`            | `GlobalKey<NavigatorState>?` | `null`  |
+| `navigatorObservers`      | `List<NavigatorObserver>`    | `[]`    |
 
 ### Navigation Parameters (Router Constructor Only)
 
-| Parameter | Type | Default |
-|---|---|---|
-| `routeInformationProvider` | `RouteInformationProvider?` | `null` |
-| `routeInformationParser` | `RouteInformationParser<Object>?` | `null` |
-| `routerDelegate` | `RouterDelegate<Object>?` | `null` |
-| `routerConfig` | `RouterConfig<Object>?` | `null` |
-| `backButtonDispatcher` | `BackButtonDispatcher?` | `null` |
+| Parameter                  | Type                              | Default |
+| -------------------------- | --------------------------------- | ------- |
+| `routeInformationProvider` | `RouteInformationProvider?`       | `null`  |
+| `routeInformationParser`   | `RouteInformationParser<Object>?` | `null`  |
+| `routerDelegate`           | `RouterDelegate<Object>?`         | `null`  |
+| `routerConfig`             | `RouterConfig<Object>?`           | `null`  |
+| `backButtonDispatcher`     | `BackButtonDispatcher?`           | `null`  |
 
 ### App-Level Parameters (Both Constructors)
 
-| Parameter | Type | Default |
-|---|---|---|
-| `title` | `String` | `''` |
-| `onGenerateTitle` | `GenerateAppTitle?` | `null` |
-| `onNavigationNotification` | `NotificationListenerCallback<NavigationNotification>?` | `null` |
-| `color` | `Color?` | `null` |
-| `builder` | `TransitionBuilder?` | `null` |
-| `locale` | `Locale?` | `null` |
-| `localizationsDelegates` | `Iterable<LocalizationsDelegate>?` | `null` |
-| `localeListResolutionCallback` | `LocaleListResolutionCallback?` | `null` |
-| `localeResolutionCallback` | `LocaleResolutionCallback?` | `null` |
-| `supportedLocales` | `Iterable<Locale>` | `[Locale('en', 'US')]` |
-| `scaffoldMessengerKey` | `GlobalKey<ScaffoldMessengerState>?` | `null` |
-| `scrollBehavior` | `ScrollBehavior?` | `null` |
-| `restorationScopeId` | `String?` | `null` |
-| `shortcuts` | `Map<ShortcutActivator, Intent>?` | `null` |
-| `actions` | `Map<Type, Action<Intent>>?` | `null` |
-| `themeAnimationDuration` | `Duration` | `kThemeAnimationDuration` |
-| `themeAnimationCurve` | `Curve` | `Curves.linear` |
-| `themeAnimationStyle` | `AnimationStyle?` | `null` |
+| Parameter                      | Type                                                    | Default                   |
+| ------------------------------ | ------------------------------------------------------- | ------------------------- |
+| `title`                        | `String`                                                | `''`                      |
+| `onGenerateTitle`              | `GenerateAppTitle?`                                     | `null`                    |
+| `onNavigationNotification`     | `NotificationListenerCallback<NavigationNotification>?` | `null`                    |
+| `color`                        | `Color?`                                                | `null`                    |
+| `builder`                      | `TransitionBuilder?`                                    | `null`                    |
+| `locale`                       | `Locale?`                                               | `null`                    |
+| `localizationsDelegates`       | `Iterable<LocalizationsDelegate>?`                      | `null`                    |
+| `localeListResolutionCallback` | `LocaleListResolutionCallback?`                         | `null`                    |
+| `localeResolutionCallback`     | `LocaleResolutionCallback?`                             | `null`                    |
+| `supportedLocales`             | `Iterable<Locale>`                                      | `[Locale('en', 'US')]`    |
+| `scaffoldMessengerKey`         | `GlobalKey<ScaffoldMessengerState>?`                    | `null`                    |
+| `scrollBehavior`               | `ScrollBehavior?`                                       | `null`                    |
+| `restorationScopeId`           | `String?`                                               | `null`                    |
+| `shortcuts`                    | `Map<ShortcutActivator, Intent>?`                       | `null`                    |
+| `actions`                      | `Map<Type, Action<Intent>>?`                            | `null`                    |
+| `themeAnimationDuration`       | `Duration`                                              | `kThemeAnimationDuration` |
+| `themeAnimationCurve`          | `Curve`                                                 | `Curves.linear`           |
+| `themeAnimationStyle`          | `AnimationStyle?`                                       | `null`                    |
 
 ### Debug Parameters (Both Constructors)
 
-| Parameter | Type | Default |
-|---|---|---|
-| `debugShowMaterialGrid` | `bool` | `false` |
-| `showPerformanceOverlay` | `bool` | `false` |
+| Parameter                       | Type   | Default |
+| ------------------------------- | ------ | ------- |
+| `debugShowMaterialGrid`         | `bool` | `false` |
+| `showPerformanceOverlay`        | `bool` | `false` |
 | `checkerboardRasterCacheImages` | `bool` | `false` |
-| `checkerboardOffscreenLayers` | `bool` | `false` |
-| `showSemanticsDebugger` | `bool` | `false` |
-| `debugShowCheckedModeBanner` | `bool` | `false` |
+| `checkerboardOffscreenLayers`   | `bool` | `false` |
+| `showSemanticsDebugger`         | `bool` | `false` |
+| `debugShowCheckedModeBanner`    | `bool` | `false` |
 
 ## How WiredThemeData Converts to Material ThemeData
 
@@ -291,6 +291,7 @@ WiredThemeData _resolveWiredTheme({...}) {
 ```
 
 Fallback chain:
+
 - `darkWiredTheme` defaults to `wiredTheme`
 - `highContrastWiredTheme` defaults to `wiredTheme`
 - `highContrastDarkWiredTheme` defaults to `darkWiredTheme`, then `wiredTheme`
@@ -404,30 +405,32 @@ Skribble provides Cupertino-style widgets that render with the hand-drawn aesthe
 
 ### Available Cupertino Widgets
 
-| Widget | Material Equivalent |
-|---|---|
-| `WiredCupertinoButton` | `CupertinoButton` |
-| `WiredCupertinoNavigationBar` | `CupertinoNavigationBar` |
-| `WiredCupertinoTextField` | `CupertinoTextField` |
-| `WiredCupertinoSwitch` | `CupertinoSwitch` |
-| `WiredCupertinoSlider` | `CupertinoSlider` |
-| `WiredCupertinoTabBar` | `CupertinoTabBar` |
-| `WiredCupertinoDatePicker` | `CupertinoDatePicker` |
-| `WiredCupertinoPicker` | `CupertinoPicker` |
-| `WiredCupertinoActionSheet` | `CupertinoActionSheet` |
-| `WiredCupertinoAlertDialog` | `CupertinoAlertDialog` |
+| Widget                           | Material Equivalent         |
+| -------------------------------- | --------------------------- |
+| `WiredCupertinoButton`           | `CupertinoButton`           |
+| `WiredCupertinoNavigationBar`    | `CupertinoNavigationBar`    |
+| `WiredCupertinoTextField`        | `CupertinoTextField`        |
+| `WiredCupertinoSwitch`           | `CupertinoSwitch`           |
+| `WiredCupertinoSlider`           | `CupertinoSlider`           |
+| `WiredCupertinoTabBar`           | `CupertinoTabBar`           |
+| `WiredCupertinoDatePicker`       | `CupertinoDatePicker`       |
+| `WiredCupertinoPicker`           | `CupertinoPicker`           |
+| `WiredCupertinoActionSheet`      | `CupertinoActionSheet`      |
+| `WiredCupertinoAlertDialog`      | `CupertinoAlertDialog`      |
 | `WiredCupertinoSegmentedControl` | `CupertinoSegmentedControl` |
-| `WiredCupertinoScaffold` | `CupertinoPageScaffold` |
+| `WiredCupertinoScaffold`         | `CupertinoPageScaffold`     |
 
 ### Usage
 
 Cupertino widgets read from `WiredTheme.of(context)` just like their Material counterparts:
 
 <!-- {=docsThemeReadPattern} -->
+
 ```dart
 final theme = WiredTheme.of(context);
 // Use theme.borderColor, theme.fillColor, theme.textColor, etc.
 ```
+
 <!-- {/docsThemeReadPattern} -->
 
 Example:

--- a/docs/site/content/core/painters.md
+++ b/docs/site/content/core/painters.md
@@ -24,12 +24,12 @@ abstract class WiredPainterBase {
 
 Parameters:
 
-| Parameter | Purpose |
-|---|---|
-| `canvas` | The Flutter `Canvas` to draw on |
-| `size` | The available area for the shape |
+| Parameter    | Purpose                                                       |
+| ------------ | ------------------------------------------------------------- |
+| `canvas`     | The Flutter `Canvas` to draw on                               |
+| `size`       | The available area for the shape                              |
 | `drawConfig` | Controls roughness, bowing, seed, and other engine parameters |
-| `filler` | The fill algorithm (hachure, dots, solid, etc.) |
+| `filler`     | The fill algorithm (hachure, dots, solid, etc.)               |
 
 Every concrete painter follows the same three-step pattern inside `paintRough`:
 
@@ -371,13 +371,13 @@ class WiredCanvas extends HookWidget {
 
 ### Parameters
 
-| Parameter | Required | Default | Description |
-|---|---|---|---|
-| `painter` | yes | -- | The shape painter to render |
-| `fillerType` | yes | -- | Which fill algorithm to use (`RoughFilter` enum) |
-| `drawConfig` | no | `DrawConfig.defaultValues` | Drawing configuration override |
-| `fillerConfig` | no | `FillerConfig.defaultConfig` | Fill configuration override |
-| `size` | no | `Size.infinite` | Custom canvas size |
+| Parameter      | Required | Default                      | Description                                      |
+| -------------- | -------- | ---------------------------- | ------------------------------------------------ |
+| `painter`      | yes      | --                           | The shape painter to render                      |
+| `fillerType`   | yes      | --                           | Which fill algorithm to use (`RoughFilter` enum) |
+| `drawConfig`   | no       | `DrawConfig.defaultValues`   | Drawing configuration override                   |
+| `fillerConfig` | no       | `FillerConfig.defaultConfig` | Fill configuration override                      |
+| `size`         | no       | `Size.infinite`              | Custom canvas size                               |
 
 ### Minimal Example
 

--- a/docs/site/content/core/rough-engine.md
+++ b/docs/site/content/core/rough-engine.md
@@ -11,12 +11,12 @@ Skribble's hand-drawn aesthetic comes from a Dart port of [rough.js](https://rou
 
 The engine has four core pieces:
 
-| Concept | Purpose |
-|---|---|
-| `DrawConfig` | Controls randomness, roughness, bowing, and curve parameters |
-| `Generator` | Produces `Drawable` shapes (rectangles, circles, polygons, etc.) |
-| `Filler` | Fills polygon interiors with patterns (hachure, dots, zigzag, etc.) |
-| `Drawable` / `OpSet` | Data structures holding drawing operations for the canvas |
+| Concept              | Purpose                                                             |
+| -------------------- | ------------------------------------------------------------------- |
+| `DrawConfig`         | Controls randomness, roughness, bowing, and curve parameters        |
+| `Generator`          | Produces `Drawable` shapes (rectangles, circles, polygons, etc.)    |
+| `Filler`             | Fills polygon interiors with patterns (hachure, dots, zigzag, etc.) |
+| `Drawable` / `OpSet` | Data structures holding drawing operations for the canvas           |
 
 The typical flow is:
 
@@ -34,16 +34,16 @@ canvas.drawRough(drawable, pathPaint, fillPaint);
 
 ### Fields
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `maxRandomnessOffset` | `double` | `2` | Maximum pixel offset for random jitter |
-| `roughness` | `double` | `1` | Overall roughness multiplier -- higher values produce wobblier lines |
-| `bowing` | `double` | `1` | How much lines bow outward at the midpoint |
-| `curveFitting` | `double` | `0.95` | How closely curves follow the intended path (0 = loose, 1 = tight) |
-| `curveTightness` | `double` | `0` | Tension of Catmull-Rom splines |
-| `curveStepCount` | `double` | `9` | Number of steps when generating curved segments |
-| `seed` | `int` | `1` | Random seed for deterministic output |
-| `randomizer` | `Randomizer` | seeded | Pseudo-random number generator |
+| Field                 | Type         | Default | Description                                                          |
+| --------------------- | ------------ | ------- | -------------------------------------------------------------------- |
+| `maxRandomnessOffset` | `double`     | `2`     | Maximum pixel offset for random jitter                               |
+| `roughness`           | `double`     | `1`     | Overall roughness multiplier -- higher values produce wobblier lines |
+| `bowing`              | `double`     | `1`     | How much lines bow outward at the midpoint                           |
+| `curveFitting`        | `double`     | `0.95`  | How closely curves follow the intended path (0 = loose, 1 = tight)   |
+| `curveTightness`      | `double`     | `0`     | Tension of Catmull-Rom splines                                       |
+| `curveStepCount`      | `double`     | `9`     | Number of steps when generating curved segments                      |
+| `seed`                | `int`        | `1`     | Random seed for deterministic output                                 |
+| `randomizer`          | `Randomizer` | seeded  | Pseudo-random number generator                                       |
 
 ### Creating a DrawConfig
 
@@ -219,15 +219,15 @@ Fillers control how the interior of a closed shape is painted. Every `Filler` su
 
 `FillerConfig` holds parameters shared across all filler types:
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `drawConfig` | `DrawConfig` | `DrawConfig.defaultValues` | Base drawing config for fill strokes |
-| `fillWeight` | `double` | `1` | Weight / thickness of fill strokes |
-| `hachureAngle` | `double` | `320` | Angle of hachure lines in degrees |
-| `hachureGap` | `double` | `15` | Spacing between hachure lines |
-| `dashOffset` | `double` | `15` | Length of each dash in dashed fills |
-| `dashGap` | `double` | `2` | Gap between dashes |
-| `zigzagOffset` | `double` | `5` | Amplitude of zigzag lines |
+| Field          | Type         | Default                    | Description                          |
+| -------------- | ------------ | -------------------------- | ------------------------------------ |
+| `drawConfig`   | `DrawConfig` | `DrawConfig.defaultValues` | Base drawing config for fill strokes |
+| `fillWeight`   | `double`     | `1`                        | Weight / thickness of fill strokes   |
+| `hachureAngle` | `double`     | `320`                      | Angle of hachure lines in degrees    |
+| `hachureGap`   | `double`     | `15`                       | Spacing between hachure lines        |
+| `dashOffset`   | `double`     | `15`                       | Length of each dash in dashed fills  |
+| `dashGap`      | `double`     | `2`                        | Gap between dashes                   |
+| `zigzagOffset` | `double`     | `5`                        | Amplitude of zigzag lines            |
 
 ```dart
 final fillerConfig = FillerConfig.build(
@@ -495,12 +495,12 @@ RoughBoxDecoration(
 
 Controls the paint properties for borders and fills:
 
-| Field | Type | Description |
-|---|---|---|
-| `width` | `double?` | Stroke width in pixels |
-| `color` | `Color?` | Solid color |
-| `gradient` | `Gradient?` | Gradient shader (overrides color) |
-| `blendMode` | `BlendMode?` | Blend mode for the paint |
+| Field       | Type         | Description                       |
+| ----------- | ------------ | --------------------------------- |
+| `width`     | `double?`    | Stroke width in pixels            |
+| `color`     | `Color?`     | Solid color                       |
+| `gradient`  | `Gradient?`  | Gradient shader (overrides color) |
+| `blendMode` | `BlendMode?` | Blend mode for the paint          |
 
 ## Low-Level Internals
 

--- a/docs/site/content/core/theme-system.md
+++ b/docs/site/content/core/theme-system.md
@@ -13,15 +13,15 @@ Every Wired widget reads its colors, stroke width, and roughness from a shared t
 
 ### Fields
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `borderColor` | `Color` | `Color(0xFF1A2B3C)` | Border stroke color for all shapes |
-| `textColor` | `Color` | `Colors.black` | Primary text color |
-| `disabledTextColor` | `Color` | `Colors.grey` | Text color for disabled states |
-| `fillColor` | `Color` | `Color(0xFFFEFEFE)` | Interior fill color for shapes |
-| `strokeWidth` | `double` | `2` | Default border stroke width |
-| `roughness` | `double` | `1` | Roughness multiplier passed to the engine |
-| `drawConfig` | `DrawConfig?` | `null` (uses `DrawConfig.defaultValues`) | Optional custom draw configuration |
+| Field               | Type          | Default                                  | Description                               |
+| ------------------- | ------------- | ---------------------------------------- | ----------------------------------------- |
+| `borderColor`       | `Color`       | `Color(0xFF1A2B3C)`                      | Border stroke color for all shapes        |
+| `textColor`         | `Color`       | `Colors.black`                           | Primary text color                        |
+| `disabledTextColor` | `Color`       | `Colors.grey`                            | Text color for disabled states            |
+| `fillColor`         | `Color`       | `Color(0xFFFEFEFE)`                      | Interior fill color for shapes            |
+| `strokeWidth`       | `double`      | `2`                                      | Default border stroke width               |
+| `roughness`         | `double`      | `1`                                      | Roughness multiplier passed to the engine |
+| `drawConfig`        | `DrawConfig?` | `null` (uses `DrawConfig.defaultValues`) | Optional custom draw configuration        |
 
 ### Creating a Theme
 
@@ -81,10 +81,12 @@ This is the value returned by `WiredTheme.of(context)` when no ancestor `WiredTh
 The standard lookup method:
 
 <!-- {=docsThemeReadPattern} -->
+
 ```dart
 final theme = WiredTheme.of(context);
 // Use theme.borderColor, theme.fillColor, theme.textColor, etc.
 ```
+
 <!-- {/docsThemeReadPattern} -->
 
 If no `WiredTheme` ancestor exists, `of` returns `WiredThemeData.defaultTheme` rather than throwing. This means Wired widgets work without any explicit theme setup -- they just use default colors.
@@ -129,17 +131,17 @@ ColorScheme toColorScheme({Brightness brightness = Brightness.light})
 
 The method uses `ColorScheme.fromSeed` with `borderColor` as the seed, then overrides key slots:
 
-| ColorScheme slot | Mapped from |
-|---|---|
-| `primary` | `borderColor` |
-| `onPrimary` | Best contrast against `borderColor` (white or black) |
-| `secondary` | `textColor` |
-| `onSecondary` | Best contrast against `textColor` |
-| `surface` | `fillColor` |
-| `onSurface` | `textColor` |
-| `outline` | `borderColor` at 70% opacity |
-| `surfaceTint` | `borderColor` |
-| `shadow` | `borderColor` at 12% opacity |
+| ColorScheme slot | Mapped from                                          |
+| ---------------- | ---------------------------------------------------- |
+| `primary`        | `borderColor`                                        |
+| `onPrimary`      | Best contrast against `borderColor` (white or black) |
+| `secondary`      | `textColor`                                          |
+| `onSecondary`    | Best contrast against `textColor`                    |
+| `surface`        | `fillColor`                                          |
+| `onSurface`      | `textColor`                                          |
+| `outline`        | `borderColor` at 70% opacity                         |
+| `surfaceTint`    | `borderColor`                                        |
+| `shadow`         | `borderColor` at 12% opacity                         |
 
 ```dart
 final scheme = theme.toColorScheme();
@@ -168,14 +170,14 @@ This method sets up Material component themes so that standard Material widgets 
 
 ### Component Theme Mapping
 
-| Material Component | Wired Theme Mapping |
-|---|---|
-| `scaffoldBackgroundColor` | `paperBackgroundColor` |
-| `canvasColor` | `fillColor` |
-| `dividerColor` | `borderColor` at 35% opacity |
-| `textTheme` | Body and display colors set to `textColor` |
-| `iconTheme` | Color set to `textColor` |
-| `primaryIconTheme` | Color set to `colorScheme.onPrimary` |
+| Material Component        | Wired Theme Mapping                        |
+| ------------------------- | ------------------------------------------ |
+| `scaffoldBackgroundColor` | `paperBackgroundColor`                     |
+| `canvasColor`             | `fillColor`                                |
+| `dividerColor`            | `borderColor` at 35% opacity               |
+| `textTheme`               | Body and display colors set to `textColor` |
+| `iconTheme`               | Color set to `textColor`                   |
+| `primaryIconTheme`        | Color set to `colorScheme.onPrimary`       |
 
 ### AppBarTheme
 
@@ -337,11 +339,11 @@ WiredMaterialApp(
 
 The app resolves which `WiredThemeData` to use based on `ThemeMode` and the platform's accessibility settings:
 
-| ThemeMode | High Contrast Off | High Contrast On |
-|---|---|---|
-| `light` | `wiredTheme` | `highContrastWiredTheme` |
-| `dark` | `darkWiredTheme` | `highContrastDarkWiredTheme` |
-| `system` | Platform brightness selects light or dark, then high-contrast is checked |
+| ThemeMode | High Contrast Off                                                        | High Contrast On             |
+| --------- | ------------------------------------------------------------------------ | ---------------------------- |
+| `light`   | `wiredTheme`                                                             | `highContrastWiredTheme`     |
+| `dark`    | `darkWiredTheme`                                                         | `highContrastDarkWiredTheme` |
+| `system`  | Platform brightness selects light or dark, then high-contrast is checked |                              |
 
 Fallback behavior: if `darkWiredTheme` is not provided, `wiredTheme` is used for dark mode. Similarly, the high-contrast variants fall back to their non-high-contrast equivalents.
 

--- a/docs/site/content/getting-started/first-widget.md
+++ b/docs/site/content/getting-started/first-widget.md
@@ -31,6 +31,7 @@ void main() {
 ## Step 1: WiredButton
 
 <!-- {=docsFirstWidgetButton} -->
+
 `WiredButton` is the simplest Wired widget. It draws a hand-sketched rectangle border around a child widget and fires `onPressed` when tapped.
 
 ```dart
@@ -77,11 +78,13 @@ WiredButton(
   child: Icon(Icons.save),
 )
 ```
+
 <!-- {/docsFirstWidgetButton} -->
 
 ## Step 2: WiredInput
 
 <!-- {=docsFirstWidgetInput} -->
+
 `WiredInput` is a text field with a hand-drawn rectangle border. It wraps Flutter's `TextField` internally, so all standard text input behavior (focus, selection, IME) works automatically.
 
 ```dart
@@ -122,16 +125,16 @@ class ExamplePage extends HookWidget {
 
 ### WiredInput parameters
 
-| Parameter | Type | Description |
-|---|---|---|
-| `controller` | `TextEditingController?` | Controls the text being edited. Use `useTextEditingController()` from flutter_hooks. |
-| `labelText` | `String?` | Label displayed to the left of the input. |
-| `hintText` | `String?` | Placeholder text inside the field. |
-| `onChanged` | `void Function(String)?` | Called every time the text changes. |
-| `obscureText` | `bool` | Hides the input text (for passwords). Defaults to `false`. |
-| `style` | `TextStyle?` | Custom text style for the input content. |
-| `labelStyle` | `TextStyle?` | Custom text style for the label. |
-| `hintStyle` | `TextStyle?` | Custom text style for the hint text. |
+| Parameter     | Type                     | Description                                                                          |
+| ------------- | ------------------------ | ------------------------------------------------------------------------------------ |
+| `controller`  | `TextEditingController?` | Controls the text being edited. Use `useTextEditingController()` from flutter_hooks. |
+| `labelText`   | `String?`                | Label displayed to the left of the input.                                            |
+| `hintText`    | `String?`                | Placeholder text inside the field.                                                   |
+| `onChanged`   | `void Function(String)?` | Called every time the text changes.                                                  |
+| `obscureText` | `bool`                   | Hides the input text (for passwords). Defaults to `false`.                           |
+| `style`       | `TextStyle?`             | Custom text style for the input content.                                             |
+| `labelStyle`  | `TextStyle?`             | Custom text style for the label.                                                     |
+| `hintStyle`   | `TextStyle?`             | Custom text style for the hint text.                                                 |
 
 ### How WiredInput reads the theme
 
@@ -141,11 +144,13 @@ class ExamplePage extends HookWidget {
 - `theme.borderColor` for the sketchy rectangle stroke
 
 The underlying `TextField` uses Flutter's default text styling, which `WiredMaterialApp` has already synced with the Wired theme's text color.
+
 <!-- {/docsFirstWidgetInput} -->
 
 ## Step 3: WiredCard
 
 <!-- {=docsFirstWidgetCard} -->
+
 `WiredCard` draws a hand-sketched rectangle container. Use it to group related content.
 
 ```dart
@@ -195,20 +200,22 @@ class ExamplePage extends HookWidget {
 
 ### WiredCard parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `child` | `Widget?` | `null` | The content inside the card. |
-| `height` | `double?` | `130.0` | Fixed height. Pass `null` to auto-size. |
-| `fill` | `bool` | `false` | When `true`, the card background is drawn with a hachure fill pattern. |
+| Parameter | Type      | Default | Description                                                            |
+| --------- | --------- | ------- | ---------------------------------------------------------------------- |
+| `child`   | `Widget?` | `null`  | The content inside the card.                                           |
+| `height`  | `double?` | `130.0` | Fixed height. Pass `null` to auto-size.                                |
+| `fill`    | `bool`    | `false` | When `true`, the card background is drawn with a hachure fill pattern. |
 
 ### How WiredCard reads the theme
 
 `WiredCard` calls `WiredTheme.of(context)` and passes `theme.fillColor` and `theme.borderColor` to its internal `WiredRectangleBase` painter.
+
 <!-- {/docsFirstWidgetCard} -->
 
 ## Step 4: WiredCheckbox
 
 <!-- {=docsFirstWidgetCheckbox} -->
+
 `WiredCheckbox` draws a hand-sketched square with a checkmark inside when checked.
 
 ```dart
@@ -242,11 +249,13 @@ class ExamplePage extends HookWidget {
 ```
 
 `WiredCheckbox` supports tristate values. Pass `null` for the indeterminate state.
+
 <!-- {/docsFirstWidgetCheckbox} -->
 
 ## Combining widgets: a complete form
 
 <!-- {=docsFirstWidgetForm} -->
+
 Here is a complete example that combines all four widgets into a sign-up form:
 
 ```dart
@@ -381,6 +390,7 @@ class SignUpForm extends HookWidget {
 ```
 
 Every widget in this form reads colors and stroke styles from `WiredTheme.of(context)`. Change the theme once and the entire form updates -- no per-widget color props needed.
+
 <!-- {/docsFirstWidgetForm} -->
 
 ## The pattern behind every Wired widget

--- a/docs/site/content/getting-started/installation.md
+++ b/docs/site/content/getting-started/installation.md
@@ -10,6 +10,7 @@ There are two ways to get started with Skribble: add it to an existing app as a 
 ## App usage
 
 <!-- {=docsInstallSection} -->
+
 Add the Skribble package to your Flutter project:
 
 ```bash
@@ -36,11 +37,13 @@ import 'package:skribble/skribble.dart';
 ```
 
 That single import gives you access to every Wired widget, the theming system, the rough-drawing engine, and the icon set. No additional setup is required -- just start using Wired widgets in your widget tree.
+
 <!-- {/docsInstallSection} -->
 
 ## Workspace contribution setup
 
 <!-- {=docsWorkspaceSetupSection} -->
+
 To contribute to Skribble or run the storybook app locally, clone the repository and set up the development environment.
 
 ### Prerequisites
@@ -78,11 +81,13 @@ skribble/
 ```
 
 The `packages/skribble/` directory contains all Wired widgets, the rough-drawing engine, the theme system, and the generated icon font. `apps/skribble_storybook/` is a Flutter app that showcases every widget with live examples.
+
 <!-- {/docsWorkspaceSetupSection} -->
 
 ## Development commands
 
 <!-- {=docsWorkspaceDevCommandsSection} -->
+
 All commands are run from the repository root via Melos:
 
 ```bash
@@ -122,6 +127,7 @@ flutter test
 cd packages/skribble
 dart analyze --fatal-infos .
 ```
+
 <!-- {/docsWorkspaceDevCommandsSection} -->
 
 ## Next steps

--- a/docs/site/content/getting-started/quick-start.md
+++ b/docs/site/content/getting-started/quick-start.md
@@ -14,6 +14,7 @@ Make sure you have [installed Skribble](/getting-started/installation) in your F
 ## Minimal app
 
 <!-- {=docsMinimalAppSection} -->
+
 Replace your `main.dart` with the following:
 
 ```dart
@@ -45,6 +46,7 @@ flutter run
 ```
 
 You should see a full-screen app with a wobbly-bordered app bar and a hand-drawn button in the center.
+
 <!-- {/docsMinimalAppSection} -->
 
 ## How WiredMaterialApp works

--- a/docs/site/content/getting-started/theming.md
+++ b/docs/site/content/getting-started/theming.md
@@ -27,15 +27,15 @@ WiredThemeData({
 
 ### Parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `borderColor` | `Color` | `Color(0xFF1A2B3C)` | The color used for all hand-drawn borders, outlines, and strokes. A dark blue-gray by default. |
-| `textColor` | `Color` | `Colors.black` | Primary text color. Applied to labels, button text, and synced to Material's `onSurface`. |
-| `disabledTextColor` | `Color` | `Colors.grey` | Text color for disabled widgets. |
-| `fillColor` | `Color` | `Color(0xFFFEFEFE)` | Background fill for cards, inputs, dialogs, and other surfaces. Near-white by default. |
-| `strokeWidth` | `double` | `2` | Width in logical pixels of the rough-drawn border strokes. |
-| `roughness` | `double` | `1` | Controls how wobbly and imperfect the hand-drawn lines are. `0` produces perfectly straight lines. Higher values increase the sketch effect. |
-| `drawConfig` | `DrawConfig?` | `null` | Advanced drawing configuration. When `null`, uses `DrawConfig.defaultValues`. Controls `maxRandomnessOffset`, `bowing`, `curveFitting`, `curveTightness`, `curveStepCount`, and the random `seed`. |
+| Parameter           | Type          | Default             | Description                                                                                                                                                                                        |
+| ------------------- | ------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `borderColor`       | `Color`       | `Color(0xFF1A2B3C)` | The color used for all hand-drawn borders, outlines, and strokes. A dark blue-gray by default.                                                                                                     |
+| `textColor`         | `Color`       | `Colors.black`      | Primary text color. Applied to labels, button text, and synced to Material's `onSurface`.                                                                                                          |
+| `disabledTextColor` | `Color`       | `Colors.grey`       | Text color for disabled widgets.                                                                                                                                                                   |
+| `fillColor`         | `Color`       | `Color(0xFFFEFEFE)` | Background fill for cards, inputs, dialogs, and other surfaces. Near-white by default.                                                                                                             |
+| `strokeWidth`       | `double`      | `2`                 | Width in logical pixels of the rough-drawn border strokes.                                                                                                                                         |
+| `roughness`         | `double`      | `1`                 | Controls how wobbly and imperfect the hand-drawn lines are. `0` produces perfectly straight lines. Higher values increase the sketch effect.                                                       |
+| `drawConfig`        | `DrawConfig?` | `null`              | Advanced drawing configuration. When `null`, uses `DrawConfig.defaultValues`. Controls `maxRandomnessOffset`, `bowing`, `curveFitting`, `curveTightness`, `curveStepCount`, and the random `seed`. |
 
 ### copyWith
 
@@ -95,6 +95,7 @@ If no `WiredTheme` ancestor exists, `WiredTheme.of(context)` returns `WiredTheme
 ## WiredMaterialApp integration
 
 <!-- {=docsThemeSetupSection} -->
+
 `WiredMaterialApp` is the recommended way to set up theming. It handles both the `WiredTheme` injection and Material `ThemeData` synchronization in one widget.
 
 ### Basic setup
@@ -156,13 +157,14 @@ WiredMaterialApp(
 
 `WiredMaterialApp` resolves the active `WiredThemeData` based on `themeMode` and the platform's accessibility settings:
 
-| `themeMode` | High contrast off | High contrast on |
-|---|---|---|
-| `ThemeMode.light` | `wiredTheme` | `highContrastWiredTheme` |
-| `ThemeMode.dark` | `darkWiredTheme` | `highContrastDarkWiredTheme` |
+| `themeMode`        | High contrast off                          | High contrast on                           |
+| ------------------ | ------------------------------------------ | ------------------------------------------ |
+| `ThemeMode.light`  | `wiredTheme`                               | `highContrastWiredTheme`                   |
+| `ThemeMode.dark`   | `darkWiredTheme`                           | `highContrastDarkWiredTheme`               |
 | `ThemeMode.system` | Light or dark based on platform brightness | High-contrast variant of the resolved mode |
 
 If an optional variant is not provided, the fallback chain is: `highContrastDarkWiredTheme` -> `darkWiredTheme` -> `wiredTheme`.
+
 <!-- {/docsThemeSetupSection} -->
 
 ## Material ThemeData synchronization

--- a/docs/site/content/guides/custom-icons.md
+++ b/docs/site/content/guides/custom-icons.md
@@ -112,11 +112,11 @@ The manifest file defines icons for the `svg-manifest` kit. It can use either a 
 
 ### Field reference
 
-| Field | Required | Description |
-|---|---|---|
-| `identifier` | Yes | Unique string identifier for the icon (used as the Dart field name) |
-| `codePoint` | Yes | Unique code point -- accepts decimal (`57345`), hex string (`"0xe001"`), bare hex (`"e001"`), or Unicode format (`"U+E001"`) |
-| `svgPath` | Yes | Path to the source SVG file (relative to the manifest file location) |
+| Field        | Required | Description                                                                                                                  |
+| ------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `identifier` | Yes      | Unique string identifier for the icon (used as the Dart field name)                                                          |
+| `codePoint`  | Yes      | Unique code point -- accepts decimal (`57345`), hex string (`"0xe001"`), bare hex (`"e001"`), or Unicode format (`"U+E001"`) |
+| `svgPath`    | Yes      | Path to the source SVG file (relative to the manifest file location)                                                         |
 
 The `svgPath` field also accepts the aliases `svg` and `path`.
 

--- a/docs/site/content/guides/custom-painters.md
+++ b/docs/site/content/guides/custom-painters.md
@@ -47,15 +47,15 @@ final generator = Generator(drawConfig, filler);
 
 The generator provides these shape constructors:
 
-| Method | Parameters |
-|---|---|
-| `generator.rectangle(x, y, width, height)` | Top-left origin and dimensions |
-| `generator.circle(cx, cy, diameter)` | Center point and diameter |
-| `generator.ellipse(cx, cy, width, height)` | Center point and radii |
-| `generator.line(x1, y1, x2, y2)` | Start and end points |
-| `generator.polygon(List<PointD>)` | Closed polygon from vertex list |
-| `generator.arc(x, y, w, h, start, stop, closed)` | Arc segment |
-| `generator.roundedRectangle(x, y, w, h, tl, tr, br, bl)` | Rounded corners |
+| Method                                                   | Parameters                      |
+| -------------------------------------------------------- | ------------------------------- |
+| `generator.rectangle(x, y, width, height)`               | Top-left origin and dimensions  |
+| `generator.circle(cx, cy, diameter)`                     | Center point and diameter       |
+| `generator.ellipse(cx, cy, width, height)`               | Center point and radii          |
+| `generator.line(x1, y1, x2, y2)`                         | Start and end points            |
+| `generator.polygon(List<PointD>)`                        | Closed polygon from vertex list |
+| `generator.arc(x, y, w, h, start, stop, closed)`         | Arc segment                     |
+| `generator.roundedRectangle(x, y, w, h, tl, tr, br, bl)` | Rounded corners                 |
 
 Each returns a `Drawable` that holds the rough path data.
 
@@ -327,15 +327,15 @@ WiredCanvas(
 
 Available `RoughFilter` values:
 
-| Filter | Description |
-|---|---|
-| `noFiller` | No fill, border only |
+| Filter          | Description               |
+| --------------- | ------------------------- |
+| `noFiller`      | No fill, border only      |
 | `hachureFiller` | Parallel diagonal strokes |
-| `zigZagFiller` | Zigzag strokes |
-| `hatchFiller` | Cross-hatched strokes |
-| `dotFiller` | Dot pattern |
-| `dashedFiller` | Dashed strokes |
-| `solidFiller` | Solid fill |
+| `zigZagFiller`  | Zigzag strokes            |
+| `hatchFiller`   | Cross-hatched strokes     |
+| `dotFiller`     | Dot pattern               |
+| `dashedFiller`  | Dashed strokes            |
+| `solidFiller`   | Solid fill                |
 
 ## Using a custom painter in a widget
 

--- a/docs/site/content/guides/rough-decorations.md
+++ b/docs/site/content/guides/rough-decorations.md
@@ -36,14 +36,14 @@ Container(
 
 The constructor parameters control different aspects:
 
-| Parameter | Type | Purpose |
-|---|---|---|
-| `shape` | `RoughBoxShape` | The geometric shape to draw |
-| `borderStyle` | `RoughDrawingStyle?` | Stroke color, width, gradient, blendMode for the border |
-| `fillStyle` | `RoughDrawingStyle?` | Stroke color, width, gradient, blendMode for the fill |
-| `drawConfig` | `DrawConfig?` | Roughness, bowing, seed, and other drawing parameters |
-| `filler` | `Filler?` | Fill pattern algorithm instance |
-| `borderRadius` | `BorderRadius?` | Corner radii (only used with `roundedRectangle`) |
+| Parameter      | Type                 | Purpose                                                 |
+| -------------- | -------------------- | ------------------------------------------------------- |
+| `shape`        | `RoughBoxShape`      | The geometric shape to draw                             |
+| `borderStyle`  | `RoughDrawingStyle?` | Stroke color, width, gradient, blendMode for the border |
+| `fillStyle`    | `RoughDrawingStyle?` | Stroke color, width, gradient, blendMode for the fill   |
+| `drawConfig`   | `DrawConfig?`        | Roughness, bowing, seed, and other drawing parameters   |
+| `filler`       | `Filler?`            | Fill pattern algorithm instance                         |
+| `borderRadius` | `BorderRadius?`      | Corner radii (only used with `roundedRectangle`)        |
 
 ## RoughBoxShape options
 
@@ -181,13 +181,13 @@ RoughBoxDecoration(
 
 ### Roughness levels
 
-| roughness | Effect |
-|---|---|
-| `0` | Perfectly straight lines (no hand-drawn effect) |
-| `0.5` | Subtle wobble |
-| `1` | Default hand-drawn look |
-| `2` | Noticeably rough |
-| `3+` | Very exaggerated sketchy style |
+| roughness | Effect                                          |
+| --------- | ----------------------------------------------- |
+| `0`       | Perfectly straight lines (no hand-drawn effect) |
+| `0.5`     | Subtle wobble                                   |
+| `1`       | Default hand-drawn look                         |
+| `2`       | Noticeably rough                                |
+| `3+`      | Very exaggerated sketchy style                  |
 
 ### Deterministic rendering
 

--- a/docs/site/content/guides/testing.md
+++ b/docs/site/content/guides/testing.md
@@ -31,6 +31,7 @@ Every `wired_*.dart` source file must have a corresponding `wired_*_test.dart` t
 ## The pumpApp() helper
 
 <!-- {=docsPumpAppHelper} -->
+
 All widget tests use the `pumpApp()` helper from `test/helpers/pump_app.dart`. It wraps your widget in a `MaterialApp` and `Scaffold`, which is the minimum tree required for Material widgets to function.
 
 ### Signature
@@ -105,6 +106,7 @@ await pumpApp(
   theme: ThemeData.dark(),
 );
 ```
+
 <!-- {/docsPumpAppHelper} -->
 
 ### Testing with WiredTheme

--- a/docs/site/content/index.md
+++ b/docs/site/content/index.md
@@ -20,6 +20,7 @@ The library ships 80+ production-ready widgets, each built on `HookWidget` and p
 ## Quick install
 
 <!-- {=docsQuickInstallSection} -->
+
 Add Skribble to your Flutter project:
 
 ```bash
@@ -31,6 +32,7 @@ Then import and use any Wired widget:
 ```dart
 import 'package:skribble/skribble.dart';
 ```
+
 <!-- {/docsQuickInstallSection} -->
 
 ## Start here
@@ -64,19 +66,19 @@ Skribble includes a generated rough icon font based on Material Icons. Use `Wire
 
 Skribble organizes its 80+ widgets into categories:
 
-| Category | Widgets |
-|---|---|
-| **Buttons** | `WiredButton`, `WiredElevatedButton`, `WiredFilledButton`, `WiredOutlinedButton`, `WiredTextButton`, `WiredIconButton`, `WiredFab` |
-| **Inputs** | `WiredInput`, `WiredTextArea`, `WiredSearchBar`, `WiredAutocomplete`, `WiredCombo` |
-| **Selection** | `WiredCheckbox`, `WiredRadio`, `WiredSwitch`, `WiredToggle`, `WiredToggleButtons`, `WiredSlider`, `WiredRangeSlider` |
-| **Layout** | `WiredCard`, `WiredDivider`, `WiredListTile`, `WiredExpansionTile`, `WiredStepper`, `WiredReorderableListView` |
-| **Navigation** | `WiredAppBar`, `WiredSliverAppBar`, `WiredBottomNav`, `WiredBottomAppBar`, `WiredNavigationBar`, `WiredNavigationRail`, `WiredNavigationDrawer`, `WiredDrawer`, `WiredTabBar` |
-| **Feedback** | `WiredDialog`, `WiredSnackBar`, `WiredTooltip`, `WiredProgress`, `WiredCircularProgress`, `WiredBadge`, `WiredMaterialBanner` |
-| **Surfaces** | `WiredScaffold`, `WiredBottomSheet`, `WiredPopupMenu`, `WiredContextMenu`, `WiredMenuBar` |
-| **Date & Time** | `WiredDatePicker`, `WiredCalendar`, `WiredCalendarDatePicker`, `WiredTimePicker` |
-| **Chips** | `WiredChip`, `WiredChoiceChip`, `WiredFilterChip`, `WiredInputChip` |
-| **Data** | `WiredDataTable` |
-| **Cupertino** | `WiredCupertinoButton`, `WiredCupertinoTextField`, `WiredCupertinoSwitch`, `WiredCupertinoSlider`, `WiredCupertinoNavigationBar`, `WiredCupertinoTabBar`, `WiredCupertinoDatePicker`, `WiredCupertinoPicker`, `WiredCupertinoActionSheet`, `WiredCupertinoAlertDialog`, `WiredCupertinoSegmentedControl`, `WiredCupertinoScaffold` |
+| Category        | Widgets                                                                                                                                                                                                                                                                                                                            |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Buttons**     | `WiredButton`, `WiredElevatedButton`, `WiredFilledButton`, `WiredOutlinedButton`, `WiredTextButton`, `WiredIconButton`, `WiredFab`                                                                                                                                                                                                 |
+| **Inputs**      | `WiredInput`, `WiredTextArea`, `WiredSearchBar`, `WiredAutocomplete`, `WiredCombo`                                                                                                                                                                                                                                                 |
+| **Selection**   | `WiredCheckbox`, `WiredRadio`, `WiredSwitch`, `WiredToggle`, `WiredToggleButtons`, `WiredSlider`, `WiredRangeSlider`                                                                                                                                                                                                               |
+| **Layout**      | `WiredCard`, `WiredDivider`, `WiredListTile`, `WiredExpansionTile`, `WiredStepper`, `WiredReorderableListView`                                                                                                                                                                                                                     |
+| **Navigation**  | `WiredAppBar`, `WiredSliverAppBar`, `WiredBottomNav`, `WiredBottomAppBar`, `WiredNavigationBar`, `WiredNavigationRail`, `WiredNavigationDrawer`, `WiredDrawer`, `WiredTabBar`                                                                                                                                                      |
+| **Feedback**    | `WiredDialog`, `WiredSnackBar`, `WiredTooltip`, `WiredProgress`, `WiredCircularProgress`, `WiredBadge`, `WiredMaterialBanner`                                                                                                                                                                                                      |
+| **Surfaces**    | `WiredScaffold`, `WiredBottomSheet`, `WiredPopupMenu`, `WiredContextMenu`, `WiredMenuBar`                                                                                                                                                                                                                                          |
+| **Date & Time** | `WiredDatePicker`, `WiredCalendar`, `WiredCalendarDatePicker`, `WiredTimePicker`                                                                                                                                                                                                                                                   |
+| **Chips**       | `WiredChip`, `WiredChoiceChip`, `WiredFilterChip`, `WiredInputChip`                                                                                                                                                                                                                                                                |
+| **Data**        | `WiredDataTable`                                                                                                                                                                                                                                                                                                                   |
+| **Cupertino**   | `WiredCupertinoButton`, `WiredCupertinoTextField`, `WiredCupertinoSwitch`, `WiredCupertinoSlider`, `WiredCupertinoNavigationBar`, `WiredCupertinoTabBar`, `WiredCupertinoDatePicker`, `WiredCupertinoPicker`, `WiredCupertinoActionSheet`, `WiredCupertinoAlertDialog`, `WiredCupertinoSegmentedControl`, `WiredCupertinoScaffold` |
 
 Browse the full [widget reference](/widgets) for API details and live examples.
 

--- a/docs/site/content/reference/agents.md
+++ b/docs/site/content/reference/agents.md
@@ -290,6 +290,7 @@ Container(
 ```
 
 Available `RoughBoxShape` values:
+
 - `rectangle` — sharp-corner rectangle
 - `roundedRectangle` — rounded corners (requires `borderRadius`)
 - `circle` — perfect circle
@@ -341,6 +342,7 @@ class WiredCounter extends HookWidget {
 ```
 
 Common hooks:
+
 - `useState<T>(initialValue)` — reactive local state
 - `useAnimationController(duration:)` — auto-disposed animation controller
 - `useAnimation(controller)` — reactive animation value
@@ -394,15 +396,15 @@ WiredCanvas(
 
 The `RoughFilter` enum controls fill patterns:
 
-| Filter | Effect |
-|--------|--------|
-| `noFiller` | Stroke only, no interior fill |
-| `hachureFiller` | Diagonal parallel lines |
-| `zigZagFiller` | Zigzag pattern |
-| `hatchFiller` | Cross-hatched grid |
-| `dotFiller` | Scattered dots |
-| `dashedFiller` | Dashed lines |
-| `solidFiller` | Solid color fill |
+| Filter          | Effect                        |
+| --------------- | ----------------------------- |
+| `noFiller`      | Stroke only, no interior fill |
+| `hachureFiller` | Diagonal parallel lines       |
+| `zigZagFiller`  | Zigzag pattern                |
+| `hatchFiller`   | Cross-hatched grid            |
+| `dotFiller`     | Scattered dots                |
+| `dashedFiller`  | Dashed lines                  |
+| `solidFiller`   | Solid color fill              |
 
 ### Accessibility
 
@@ -506,15 +508,15 @@ Container(color: theme.borderColor)
 
 ### WiredThemeData defaults (reference)
 
-| Field | Default Value | Description |
-|-------|--------------|-------------|
-| `borderColor` | `Color(0xFF1A2B3C)` | Sketchy stroke/border color |
-| `textColor` | `Colors.black` | Primary text color |
-| `disabledTextColor` | `Colors.grey` | Disabled state text color |
-| `fillColor` | `Color(0xFFFEFEFE)` | Paper-like background fill |
-| `strokeWidth` | `2.0` | Default stroke thickness |
-| `roughness` | `1.0` | Sketch randomness (0 = smooth, 2+ = very rough) |
-| `drawConfig` | `DrawConfig.defaultValues` | Advanced rough engine config |
+| Field               | Default Value              | Description                                     |
+| ------------------- | -------------------------- | ----------------------------------------------- |
+| `borderColor`       | `Color(0xFF1A2B3C)`        | Sketchy stroke/border color                     |
+| `textColor`         | `Colors.black`             | Primary text color                              |
+| `disabledTextColor` | `Colors.grey`              | Disabled state text color                       |
+| `fillColor`         | `Color(0xFFFEFEFE)`        | Paper-like background fill                      |
+| `strokeWidth`       | `2.0`                      | Default stroke thickness                        |
+| `roughness`         | `1.0`                      | Sketch randomness (0 = smooth, 2+ = very rough) |
+| `drawConfig`        | `DrawConfig.defaultValues` | Advanced rough engine config                    |
 
 ### WiredMaterialApp theme setup
 
@@ -552,6 +554,7 @@ WiredMaterialApp(
 ```
 
 Theme resolution follows this fallback chain:
+
 - Light mode: `wiredTheme`
 - Dark mode: `darkWiredTheme` -> `wiredTheme`
 - High contrast light: `highContrastWiredTheme` -> `wiredTheme`
@@ -727,18 +730,18 @@ WiredDataTable(
 
 Skribble provides both Material and Cupertino variants for common patterns. Use the Cupertino variants when building iOS-native experiences:
 
-| Material | Cupertino | When to use Cupertino |
-|----------|-----------|----------------------|
-| `WiredButton` | `WiredCupertinoButton` | iOS press-opacity effect |
-| `WiredAppBar` | `WiredCupertinoNavigationBar` | iOS-style navigation bar |
-| `WiredBottomNavigationBar` | `WiredCupertinoTabBar` | iOS tab bar look |
-| `WiredSwitch` | `WiredCupertinoSwitch` | iOS-style animated toggle |
-| `WiredSlider` | `WiredCupertinoSlider` | iOS slider feel |
-| `WiredInput` | `WiredCupertinoTextField` | iOS rounded text field |
-| `WiredDialog` | `WiredCupertinoAlertDialog` | iOS alert style |
-| `WiredDatePicker` | `WiredCupertinoDatePicker` | iOS wheel picker |
-| `WiredSegmentedButton` | `WiredCupertinoSegmentedControl` | iOS segmented control |
-| `WiredScaffold` | `WiredPageScaffold` | iOS page scaffold |
+| Material                   | Cupertino                        | When to use Cupertino     |
+| -------------------------- | -------------------------------- | ------------------------- |
+| `WiredButton`              | `WiredCupertinoButton`           | iOS press-opacity effect  |
+| `WiredAppBar`              | `WiredCupertinoNavigationBar`    | iOS-style navigation bar  |
+| `WiredBottomNavigationBar` | `WiredCupertinoTabBar`           | iOS tab bar look          |
+| `WiredSwitch`              | `WiredCupertinoSwitch`           | iOS-style animated toggle |
+| `WiredSlider`              | `WiredCupertinoSlider`           | iOS slider feel           |
+| `WiredInput`               | `WiredCupertinoTextField`        | iOS rounded text field    |
+| `WiredDialog`              | `WiredCupertinoAlertDialog`      | iOS alert style           |
+| `WiredDatePicker`          | `WiredCupertinoDatePicker`       | iOS wheel picker          |
+| `WiredSegmentedButton`     | `WiredCupertinoSegmentedControl` | iOS segmented control     |
+| `WiredScaffold`            | `WiredPageScaffold`              | iOS page scaffold         |
 
 For platform-adaptive apps, check `Theme.of(context).platform` and choose accordingly.
 
@@ -746,16 +749,16 @@ For platform-adaptive apps, check `Theme.of(context).platform` and choose accord
 
 When implementing selection UI, choose the right widget:
 
-| Pattern | Widget | Use when |
-|---------|--------|----------|
-| Single exclusive choice | `WiredRadio` / `WiredRadioListTile` | User picks exactly one option from a small set |
-| Multiple independent choices | `WiredCheckbox` / `WiredCheckboxListTile` | User can toggle multiple options on/off |
-| Tag-like selection | `WiredChoiceChip` / `WiredFilterChip` | Compact chip-based selection |
-| Single exclusive (compact) | `WiredSegmentedButton` | 2-5 mutually exclusive options |
-| Dropdown single choice | `WiredCombo` | Long list, pick one |
-| Color selection | `WiredColorPicker` | Color swatch grid |
-| Date selection | `WiredDatePicker` / `WiredCalendarDatePicker` | Date input |
-| Time selection | `WiredTimePicker` | Time input |
+| Pattern                      | Widget                                        | Use when                                       |
+| ---------------------------- | --------------------------------------------- | ---------------------------------------------- |
+| Single exclusive choice      | `WiredRadio` / `WiredRadioListTile`           | User picks exactly one option from a small set |
+| Multiple independent choices | `WiredCheckbox` / `WiredCheckboxListTile`     | User can toggle multiple options on/off        |
+| Tag-like selection           | `WiredChoiceChip` / `WiredFilterChip`         | Compact chip-based selection                   |
+| Single exclusive (compact)   | `WiredSegmentedButton`                        | 2-5 mutually exclusive options                 |
+| Dropdown single choice       | `WiredCombo`                                  | Long list, pick one                            |
+| Color selection              | `WiredColorPicker`                            | Color swatch grid                              |
+| Date selection               | `WiredDatePicker` / `WiredCalendarDatePicker` | Date input                                     |
+| Time selection               | `WiredTimePicker`                             | Time input                                     |
 
 ## Rough engine reference for agents
 
@@ -814,13 +817,13 @@ canvas.drawRough(
 
 These are the built-in painters agents should reuse where possible:
 
-| Painter | Shape | Key Parameters |
-|---------|-------|---------------|
-| `WiredRectangleBase` | Rectangle | `leftIndent`, `rightIndent`, `fillColor`, `borderColor`, `strokeWidth` |
-| `WiredCircleBase` | Circle | `diameterRatio`, `fillColor`, `borderColor`, `strokeWidth` |
-| `WiredLineBase` | Line | `x1`, `y1`, `x2`, `y2`, `borderColor`, `strokeWidth` |
-| `WiredRoundedRectangleBase` | Rounded rect | `borderRadius`, `fillColor`, `borderColor`, `strokeWidth` |
-| `WiredInvertedTriangleBase` | Inverted triangle | `borderColor`, `strokeWidth` |
+| Painter                     | Shape             | Key Parameters                                                         |
+| --------------------------- | ----------------- | ---------------------------------------------------------------------- |
+| `WiredRectangleBase`        | Rectangle         | `leftIndent`, `rightIndent`, `fillColor`, `borderColor`, `strokeWidth` |
+| `WiredCircleBase`           | Circle            | `diameterRatio`, `fillColor`, `borderColor`, `strokeWidth`             |
+| `WiredLineBase`             | Line              | `x1`, `y1`, `x2`, `y2`, `borderColor`, `strokeWidth`                   |
+| `WiredRoundedRectangleBase` | Rounded rect      | `borderRadius`, `fillColor`, `borderColor`, `strokeWidth`              |
+| `WiredInvertedTriangleBase` | Inverted triangle | `borderColor`, `strokeWidth`                                           |
 
 ## Constants reference
 
@@ -886,13 +889,13 @@ chore: bump version to 0.3.5
 
 ## File naming conventions
 
-| Type | Location | Naming |
-|------|----------|--------|
-| Widget | `packages/skribble/lib/src/` | `wired_<name>.dart` (snake_case) |
-| Export | `packages/skribble/lib/skribble.dart` | `export 'src/wired_<name>.dart';` |
-| Test | `packages/skribble/test/widgets/` | `wired_<name>_test.dart` |
-| Storybook page | `apps/skribble_storybook/lib/pages/` | `<category>_page.dart` |
-| Docs page | `docs/site/content/widgets/` | `<category>.md` |
+| Type           | Location                              | Naming                            |
+| -------------- | ------------------------------------- | --------------------------------- |
+| Widget         | `packages/skribble/lib/src/`          | `wired_<name>.dart` (snake_case)  |
+| Export         | `packages/skribble/lib/skribble.dart` | `export 'src/wired_<name>.dart';` |
+| Test           | `packages/skribble/test/widgets/`     | `wired_<name>_test.dart`          |
+| Storybook page | `apps/skribble_storybook/lib/pages/`  | `<category>_page.dart`            |
+| Docs page      | `docs/site/content/widgets/`          | `<category>.md`                   |
 
 ## Checklist for agents
 
@@ -933,11 +936,13 @@ Before marking any widget task as complete, verify:
 ### When to use RoughBoxDecoration vs custom painters
 
 Use `RoughBoxDecoration` when:
+
 - You need a standard shape (rectangle, rounded rect, circle, ellipse)
 - You want drop-in replacement for `BoxDecoration`
 - The widget uses `Container` or `DecoratedBox`
 
 Use a custom `WiredPainterBase` when:
+
 - You need a non-standard shape (star, wave, arrow, etc.)
 - You need to draw multiple shapes in a single painter
 - You need fine-grained control over the drawing sequence
@@ -958,6 +963,7 @@ Without a fixed seed, rough drawings will vary between renders, which can cause 
 **Every change to the codebase must have corresponding documentation updates.** This is a hard rule, not a suggestion. No PR should be merged without documentation for what changed.
 
 **When you add a widget:**
+
 1. Add it to the appropriate widget catalog page in `docs/site/content/widgets/`
 2. Include a code example, parameter table, and behavioral notes
 3. Export it from `packages/skribble/lib/skribble.dart`
@@ -965,37 +971,44 @@ Without a fixed seed, rough drawings will vary between renders, which can cause 
 5. Add the widget to the API overview at `docs/site/content/reference/api-overview.md`
 
 **When you modify a widget API:**
+
 1. Update the widget's entry in the widget catalog
 2. Update any code examples that reference the changed API
 3. Update MDT template blocks if the change affects reusable patterns
 4. Update the agents.md reference if it lists the widget's parameters
 
 **When you add a feature:**
+
 1. Add or update the relevant guide in `docs/site/content/guides/`
 2. Update the getting-started pages if the feature is fundamental
 3. Update this agents.md if the feature changes agent workflows
 4. Update the API overview if new public types are introduced
 
 **When you modify the theme system:**
+
 1. Update `docs/site/content/core/theme-system.md`
 2. Update the theming getting-started page
 3. Update the WiredThemeData defaults table in this document
 4. Update the theming MDT template block in `template.t.md`
 
 **When you modify tests or testing infrastructure:**
+
 1. Update `docs/site/content/guides/testing.md`
 2. Update the test template in this agents.md
 
 **When you modify the rough engine:**
+
 1. Update `docs/site/content/core/rough-engine.md`
 2. Update `docs/site/content/core/painters.md` if painters are affected
 3. Update the rough engine reference section in this agents.md
 
 **When you add or modify devenv scripts:**
+
 1. Update the commands section in AGENTS.md (root)
 2. Update the workspace commands table at the bottom of this agents.md
 
 **When you modify the docs site itself:**
+
 1. Update the sidebar if pages were added/removed (`docs/site/lib/components/site_sidebar.dart`)
 2. Update internal cross-links between pages
 
@@ -1011,6 +1024,7 @@ melos run rough-icons-font     # SVG + TTF font + Dart helpers
 ### Generating custom icon sets
 
 1. Create a manifest JSON:
+
 ```json
 [
   {
@@ -1022,6 +1036,7 @@ melos run rough-icons-font     # SVG + TTF font + Dart helpers
 ```
 
 2. Run the generator:
+
 ```bash
 dart run tool/generate_rough_icons.dart \
   --kit svg-manifest \
@@ -1042,18 +1057,18 @@ WiredIcon.svg(iconData: myCustomIconData)
 
 ## Workspace commands quick reference
 
-| Command | What it does |
-|---------|-------------|
-| `melos run analyze` | Dart analyze across all packages |
-| `melos run flutter-test` | Run Flutter widget tests |
-| `melos run format` | Format all Dart code |
-| `melos run screenshot` | Capture component screenshots |
-| `melos run rough-icons` | Generate rough Material icon SVGs |
-| `melos run rough-icons-font` | Generate icon font + Dart helpers |
-| `melos run rough-icons-custom` | Generate custom icon artifacts |
-| `melos run rough-icons-ci-check` | CI-equivalent icon checks |
-| `lint:all` | All lint checks (format + analyze) |
-| `test:all` | All unit and widget tests |
-| `fix:all` | Auto-fix format + lint issues |
-| `docs:site:serve` | Serve docs site locally |
-| `docs:site:build` | Build static docs for deployment |
+| Command                          | What it does                       |
+| -------------------------------- | ---------------------------------- |
+| `melos run analyze`              | Dart analyze across all packages   |
+| `melos run flutter-test`         | Run Flutter widget tests           |
+| `melos run format`               | Format all Dart code               |
+| `melos run screenshot`           | Capture component screenshots      |
+| `melos run rough-icons`          | Generate rough Material icon SVGs  |
+| `melos run rough-icons-font`     | Generate icon font + Dart helpers  |
+| `melos run rough-icons-custom`   | Generate custom icon artifacts     |
+| `melos run rough-icons-ci-check` | CI-equivalent icon checks          |
+| `lint:all`                       | All lint checks (format + analyze) |
+| `test:all`                       | All unit and widget tests          |
+| `fix:all`                        | Auto-fix format + lint issues      |
+| `docs:site:serve`                | Serve docs site locally            |
+| `docs:site:build`                | Build static docs for deployment   |

--- a/docs/site/content/reference/api-overview.md
+++ b/docs/site/content/reference/api-overview.md
@@ -19,11 +19,12 @@ The public API is organized into five layers, from lowest to highest:
 
 The Dart port of rough.js that generates hand-drawn paths.
 
-| Export | Purpose |
-|--------|---------|
+| Export                | Purpose                     |
+| --------------------- | --------------------------- |
 | `skribble_rough.dart` | Full rough engine re-export |
 
 Key types:
+
 - `DrawConfig` — roughness, bowing, seed, and curve settings
 - `Generator` — creates `Drawable` shapes (rectangle, circle, polygon, arc, etc.)
 - `Filler` — abstract fill pattern (HachureFiller, DotFiller, SolidFiller, etc.)
@@ -39,13 +40,14 @@ Key types:
 
 Low-level painting infrastructure.
 
-| Export | Purpose |
-|--------|---------|
-| `wired_canvas.dart` | HookWidget that renders rough shapes via CustomPaint |
-| `wired_painter.dart` | CustomPainter implementation for rough shapes |
-| `wired_painter_base.dart` | Abstract base class for shape painters |
+| Export                    | Purpose                                              |
+| ------------------------- | ---------------------------------------------------- |
+| `wired_canvas.dart`       | HookWidget that renders rough shapes via CustomPaint |
+| `wired_painter.dart`      | CustomPainter implementation for rough shapes        |
+| `wired_painter_base.dart` | Abstract base class for shape painters               |
 
 Key types:
+
 - `WiredPainterBase` — override `paintRough(Canvas, Size, DrawConfig, Filler)`
 - `WiredCanvas` — widget that takes a painter + filler type
 - `WiredPainter` — CustomPainter adapter for WiredPainterBase
@@ -54,11 +56,12 @@ Key types:
 
 Shared constants, paint helpers, and repaint isolation.
 
-| Export | Purpose |
-|--------|---------|
+| Export            | Purpose                                         |
+| ----------------- | ----------------------------------------------- |
 | `wired_base.dart` | WiredBase, WiredBaseWidget, painters, constants |
 
 Key types:
+
 - `WiredBase` — static `fillPainter(Color)` and `pathPainter(double, {Color})`
 - `WiredBaseWidget` — abstract HookWidget with built-in RepaintBoundary
 - `WiredRepaintMixin` — mixin for RepaintBoundary wrapping
@@ -70,12 +73,13 @@ Key types:
 
 Colors, roughness, and Material bridge.
 
-| Export | Purpose |
-|--------|---------|
-| `wired_theme.dart` | WiredThemeData + WiredTheme InheritedWidget |
-| `wired_material_app.dart` | WiredMaterialApp (.router) |
+| Export                    | Purpose                                     |
+| ------------------------- | ------------------------------------------- |
+| `wired_theme.dart`        | WiredThemeData + WiredTheme InheritedWidget |
+| `wired_material_app.dart` | WiredMaterialApp (.router)                  |
 
 Key types:
+
 - `WiredThemeData` — borderColor, textColor, fillColor, strokeWidth, roughness, drawConfig
 - `WiredTheme` — InheritedWidget, accessed via `WiredTheme.of(context)`
 - `WiredMaterialApp` — MaterialApp wrapper that syncs WiredTheme + Material ThemeData
@@ -86,139 +90,139 @@ All widgets follow the `Wired*` naming convention and extend `HookWidget`.
 
 #### Buttons (10)
 
-| Widget | File |
-|--------|------|
-| `WiredButton` | `wired_button.dart` |
-| `WiredElevatedButton` | `wired_elevated_button.dart` |
-| `WiredFilledButton` | `wired_filled_button.dart` |
-| `WiredFloatingActionButton` | `wired_fab.dart` |
-| `WiredIconButton` | `wired_icon_button.dart` |
-| `WiredOutlinedButton` | `wired_outlined_button.dart` |
-| `WiredTextButton` | `wired_text_button.dart` |
-| `WiredToggleButtons` | `wired_toggle_buttons.dart` |
-| `WiredSegmentedButton` | `wired_segmented_button.dart` |
-| `WiredCupertinoButton` | `wired_cupertino_button.dart` |
+| Widget                      | File                          |
+| --------------------------- | ----------------------------- |
+| `WiredButton`               | `wired_button.dart`           |
+| `WiredElevatedButton`       | `wired_elevated_button.dart`  |
+| `WiredFilledButton`         | `wired_filled_button.dart`    |
+| `WiredFloatingActionButton` | `wired_fab.dart`              |
+| `WiredIconButton`           | `wired_icon_button.dart`      |
+| `WiredOutlinedButton`       | `wired_outlined_button.dart`  |
+| `WiredTextButton`           | `wired_text_button.dart`      |
+| `WiredToggleButtons`        | `wired_toggle_buttons.dart`   |
+| `WiredSegmentedButton`      | `wired_segmented_button.dart` |
+| `WiredCupertinoButton`      | `wired_cupertino_button.dart` |
 
 #### Inputs (17)
 
-| Widget | File |
-|--------|------|
-| `WiredInput` | `wired_input.dart` |
-| `WiredTextArea` | `wired_text_area.dart` |
-| `WiredSearchBar` | `wired_search_bar.dart` |
-| `WiredCheckbox` | `wired_checkbox.dart` |
-| `WiredCheckboxListTile` | `wired_checkbox_list_tile.dart` |
-| `WiredRadio` | `wired_radio.dart` |
-| `WiredRadioListTile` | `wired_radio_list_tile.dart` |
-| `WiredSwitch` | `wired_switch.dart` |
-| `WiredSwitchListTile` | `wired_switch_list_tile.dart` |
-| `WiredSlider` | `wired_slider.dart` |
-| `WiredRangeSlider` | `wired_range_slider.dart` |
-| `WiredToggle` | `wired_toggle.dart` |
-| `WiredForm` | `wired_form.dart` |
-| `WiredAutocomplete` | `wired_autocomplete.dart` |
+| Widget                    | File                              |
+| ------------------------- | --------------------------------- |
+| `WiredInput`              | `wired_input.dart`                |
+| `WiredTextArea`           | `wired_text_area.dart`            |
+| `WiredSearchBar`          | `wired_search_bar.dart`           |
+| `WiredCheckbox`           | `wired_checkbox.dart`             |
+| `WiredCheckboxListTile`   | `wired_checkbox_list_tile.dart`   |
+| `WiredRadio`              | `wired_radio.dart`                |
+| `WiredRadioListTile`      | `wired_radio_list_tile.dart`      |
+| `WiredSwitch`             | `wired_switch.dart`               |
+| `WiredSwitchListTile`     | `wired_switch_list_tile.dart`     |
+| `WiredSlider`             | `wired_slider.dart`               |
+| `WiredRangeSlider`        | `wired_range_slider.dart`         |
+| `WiredToggle`             | `wired_toggle.dart`               |
+| `WiredForm`               | `wired_form.dart`                 |
+| `WiredAutocomplete`       | `wired_autocomplete.dart`         |
 | `WiredCupertinoTextField` | `wired_cupertino_text_field.dart` |
-| `WiredCupertinoSlider` | `wired_cupertino_slider.dart` |
-| `WiredCupertinoSwitch` | `wired_cupertino_switch.dart` |
+| `WiredCupertinoSlider`    | `wired_cupertino_slider.dart`     |
+| `WiredCupertinoSwitch`    | `wired_cupertino_switch.dart`     |
 
 #### Navigation (13)
 
-| Widget | File |
-|--------|------|
-| `WiredAppBar` | `wired_app_bar.dart` |
-| `WiredBottomNavigationBar` | `wired_bottom_nav.dart` |
-| `WiredNavigationBar` | `wired_navigation_bar.dart` |
-| `WiredNavigationRail` | `wired_navigation_rail.dart` |
-| `WiredNavigationDrawer` | `wired_navigation_drawer.dart` |
-| `WiredTabBar` | `wired_tab_bar.dart` |
-| `WiredDrawer` | `wired_drawer.dart` |
-| `WiredPopupMenuButton` | `wired_popup_menu.dart` |
-| `WiredMenuBar` | `wired_menu_bar.dart` |
-| `WiredBottomAppBar` | `wired_bottom_app_bar.dart` |
-| `WiredSliverAppBar` | `wired_sliver_app_bar.dart` |
+| Widget                        | File                                  |
+| ----------------------------- | ------------------------------------- |
+| `WiredAppBar`                 | `wired_app_bar.dart`                  |
+| `WiredBottomNavigationBar`    | `wired_bottom_nav.dart`               |
+| `WiredNavigationBar`          | `wired_navigation_bar.dart`           |
+| `WiredNavigationRail`         | `wired_navigation_rail.dart`          |
+| `WiredNavigationDrawer`       | `wired_navigation_drawer.dart`        |
+| `WiredTabBar`                 | `wired_tab_bar.dart`                  |
+| `WiredDrawer`                 | `wired_drawer.dart`                   |
+| `WiredPopupMenuButton`        | `wired_popup_menu.dart`               |
+| `WiredMenuBar`                | `wired_menu_bar.dart`                 |
+| `WiredBottomAppBar`           | `wired_bottom_app_bar.dart`           |
+| `WiredSliverAppBar`           | `wired_sliver_app_bar.dart`           |
 | `WiredCupertinoNavigationBar` | `wired_cupertino_navigation_bar.dart` |
-| `WiredCupertinoTabBar` | `wired_cupertino_tab_bar.dart` |
+| `WiredCupertinoTabBar`        | `wired_cupertino_tab_bar.dart`        |
 
 #### Selection (12)
 
-| Widget | File |
-|--------|------|
-| `WiredChip` | `wired_chip.dart` |
-| `WiredChoiceChip` | `wired_choice_chip.dart` |
-| `WiredFilterChip` | `wired_filter_chip.dart` |
-| `WiredInputChip` | `wired_input_chip.dart` |
-| `WiredCombo` | `wired_combo.dart` |
-| `WiredDatePicker` | `wired_date_picker.dart` |
-| `WiredTimePicker` | `wired_time_picker.dart` |
-| `WiredCalendarDatePicker` | `wired_calendar_date_picker.dart` |
-| `WiredColorPicker` | `wired_color_picker.dart` |
-| `WiredCupertinoPicker` | `wired_cupertino_picker.dart` |
-| `WiredCupertinoDatePicker` | `wired_cupertino_date_picker.dart` |
+| Widget                           | File                                     |
+| -------------------------------- | ---------------------------------------- |
+| `WiredChip`                      | `wired_chip.dart`                        |
+| `WiredChoiceChip`                | `wired_choice_chip.dart`                 |
+| `WiredFilterChip`                | `wired_filter_chip.dart`                 |
+| `WiredInputChip`                 | `wired_input_chip.dart`                  |
+| `WiredCombo`                     | `wired_combo.dart`                       |
+| `WiredDatePicker`                | `wired_date_picker.dart`                 |
+| `WiredTimePicker`                | `wired_time_picker.dart`                 |
+| `WiredCalendarDatePicker`        | `wired_calendar_date_picker.dart`        |
+| `WiredColorPicker`               | `wired_color_picker.dart`                |
+| `WiredCupertinoPicker`           | `wired_cupertino_picker.dart`            |
+| `WiredCupertinoDatePicker`       | `wired_cupertino_date_picker.dart`       |
 | `WiredCupertinoSegmentedControl` | `wired_cupertino_segmented_control.dart` |
 
 #### Feedback (13)
 
-| Widget | File |
-|--------|------|
-| `WiredDialog` | `wired_dialog.dart` |
-| `WiredSnackBarContent` | `wired_snack_bar.dart` |
-| `WiredTooltip` | `wired_tooltip.dart` |
-| `WiredProgress` | `wired_progress.dart` |
-| `WiredCircularProgress` | `wired_circular_progress.dart` |
-| `WiredBadge` | `wired_badge.dart` |
-| `WiredBottomSheet` | `wired_bottom_sheet.dart` |
-| `WiredAboutDialog` | `wired_about_dialog.dart` |
-| `WiredContextMenu` | `wired_context_menu.dart` |
-| `WiredAnimatedIcon` | `wired_animated_icon.dart` |
-| `WiredMaterialBanner` | `wired_material_banner.dart` |
+| Widget                      | File                                |
+| --------------------------- | ----------------------------------- |
+| `WiredDialog`               | `wired_dialog.dart`                 |
+| `WiredSnackBarContent`      | `wired_snack_bar.dart`              |
+| `WiredTooltip`              | `wired_tooltip.dart`                |
+| `WiredProgress`             | `wired_progress.dart`               |
+| `WiredCircularProgress`     | `wired_circular_progress.dart`      |
+| `WiredBadge`                | `wired_badge.dart`                  |
+| `WiredBottomSheet`          | `wired_bottom_sheet.dart`           |
+| `WiredAboutDialog`          | `wired_about_dialog.dart`           |
+| `WiredContextMenu`          | `wired_context_menu.dart`           |
+| `WiredAnimatedIcon`         | `wired_animated_icon.dart`          |
+| `WiredMaterialBanner`       | `wired_material_banner.dart`        |
 | `WiredCupertinoAlertDialog` | `wired_cupertino_alert_dialog.dart` |
 | `WiredCupertinoActionSheet` | `wired_cupertino_action_sheet.dart` |
 
 #### Layout (16)
 
-| Widget | File |
-|--------|------|
-| `WiredCard` | `wired_card.dart` |
-| `WiredDivider` | `wired_divider.dart` |
-| `WiredListTile` | `wired_list_tile.dart` |
-| `WiredExpansionTile` | `wired_expansion_tile.dart` |
-| `WiredDataTable` | `wired_data_table.dart` |
-| `WiredStepper` | `wired_stepper.dart` |
-| `WiredCalendar` | `wired_calendar.dart` |
-| `WiredScrollbar` | `wired_scrollbar.dart` |
-| `WiredScaffold` | `wired_scaffold.dart` |
+| Widget                     | File                               |
+| -------------------------- | ---------------------------------- |
+| `WiredCard`                | `wired_card.dart`                  |
+| `WiredDivider`             | `wired_divider.dart`               |
+| `WiredListTile`            | `wired_list_tile.dart`             |
+| `WiredExpansionTile`       | `wired_expansion_tile.dart`        |
+| `WiredDataTable`           | `wired_data_table.dart`            |
+| `WiredStepper`             | `wired_stepper.dart`               |
+| `WiredCalendar`            | `wired_calendar.dart`              |
+| `WiredScrollbar`           | `wired_scrollbar.dart`             |
+| `WiredScaffold`            | `wired_scaffold.dart`              |
 | `WiredReorderableListView` | `wired_reorderable_list_view.dart` |
-| `WiredDismissible` | `wired_dismissible.dart` |
-| `WiredSelectableText` | `wired_selectable_text.dart` |
-| `WiredDrawerHeader` | `wired_drawer_header.dart` |
-| `WiredAvatar` | `wired_avatar.dart` |
-| `WiredPageScaffold` | `wired_cupertino_scaffold.dart` |
-| `WiredTabScaffold` | `wired_cupertino_scaffold.dart` |
+| `WiredDismissible`         | `wired_dismissible.dart`           |
+| `WiredSelectableText`      | `wired_selectable_text.dart`       |
+| `WiredDrawerHeader`        | `wired_drawer_header.dart`         |
+| `WiredAvatar`              | `wired_avatar.dart`                |
+| `WiredPageScaffold`        | `wired_cupertino_scaffold.dart`    |
+| `WiredTabScaffold`         | `wired_cupertino_scaffold.dart`    |
 
 #### Icons
 
-| Widget | File |
-|--------|------|
-| `WiredIcon` | `wired_icon.dart` |
-| `WiredSvgIconData` | `wired_svg_icon_data.dart` |
+| Widget              | File                       |
+| ------------------- | -------------------------- |
+| `WiredIcon`         | `wired_icon.dart`          |
+| `WiredSvgIconData`  | `wired_svg_icon_data.dart` |
 | `WiredAnimatedIcon` | `wired_animated_icon.dart` |
 
 ## Package dependencies
 
 The main library depends on:
 
-| Package | Version | Purpose |
-|---------|---------|---------|
-| `flutter` | SDK | Core Flutter framework |
-| `flutter_hooks` | `^0.21.3` | HookWidget, useState, useEffect, etc. |
-| `google_fonts` | `^8.0.2` | Hand-drawn font access |
-| `path_parsing` | `^1.1.0` | SVG path parsing for rough icon rendering |
+| Package         | Version   | Purpose                                   |
+| --------------- | --------- | ----------------------------------------- |
+| `flutter`       | SDK       | Core Flutter framework                    |
+| `flutter_hooks` | `^0.21.3` | HookWidget, useState, useEffect, etc.     |
+| `google_fonts`  | `^8.0.2`  | Hand-drawn font access                    |
+| `path_parsing`  | `^1.1.0`  | SVG path parsing for rough icon rendering |
 
 ## Companion packages
 
-| Package | Purpose |
-|---------|---------|
-| `skribble_lints` | Shared lint rules (extends `very_good_analysis`) |
+| Package                 | Purpose                                            |
+| ----------------------- | -------------------------------------------------- |
+| `skribble_lints`        | Shared lint rules (extends `very_good_analysis`)   |
 | `skribble_icons_custom` | Example custom icon set with SVG-manifest pipeline |
 
 ## API documentation

--- a/docs/site/content/reference/contributing.md
+++ b/docs/site/content/reference/contributing.md
@@ -76,14 +76,14 @@ skribble/
 
 Every widget test file must have **>= 6 `testWidgets`** covering:
 
-| Category | Example |
-|----------|---------|
-| Rendering | Renders without error, renders child content |
-| Dimensions | Correct size, respects custom height/width |
-| Interaction | Responds to tap, calls `onChanged` |
-| State | Rebuilds on value change, animations complete |
-| Edge cases | Null values, rapid interactions |
-| Accessibility | Semantic labels where applicable |
+| Category      | Example                                       |
+| ------------- | --------------------------------------------- |
+| Rendering     | Renders without error, renders child content  |
+| Dimensions    | Correct size, respects custom height/width    |
+| Interaction   | Responds to tap, calls `onChanged`            |
+| State         | Rebuilds on value change, animations complete |
+| Edge cases    | Null values, rapid interactions               |
+| Accessibility | Semantic labels where applicable              |
 
 ### Test helper
 

--- a/docs/site/content/widgets/buttons.md
+++ b/docs/site/content/widgets/buttons.md
@@ -14,6 +14,7 @@ Skribble provides a full set of button widgets that replace their Material and C
 A basic button with a hand-drawn rectangle border. The simplest entry point for actions.
 
 <!-- {=docsButtonBasicUsage} -->
+
 ```dart
 WiredButton(
   onPressed: () => print('tapped'),
@@ -23,11 +24,11 @@ WiredButton(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `child` | `Widget` | **required** | The button label. |
-| `onPressed` | `void Function()` | **required** | Callback when the button is tapped. |
-| `semanticLabel` | `String?` | `null` | Accessibility label exposed to screen readers. |
+| Parameter       | Type              | Default      | Description                                    |
+| --------------- | ----------------- | ------------ | ---------------------------------------------- |
+| `child`         | `Widget`          | **required** | The button label.                              |
+| `onPressed`     | `void Function()` | **required** | Callback when the button is tapped.            |
+| `semanticLabel` | `String?`         | `null`       | Accessibility label exposed to screen readers. |
 
 ### Notes
 
@@ -42,6 +43,7 @@ WiredButton(
 An elevated variant with a slight offset shadow layer rendered behind the main button face. Both the shadow and the face use hachure fills for a tactile, layered look.
 
 <!-- {=docsElevatedButtonUsage} -->
+
 ```dart
 WiredElevatedButton(
   onPressed: () {},
@@ -51,11 +53,11 @@ WiredElevatedButton(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `child` | `Widget` | **required** | The button label. |
-| `onPressed` | `VoidCallback?` | `null` | Callback when tapped. `null` disables the button. |
-| `semanticLabel` | `String?` | `null` | Accessibility label. |
+| Parameter       | Type            | Default      | Description                                       |
+| --------------- | --------------- | ------------ | ------------------------------------------------- |
+| `child`         | `Widget`        | **required** | The button label.                                 |
+| `onPressed`     | `VoidCallback?` | `null`       | Callback when tapped. `null` disables the button. |
+| `semanticLabel` | `String?`       | `null`       | Accessibility label.                              |
 
 ### Notes
 
@@ -69,6 +71,7 @@ WiredElevatedButton(
 A solid button with a dense hachure fill, analogous to Material's `FilledButton`. Good for primary call-to-action placement.
 
 <!-- {=docsFilledButtonUsage} -->
+
 ```dart
 WiredFilledButton(
   onPressed: () {},
@@ -78,13 +81,13 @@ WiredFilledButton(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `child` | `Widget` | **required** | The button label. |
-| `onPressed` | `VoidCallback?` | `null` | Callback when tapped. |
-| `fillColor` | `Color?` | `null` | Custom fill color. Defaults to `theme.borderColor`. |
-| `foregroundColor` | `Color?` | `null` | Text/icon color. Defaults to white. |
-| `semanticLabel` | `String?` | `null` | Accessibility label. |
+| Parameter         | Type            | Default      | Description                                         |
+| ----------------- | --------------- | ------------ | --------------------------------------------------- |
+| `child`           | `Widget`        | **required** | The button label.                                   |
+| `onPressed`       | `VoidCallback?` | `null`       | Callback when tapped.                               |
+| `fillColor`       | `Color?`        | `null`       | Custom fill color. Defaults to `theme.borderColor`. |
+| `foregroundColor` | `Color?`        | `null`       | Text/icon color. Defaults to white.                 |
+| `semanticLabel`   | `String?`       | `null`       | Accessibility label.                                |
 
 ### Notes
 
@@ -98,6 +101,7 @@ WiredFilledButton(
 A circular floating action button with a hand-drawn circle border and hachure fill. Designed for primary screen actions.
 
 <!-- {=docsFabUsage} -->
+
 ```dart
 WiredFloatingActionButton(
   icon: Icons.add,
@@ -107,13 +111,13 @@ WiredFloatingActionButton(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `icon` | `IconData` | **required** | The icon displayed in the center. |
-| `onPressed` | `VoidCallback?` | `null` | Callback when tapped. |
-| `size` | `double` | `56.0` | Diameter of the FAB. |
-| `iconColor` | `Color?` | `null` | Icon color override. Defaults to `theme.fillColor`. |
-| `semanticLabel` | `String?` | `null` | Accessibility label. |
+| Parameter       | Type            | Default      | Description                                         |
+| --------------- | --------------- | ------------ | --------------------------------------------------- |
+| `icon`          | `IconData`      | **required** | The icon displayed in the center.                   |
+| `onPressed`     | `VoidCallback?` | `null`       | Callback when tapped.                               |
+| `size`          | `double`        | `56.0`       | Diameter of the FAB.                                |
+| `iconColor`     | `Color?`        | `null`       | Icon color override. Defaults to `theme.fillColor`. |
+| `semanticLabel` | `String?`       | `null`       | Accessibility label.                                |
 
 ### Notes
 
@@ -128,6 +132,7 @@ WiredFloatingActionButton(
 An icon button enclosed in a hand-drawn circle border with no fill. Ideal for toolbar actions and compact controls.
 
 <!-- {=docsIconButtonUsage} -->
+
 ```dart
 WiredIconButton(
   icon: Icons.favorite,
@@ -137,13 +142,13 @@ WiredIconButton(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `icon` | `IconData` | **required** | The icon to display. |
-| `onPressed` | `VoidCallback?` | `null` | Callback when tapped. |
-| `size` | `double` | `48.0` | Overall size of the button. |
-| `iconColor` | `Color?` | `null` | Icon color override. Defaults to `theme.textColor`. |
-| `semanticLabel` | `String?` | `null` | Accessibility label. |
+| Parameter       | Type            | Default      | Description                                         |
+| --------------- | --------------- | ------------ | --------------------------------------------------- |
+| `icon`          | `IconData`      | **required** | The icon to display.                                |
+| `onPressed`     | `VoidCallback?` | `null`       | Callback when tapped.                               |
+| `size`          | `double`        | `48.0`       | Overall size of the button.                         |
+| `iconColor`     | `Color?`        | `null`       | Icon color override. Defaults to `theme.textColor`. |
+| `semanticLabel` | `String?`       | `null`       | Accessibility label.                                |
 
 ### Notes
 
@@ -157,6 +162,7 @@ WiredIconButton(
 A button with a thick hand-drawn border (2px stroke width) and no fill. The heavier outline provides strong visual emphasis without a background.
 
 <!-- {=docsOutlinedButtonUsage} -->
+
 ```dart
 WiredOutlinedButton(
   onPressed: () {},
@@ -166,11 +172,11 @@ WiredOutlinedButton(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `child` | `Widget` | **required** | The button label. |
-| `onPressed` | `VoidCallback?` | `null` | Callback when tapped. |
-| `semanticLabel` | `String?` | `null` | Accessibility label. |
+| Parameter       | Type            | Default      | Description           |
+| --------------- | --------------- | ------------ | --------------------- |
+| `child`         | `Widget`        | **required** | The button label.     |
+| `onPressed`     | `VoidCallback?` | `null`       | Callback when tapped. |
+| `semanticLabel` | `String?`       | `null`       | Accessibility label.  |
 
 ### Notes
 
@@ -183,6 +189,7 @@ WiredOutlinedButton(
 A text-only button with a sketchy underline drawn beneath the label. No border or fill surrounds the text.
 
 <!-- {=docsTextButtonUsage} -->
+
 ```dart
 WiredTextButton(
   onPressed: () {},
@@ -192,11 +199,11 @@ WiredTextButton(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `child` | `Widget` | **required** | The button label. |
-| `onPressed` | `VoidCallback?` | `null` | Callback when tapped. |
-| `semanticLabel` | `String?` | `null` | Accessibility label. |
+| Parameter       | Type            | Default      | Description           |
+| --------------- | --------------- | ------------ | --------------------- |
+| `child`         | `Widget`        | **required** | The button label.     |
+| `onPressed`     | `VoidCallback?` | `null`       | Callback when tapped. |
+| `semanticLabel` | `String?`       | `null`       | Accessibility label.  |
 
 ### Notes
 
@@ -210,6 +217,7 @@ WiredTextButton(
 A multi-toggle button group where each button gets a sketchy rectangle border. Selected buttons receive a hachure fill; unselected buttons remain transparent.
 
 <!-- {=docsToggleButtonsUsage} -->
+
 ```dart
 WiredToggleButtons(
   isSelected: [true, false, false],
@@ -228,13 +236,13 @@ WiredToggleButtons(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `children` | `List<Widget>` | **required** | Button labels. |
-| `isSelected` | `List<bool>` | **required** | Selection state per button. Must match `children` length. |
-| `onPressed` | `ValueChanged<int>?` | `null` | Called with the tapped index. |
-| `height` | `double` | `42` | Height of each toggle button. |
-| `horizontalPadding` | `double` | `16` | Horizontal padding inside each button. |
+| Parameter           | Type                 | Default      | Description                                               |
+| ------------------- | -------------------- | ------------ | --------------------------------------------------------- |
+| `children`          | `List<Widget>`       | **required** | Button labels.                                            |
+| `isSelected`        | `List<bool>`         | **required** | Selection state per button. Must match `children` length. |
+| `onPressed`         | `ValueChanged<int>?` | `null`       | Called with the tapped index.                             |
+| `height`            | `double`             | `42`         | Height of each toggle button.                             |
+| `horizontalPadding` | `double`             | `16`         | Horizontal padding inside each button.                    |
 
 ### Notes
 
@@ -248,6 +256,7 @@ WiredToggleButtons(
 A segmented control with connected rounded rectangles, analogous to Material 3's `SegmentedButton`. Each segment can display a label and optional icon.
 
 <!-- {=docsSegmentedButtonUsage} -->
+
 ```dart
 WiredSegmentedButton<String>(
   segments: [
@@ -264,20 +273,20 @@ WiredSegmentedButton<String>(
 
 ### WiredButtonSegment parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `value` | `T` | **required** | The value this segment represents. |
-| `label` | `Widget` | **required** | Displayed label. |
-| `icon` | `IconData?` | `null` | Optional icon shown before the label. |
+| Parameter | Type        | Default      | Description                           |
+| --------- | ----------- | ------------ | ------------------------------------- |
+| `value`   | `T`         | **required** | The value this segment represents.    |
+| `label`   | `Widget`    | **required** | Displayed label.                      |
+| `icon`    | `IconData?` | `null`       | Optional icon shown before the label. |
 
 ### WiredSegmentedButton parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `segments` | `List<WiredButtonSegment<T>>` | **required** | The available segments. |
-| `selected` | `Set<T>` | **required** | Currently selected values. |
-| `onSelectionChanged` | `void Function(Set<T>)?` | `null` | Called when selection changes. |
-| `multiSelectionEnabled` | `bool` | `false` | Allow selecting multiple segments simultaneously. |
+| Parameter               | Type                          | Default      | Description                                       |
+| ----------------------- | ----------------------------- | ------------ | ------------------------------------------------- |
+| `segments`              | `List<WiredButtonSegment<T>>` | **required** | The available segments.                           |
+| `selected`              | `Set<T>`                      | **required** | Currently selected values.                        |
+| `onSelectionChanged`    | `void Function(Set<T>)?`      | `null`       | Called when selection changes.                    |
+| `multiSelectionEnabled` | `bool`                        | `false`      | Allow selecting multiple segments simultaneously. |
 
 ### Notes
 
@@ -292,6 +301,7 @@ WiredSegmentedButton<String>(
 A Cupertino-style press-opacity button with a hand-drawn rounded rectangle border. Mirrors the `CupertinoButton` API including a `.filled` factory constructor.
 
 <!-- {=docsCupertinoButtonUsage} -->
+
 ```dart
 // Default (outlined)
 WiredCupertinoButton(
@@ -308,17 +318,17 @@ WiredCupertinoButton.filled(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `child` | `Widget` | **required** | The button label. |
-| `onPressed` | `VoidCallback?` | **required** | Callback when tapped. `null` disables the button. |
-| `padding` | `EdgeInsetsGeometry?` | `null` | Padding around the child. Defaults to `16h / 10v`. |
-| `color` | `Color?` | `null` | Background color. Set automatically by `.filled`. |
-| `disabledColor` | `Color` | `CupertinoColors.quaternarySystemFill` | Background when disabled. |
-| `minSize` | `double` | `kMinInteractiveDimensionCupertino` | Minimum tap target size. |
-| `pressedOpacity` | `double` | `0.4` | Opacity applied during a press gesture. |
-| `borderRadius` | `BorderRadius?` | `BorderRadius.circular(8)` | Rounded rectangle corner radius. |
-| `alignment` | `AlignmentGeometry` | `Alignment.center` | Child alignment within the button. |
+| Parameter        | Type                  | Default                                | Description                                        |
+| ---------------- | --------------------- | -------------------------------------- | -------------------------------------------------- |
+| `child`          | `Widget`              | **required**                           | The button label.                                  |
+| `onPressed`      | `VoidCallback?`       | **required**                           | Callback when tapped. `null` disables the button.  |
+| `padding`        | `EdgeInsetsGeometry?` | `null`                                 | Padding around the child. Defaults to `16h / 10v`. |
+| `color`          | `Color?`              | `null`                                 | Background color. Set automatically by `.filled`.  |
+| `disabledColor`  | `Color`               | `CupertinoColors.quaternarySystemFill` | Background when disabled.                          |
+| `minSize`        | `double`              | `kMinInteractiveDimensionCupertino`    | Minimum tap target size.                           |
+| `pressedOpacity` | `double`              | `0.4`                                  | Opacity applied during a press gesture.            |
+| `borderRadius`   | `BorderRadius?`       | `BorderRadius.circular(8)`             | Rounded rectangle corner radius.                   |
+| `alignment`      | `AlignmentGeometry`   | `Alignment.center`                     | Child alignment within the button.                 |
 
 ### Notes
 

--- a/docs/site/content/widgets/feedback.md
+++ b/docs/site/content/widgets/feedback.md
@@ -14,6 +14,7 @@ Skribble provides feedback widgets that communicate status, confirmations, and p
 A dialog with a hand-drawn rectangle border drawn behind the content. Uses Flutter's `Dialog` widget internally.
 
 <!-- {=docsDialogUsage} -->
+
 ```dart
 showDialog(
   context: context,
@@ -45,10 +46,10 @@ showDialog(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `child` | `Widget` | **required** | The dialog content. |
-| `padding` | `EdgeInsetsGeometry?` | `null` | Padding around the content. Defaults to 20px on all sides. |
+| Parameter | Type                  | Default      | Description                                                |
+| --------- | --------------------- | ------------ | ---------------------------------------------------------- |
+| `child`   | `Widget`              | **required** | The dialog content.                                        |
+| `padding` | `EdgeInsetsGeometry?` | `null`       | Padding around the content. Defaults to 20px on all sides. |
 
 ### Notes
 
@@ -63,6 +64,7 @@ showDialog(
 A snack bar content wrapper with a hand-drawn border and solid fill. The `showWiredSnackBar` helper function displays it via `ScaffoldMessenger`.
 
 <!-- {=docsSnackBarUsage} -->
+
 ```dart
 // Using the helper function
 showWiredSnackBar(
@@ -86,18 +88,18 @@ showWiredSnackBar(
 
 ### showWiredSnackBar parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `content` | `Widget` | **required** | The snack bar content. |
-| `duration` | `Duration` | `4 seconds` | How long the snack bar is displayed. |
-| `action` | `SnackBarAction?` | `null` | Optional action button. |
+| Parameter  | Type              | Default      | Description                          |
+| ---------- | ----------------- | ------------ | ------------------------------------ |
+| `content`  | `Widget`          | **required** | The snack bar content.               |
+| `duration` | `Duration`        | `4 seconds`  | How long the snack bar is displayed. |
+| `action`   | `SnackBarAction?` | `null`       | Optional action button.              |
 
 ### WiredSnackBarContent parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `child` | `Widget` | **required** | The message content. |
-| `action` | `Widget?` | `null` | Optional trailing action widget. |
+| Parameter | Type      | Default      | Description                      |
+| --------- | --------- | ------------ | -------------------------------- |
+| `child`   | `Widget`  | **required** | The message content.             |
+| `action`  | `Widget?` | `null`       | Optional trailing action widget. |
 
 ### Notes
 
@@ -112,6 +114,7 @@ showWiredSnackBar(
 A tooltip with a hand-drawn rectangle border. Wraps Flutter's `Tooltip` widget with sketchy decoration.
 
 <!-- {=docsTooltipUsage} -->
+
 ```dart
 WiredTooltip(
   message: 'Add to favorites',
@@ -124,12 +127,12 @@ WiredTooltip(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `child` | `Widget` | **required** | The widget that triggers the tooltip. |
-| `message` | `String` | **required** | The tooltip message. |
-| `waitDuration` | `Duration?` | `null` | Delay before showing the tooltip on hover. |
-| `showDuration` | `Duration?` | `null` | How long the tooltip stays visible. |
+| Parameter      | Type        | Default      | Description                                |
+| -------------- | ----------- | ------------ | ------------------------------------------ |
+| `child`        | `Widget`    | **required** | The widget that triggers the tooltip.      |
+| `message`      | `String`    | **required** | The tooltip message.                       |
+| `waitDuration` | `Duration?` | `null`       | Delay before showing the tooltip on hover. |
+| `showDuration` | `Duration?` | `null`       | How long the tooltip stays visible.        |
 
 ### Notes
 
@@ -143,6 +146,7 @@ WiredTooltip(
 A hand-drawn linear progress bar. Renders a sketchy rectangle track with a hachure-filled progress region that animates via an `AnimationController`.
 
 <!-- {=docsProgressUsage} -->
+
 ```dart
 // In a HookWidget:
 final controller = useAnimationController(
@@ -160,10 +164,10 @@ WiredProgress(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `controller` | `AnimationController` | **required** | Drives the progress animation. |
-| `value` | `double` | `0.0` | Initial progress value (0.0 to 1.0). |
+| Parameter    | Type                  | Default      | Description                          |
+| ------------ | --------------------- | ------------ | ------------------------------------ |
+| `controller` | `AnimationController` | **required** | Drives the progress animation.       |
+| `value`      | `double`              | `0.0`        | Initial progress value (0.0 to 1.0). |
 
 ### Notes
 
@@ -179,6 +183,7 @@ WiredProgress(
 A circular progress indicator with a hand-drawn arc and background circle. Supports both determinate and indeterminate modes.
 
 <!-- {=docsCircularProgressUsage} -->
+
 ```dart
 // Indeterminate (spinner)
 WiredCircularProgress()
@@ -193,11 +198,11 @@ WiredCircularProgress(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `value` | `double?` | `null` | Progress from 0.0 to 1.0. `null` for indeterminate mode. |
-| `size` | `double` | `48.0` | Diameter of the indicator. |
-| `strokeWidth` | `double` | `3` | Width of the progress arc. |
+| Parameter     | Type      | Default | Description                                              |
+| ------------- | --------- | ------- | -------------------------------------------------------- |
+| `value`       | `double?` | `null`  | Progress from 0.0 to 1.0. `null` for indeterminate mode. |
+| `size`        | `double`  | `48.0`  | Diameter of the indicator.                               |
+| `strokeWidth` | `double`  | `3`     | Width of the progress arc.                               |
 
 ### Notes
 
@@ -212,6 +217,7 @@ WiredCircularProgress(
 A badge overlay that positions a hand-drawn circle indicator at the top-right corner of its child. Supports optional text labels.
 
 <!-- {=docsBadgeUsage} -->
+
 ```dart
 WiredBadge(
   label: '3',
@@ -229,12 +235,12 @@ WiredBadge(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `child` | `Widget` | **required** | The widget to badge. |
-| `label` | `String?` | `null` | Text inside the badge. When `null`, shows a dot. |
-| `isVisible` | `bool` | `true` | Whether the badge is shown. |
-| `backgroundColor` | `Color?` | `null` | Badge color. Defaults to `theme.borderColor`. |
+| Parameter         | Type      | Default      | Description                                      |
+| ----------------- | --------- | ------------ | ------------------------------------------------ |
+| `child`           | `Widget`  | **required** | The widget to badge.                             |
+| `label`           | `String?` | `null`       | Text inside the badge. When `null`, shows a dot. |
+| `isVisible`       | `bool`    | `true`       | Whether the badge is shown.                      |
+| `backgroundColor` | `Color?`  | `null`       | Badge color. Defaults to `theme.borderColor`.    |
 
 ### Notes
 
@@ -249,6 +255,7 @@ WiredBadge(
 A bottom sheet with a hand-drawn top border. Can be shown as a modal or persistent sheet.
 
 <!-- {=docsBottomSheetUsage} -->
+
 ```dart
 showModalBottomSheet(
   context: context,
@@ -271,6 +278,7 @@ showModalBottomSheet(
 An about dialog with a hand-drawn border, application icon, and version info. The `showWiredAboutDialog` helper function displays it.
 
 <!-- {=docsAboutDialogUsage} -->
+
 ```dart
 showWiredAboutDialog(
   context: context,
@@ -290,6 +298,7 @@ showWiredAboutDialog(
 A context menu with hand-drawn borders, triggered by long-press or right-click. Menu items appear in a sketchy bordered overlay.
 
 <!-- {=docsContextMenuUsage} -->
+
 ```dart
 WiredContextMenu(
   items: [
@@ -308,6 +317,7 @@ WiredContextMenu(
 A hand-drawn wrapper around Flutter's `AnimatedIcon`. Applies Skribble theming to animated icon transitions.
 
 <!-- {=docsAnimatedIconUsage} -->
+
 ```dart
 // In a HookWidget:
 final controller = useAnimationController(
@@ -323,14 +333,14 @@ WiredAnimatedIcon(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `icon` | `AnimatedIconData` | **required** | The animated icon data (e.g., `AnimatedIcons.menu_arrow`). |
-| `progress` | `Animation<double>` | **required** | Animation progress from 0.0 to 1.0. |
-| `color` | `Color?` | `null` | Icon color. Defaults to `theme.textColor`. |
-| `size` | `double?` | `null` | Icon size. |
-| `semanticLabel` | `String?` | `null` | Accessibility label. |
-| `textDirection` | `TextDirection?` | `null` | Text direction for the icon. |
+| Parameter       | Type                | Default      | Description                                                |
+| --------------- | ------------------- | ------------ | ---------------------------------------------------------- |
+| `icon`          | `AnimatedIconData`  | **required** | The animated icon data (e.g., `AnimatedIcons.menu_arrow`). |
+| `progress`      | `Animation<double>` | **required** | Animation progress from 0.0 to 1.0.                        |
+| `color`         | `Color?`            | `null`       | Icon color. Defaults to `theme.textColor`.                 |
+| `size`          | `double?`           | `null`       | Icon size.                                                 |
+| `semanticLabel` | `String?`           | `null`       | Accessibility label.                                       |
+| `textDirection` | `TextDirection?`    | `null`       | Text direction for the icon.                               |
 
 ---
 
@@ -339,6 +349,7 @@ WiredAnimatedIcon(
 A banner with a hand-drawn border displayed at the top of the scaffold. Contains a message and action buttons.
 
 <!-- {=docsMaterialBannerUsage} -->
+
 ```dart
 ScaffoldMessenger.of(context).showMaterialBanner(
   WiredMaterialBanner(
@@ -364,6 +375,7 @@ ScaffoldMessenger.of(context).showMaterialBanner(
 A Cupertino-style alert dialog with hand-drawn borders. Mirrors the `CupertinoAlertDialog` API with sketchy styling.
 
 <!-- {=docsCupertinoAlertDialogUsage} -->
+
 ```dart
 showCupertinoDialog(
   context: context,
@@ -394,6 +406,7 @@ showCupertinoDialog(
 A Cupertino-style action sheet with hand-drawn borders. Slides up from the bottom of the screen.
 
 <!-- {=docsCupertinoActionSheetUsage} -->
+
 ```dart
 showCupertinoModalPopup(
   context: context,

--- a/docs/site/content/widgets/icons.md
+++ b/docs/site/content/widgets/icons.md
@@ -14,6 +14,7 @@ Skribble renders Material icons with rough, hand-drawn outlines and optional hac
 The primary icon widget. Looks up the given `IconData` in the pre-generated rough icon catalog and renders it with hand-drawn strokes. Falls back to Flutter's standard `Icon` for unsupported icon families.
 
 <!-- {=docsIconUsage} -->
+
 ```dart
 // Basic usage
 WiredIcon(icon: Icons.home)
@@ -30,28 +31,28 @@ WiredIcon(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `icon` | `IconData` | **required** | The icon to render. |
-| `size` | `double?` | `null` | Icon size. Defaults to `IconTheme.of(context).size` or 24. |
-| `color` | `Color?` | `null` | Icon color. Defaults to `IconTheme.of(context).color` or `theme.textColor`. |
-| `semanticLabel` | `String?` | `null` | Accessibility label. |
-| `fillStyle` | `WiredIconFillStyle` | `.solid` | Fill strategy for the icon shapes. |
-| `strokeWidth` | `double` | `1.6` | Width of the outline strokes. |
-| `drawConfig` | `DrawConfig?` | `null` | Custom rough drawing configuration. |
-| `sampleDistance` | `double` | `1.2` | Sampling distance along path contours. |
-| `hachureGap` | `double` | `2.25` | Gap between hachure fill lines. |
-| `hachureAngle` | `double` | `320` | Angle of hachure fill lines in degrees. |
+| Parameter        | Type                 | Default      | Description                                                                 |
+| ---------------- | -------------------- | ------------ | --------------------------------------------------------------------------- |
+| `icon`           | `IconData`           | **required** | The icon to render.                                                         |
+| `size`           | `double?`            | `null`       | Icon size. Defaults to `IconTheme.of(context).size` or 24.                  |
+| `color`          | `Color?`             | `null`       | Icon color. Defaults to `IconTheme.of(context).color` or `theme.textColor`. |
+| `semanticLabel`  | `String?`            | `null`       | Accessibility label.                                                        |
+| `fillStyle`      | `WiredIconFillStyle` | `.solid`     | Fill strategy for the icon shapes.                                          |
+| `strokeWidth`    | `double`             | `1.6`        | Width of the outline strokes.                                               |
+| `drawConfig`     | `DrawConfig?`        | `null`       | Custom rough drawing configuration.                                         |
+| `sampleDistance` | `double`             | `1.2`        | Sampling distance along path contours.                                      |
+| `hachureGap`     | `double`             | `2.25`       | Gap between hachure fill lines.                                             |
+| `hachureAngle`   | `double`             | `320`        | Angle of hachure fill lines in degrees.                                     |
 
 ### Fill styles
 
 The `WiredIconFillStyle` enum controls how icon shapes are filled:
 
-| Style | Description |
-|---|---|
-| `none` | Outline only, no fill. |
-| `solid` | Solid color fill (default). Clean and readable. |
-| `hachure` | Diagonal hatching lines at the configured angle and gap. |
+| Style        | Description                                              |
+| ------------ | -------------------------------------------------------- |
+| `none`       | Outline only, no fill.                                   |
+| `solid`      | Solid color fill (default). Clean and readable.          |
+| `hachure`    | Diagonal hatching lines at the configured angle and gap. |
 | `crossHatch` | Two layers of hachure lines at 90 degrees to each other. |
 
 ### Notes
@@ -68,6 +69,7 @@ The `WiredIconFillStyle` enum controls how icon shapes are filled:
 Renders a pre-parsed `WiredSvgIconData` with rough hand-drawn strokes. This is the lower-level rendering widget used by `WiredIcon` internally.
 
 <!-- {=docsSvgIconUsage} -->
+
 ```dart
 WiredSvgIcon(
   data: myCustomSvgIconData,
@@ -80,19 +82,19 @@ WiredSvgIcon(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `data` | `WiredSvgIconData` | **required** | Pre-parsed SVG icon data. |
-| `size` | `double?` | `null` | Icon size. |
-| `color` | `Color?` | `null` | Icon color. |
-| `semanticLabel` | `String?` | `null` | Accessibility label. |
-| `fillStyle` | `WiredIconFillStyle` | `.solid` | Fill strategy. |
-| `strokeWidth` | `double` | `1.6` | Outline stroke width. |
-| `drawConfig` | `DrawConfig?` | `null` | Custom rough drawing configuration. |
-| `flipHorizontally` | `bool` | `false` | Mirror the icon horizontally. |
-| `sampleDistance` | `double` | `1.2` | Path sampling distance. |
-| `hachureGap` | `double` | `2.25` | Hachure line gap. |
-| `hachureAngle` | `double` | `320` | Hachure angle in degrees. |
+| Parameter          | Type                 | Default      | Description                         |
+| ------------------ | -------------------- | ------------ | ----------------------------------- |
+| `data`             | `WiredSvgIconData`   | **required** | Pre-parsed SVG icon data.           |
+| `size`             | `double?`            | `null`       | Icon size.                          |
+| `color`            | `Color?`             | `null`       | Icon color.                         |
+| `semanticLabel`    | `String?`            | `null`       | Accessibility label.                |
+| `fillStyle`        | `WiredIconFillStyle` | `.solid`     | Fill strategy.                      |
+| `strokeWidth`      | `double`             | `1.6`        | Outline stroke width.               |
+| `drawConfig`       | `DrawConfig?`        | `null`       | Custom rough drawing configuration. |
+| `flipHorizontally` | `bool`               | `false`      | Mirror the icon horizontally.       |
+| `sampleDistance`   | `double`             | `1.2`        | Path sampling distance.             |
+| `hachureGap`       | `double`             | `2.25`       | Hachure line gap.                   |
+| `hachureAngle`     | `double`             | `320`        | Hachure angle in degrees.           |
 
 ### Notes
 
@@ -107,6 +109,7 @@ WiredSvgIcon(
 The data type that represents a pre-parsed SVG icon. Contains the viewport dimensions and a list of drawable primitives.
 
 <!-- {=docsSvgIconDataUsage} -->
+
 ```dart
 const myIcon = WiredSvgIconData(
   width: 24,
@@ -130,11 +133,11 @@ final class WiredSvgIconData {
 
 ### Primitive types
 
-| Type | Factory | Description |
-|---|---|---|
-| `WiredSvgPathPrimitive` | `.path(data)` | An SVG path string (e.g., `'M0 0L10 10'`). |
-| `WiredSvgCirclePrimitive` | `.circle(cx, cy, radius)` | A circle primitive. |
-| `WiredSvgEllipsePrimitive` | `.ellipse(cx, cy, radiusX, radiusY)` | An ellipse primitive. |
+| Type                       | Factory                              | Description                                |
+| -------------------------- | ------------------------------------ | ------------------------------------------ |
+| `WiredSvgPathPrimitive`    | `.path(data)`                        | An SVG path string (e.g., `'M0 0L10 10'`). |
+| `WiredSvgCirclePrimitive`  | `.circle(cx, cy, radius)`            | A circle primitive.                        |
+| `WiredSvgEllipsePrimitive` | `.ellipse(cx, cy, radiusX, radiusY)` | An ellipse primitive.                      |
 
 Each primitive supports an optional `fillRule` parameter (`WiredSvgFillRule.nonZero` or `.evenOdd`).
 
@@ -145,6 +148,7 @@ Each primitive supports an optional `fillRule` parameter (`WiredSvgFillRule.nonZ
 A hand-drawn wrapper around Flutter's `AnimatedIcon`. Applies Skribble theme colors while preserving the standard animation behavior.
 
 <!-- {=docsAnimatedIconUsage} -->
+
 ```dart
 final controller = useAnimationController(
   duration: Duration(milliseconds: 300),
@@ -159,14 +163,14 @@ WiredAnimatedIcon(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `icon` | `AnimatedIconData` | **required** | The animated icon data. |
-| `progress` | `Animation<double>` | **required** | Animation progress (0.0 to 1.0). |
-| `color` | `Color?` | `null` | Icon color. Defaults to `theme.textColor`. |
-| `size` | `double?` | `null` | Icon size. |
-| `semanticLabel` | `String?` | `null` | Accessibility label. |
-| `textDirection` | `TextDirection?` | `null` | Text direction for the icon. |
+| Parameter       | Type                | Default      | Description                                |
+| --------------- | ------------------- | ------------ | ------------------------------------------ |
+| `icon`          | `AnimatedIconData`  | **required** | The animated icon data.                    |
+| `progress`      | `Animation<double>` | **required** | Animation progress (0.0 to 1.0).           |
+| `color`         | `Color?`            | `null`       | Icon color. Defaults to `theme.textColor`. |
+| `size`          | `double?`           | `null`       | Icon size.                                 |
+| `semanticLabel` | `String?`           | `null`       | Accessibility label.                       |
+| `textDirection` | `TextDirection?`    | `null`       | Text direction for the icon.               |
 
 ### Notes
 
@@ -221,15 +225,15 @@ final codePoints = materialRoughIconCodePoints;
 
 ### Icon lookup helpers
 
-| Function | Description |
-|---|---|
-| `lookupMaterialRoughIcon(IconData)` | Returns `WiredSvgIconData?` for a Material icon. |
+| Function                                      | Description                                      |
+| --------------------------------------------- | ------------------------------------------------ |
+| `lookupMaterialRoughIcon(IconData)`           | Returns `WiredSvgIconData?` for a Material icon. |
 | `lookupMaterialRoughIconByIdentifier(String)` | Returns `WiredSvgIconData?` by icon name string. |
-| `lookupMaterialRoughFontIcon(String)` | Returns `IconData?` for the rough icon font. |
-| `materialRoughFontFamily` | The font family string for the rough icon font. |
-| `materialRoughFontCodePoints` | `Map<String, int>` of icon name to code point. |
-| `materialRoughIconIdentifiers` | `List<String>` of all available icon names. |
-| `materialRoughIconCodePoints` | `List<int>` of all available code points. |
+| `lookupMaterialRoughFontIcon(String)`         | Returns `IconData?` for the rough icon font.     |
+| `materialRoughFontFamily`                     | The font family string for the rough icon font.  |
+| `materialRoughFontCodePoints`                 | `Map<String, int>` of icon name to code point.   |
+| `materialRoughIconIdentifiers`                | `List<String>` of all available icon names.      |
+| `materialRoughIconCodePoints`                 | `List<int>` of all available code points.        |
 
 ---
 
@@ -245,6 +249,7 @@ The `skribble_icons_custom` package provides tooling for generating rough icon c
 4. Use the generated constants with `WiredSvgIcon`.
 
 <!-- {=docsCustomIconsUsage} -->
+
 ```dart
 // After generating from your SVG set:
 import 'package:my_app/generated/custom_icons.g.dart';

--- a/docs/site/content/widgets/inputs.md
+++ b/docs/site/content/widgets/inputs.md
@@ -14,6 +14,7 @@ Skribble replaces standard form controls with sketchy, hand-drawn equivalents. A
 A single-line text field wrapped in a hand-drawn rectangle border. Supports labels, hints, and password masking.
 
 <!-- {=docsInputUsage} -->
+
 ```dart
 WiredInput(
   labelText: 'Name',
@@ -24,16 +25,16 @@ WiredInput(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `controller` | `TextEditingController?` | `null` | External text controller. |
-| `style` | `TextStyle?` | `null` | Text style for the input value. |
-| `labelText` | `String?` | `null` | Label displayed to the left of the field. |
-| `labelStyle` | `TextStyle?` | `null` | Style for the label text. |
-| `hintText` | `String?` | `null` | Placeholder text inside the field. |
-| `hintStyle` | `TextStyle?` | `null` | Style for the hint text. |
-| `onChanged` | `void Function(String)?` | `null` | Called on every text change. |
-| `obscureText` | `bool` | `false` | Hides input for passwords. |
+| Parameter     | Type                     | Default | Description                               |
+| ------------- | ------------------------ | ------- | ----------------------------------------- |
+| `controller`  | `TextEditingController?` | `null`  | External text controller.                 |
+| `style`       | `TextStyle?`             | `null`  | Text style for the input value.           |
+| `labelText`   | `String?`                | `null`  | Label displayed to the left of the field. |
+| `labelStyle`  | `TextStyle?`             | `null`  | Style for the label text.                 |
+| `hintText`    | `String?`                | `null`  | Placeholder text inside the field.        |
+| `hintStyle`   | `TextStyle?`             | `null`  | Style for the hint text.                  |
+| `onChanged`   | `void Function(String)?` | `null`  | Called on every text change.              |
+| `obscureText` | `bool`                   | `false` | Hides input for passwords.                |
 
 ### Notes
 
@@ -48,6 +49,7 @@ WiredInput(
 A multi-line text input with a hand-drawn rectangle border. The border fills behind the text area using `Positioned.fill`.
 
 <!-- {=docsTextAreaUsage} -->
+
 ```dart
 WiredTextArea(
   hintText: 'Write something...',
@@ -59,15 +61,15 @@ WiredTextArea(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `controller` | `TextEditingController?` | `null` | External text controller. |
-| `style` | `TextStyle?` | `null` | Text style. |
-| `hintText` | `String?` | `null` | Placeholder text. |
-| `hintStyle` | `TextStyle?` | `null` | Hint text style. |
-| `onChanged` | `void Function(String)?` | `null` | Called on text changes. |
-| `maxLines` | `int` | `5` | Maximum visible lines. |
-| `minLines` | `int` | `3` | Minimum visible lines. |
+| Parameter    | Type                     | Default | Description               |
+| ------------ | ------------------------ | ------- | ------------------------- |
+| `controller` | `TextEditingController?` | `null`  | External text controller. |
+| `style`      | `TextStyle?`             | `null`  | Text style.               |
+| `hintText`   | `String?`                | `null`  | Placeholder text.         |
+| `hintStyle`  | `TextStyle?`             | `null`  | Hint text style.          |
+| `onChanged`  | `void Function(String)?` | `null`  | Called on text changes.   |
+| `maxLines`   | `int`                    | `5`     | Maximum visible lines.    |
+| `minLines`   | `int`                    | `3`     | Minimum visible lines.    |
 
 ### Notes
 
@@ -81,6 +83,7 @@ WiredTextArea(
 A search input with a pill-shaped hand-drawn border (24px border radius). Includes a leading search icon and optional trailing widget.
 
 <!-- {=docsSearchBarUsage} -->
+
 ```dart
 WiredSearchBar(
   hintText: 'Search widgets...',
@@ -91,14 +94,14 @@ WiredSearchBar(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `controller` | `TextEditingController?` | `null` | Text controller. |
-| `hintText` | `String?` | `null` | Placeholder text. Defaults to `'Search...'`. |
-| `onChanged` | `ValueChanged<String>?` | `null` | Called on every keystroke. |
-| `onSubmitted` | `ValueChanged<String>?` | `null` | Called when the user submits. |
-| `leading` | `Widget?` | `null` | Custom leading widget. Defaults to a `WiredIcon` search icon. |
-| `trailing` | `Widget?` | `null` | Optional trailing widget (e.g., a clear button). |
+| Parameter     | Type                     | Default | Description                                                   |
+| ------------- | ------------------------ | ------- | ------------------------------------------------------------- |
+| `controller`  | `TextEditingController?` | `null`  | Text controller.                                              |
+| `hintText`    | `String?`                | `null`  | Placeholder text. Defaults to `'Search...'`.                  |
+| `onChanged`   | `ValueChanged<String>?`  | `null`  | Called on every keystroke.                                    |
+| `onSubmitted` | `ValueChanged<String>?`  | `null`  | Called when the user submits.                                 |
+| `leading`     | `Widget?`                | `null`  | Custom leading widget. Defaults to a `WiredIcon` search icon. |
+| `trailing`    | `Widget?`                | `null`  | Optional trailing widget (e.g., a clear button).              |
 
 ### Notes
 
@@ -113,6 +116,7 @@ WiredSearchBar(
 A hand-drawn checkbox with a sketchy rectangle border. The checkmark is rendered by an underlying transparent `Checkbox` widget, scaled up for visual presence.
 
 <!-- {=docsCheckboxUsage} -->
+
 ```dart
 WiredCheckbox(
   value: isChecked,
@@ -124,10 +128,10 @@ WiredCheckbox(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `value` | `bool?` | **required** | Current checked state. Supports tristate (`null`). |
-| `onChanged` | `void Function(bool?)` | **required** | Called when the user taps the checkbox. |
+| Parameter   | Type                   | Default      | Description                                        |
+| ----------- | ---------------------- | ------------ | -------------------------------------------------- |
+| `value`     | `bool?`                | **required** | Current checked state. Supports tristate (`null`). |
+| `onChanged` | `void Function(bool?)` | **required** | Called when the user taps the checkbox.            |
 
 ### Notes
 
@@ -142,6 +146,7 @@ WiredCheckbox(
 Combines `WiredCheckbox` with a `WiredListTile`-style layout including title, subtitle, and optional secondary widget. Follows the same API pattern as Material's `CheckboxListTile`.
 
 <!-- {=docsCheckboxListTileUsage} -->
+
 ```dart
 WiredCheckboxListTile(
   title: Text('Accept terms'),
@@ -157,6 +162,7 @@ WiredCheckboxListTile(
 A hand-drawn radio button with a sketchy circle border. When selected, the inner circle fills with a hachure pattern.
 
 <!-- {=docsRadioUsage} -->
+
 ```dart
 WiredRadio<String>(
   value: 'option1',
@@ -169,11 +175,11 @@ WiredRadio<String>(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `value` | `T` | **required** | The value this radio represents. |
-| `groupValue` | `T?` | **required** | The currently selected value in the group. |
-| `onChanged` | `bool Function(T?)?` | **required** | Called when this radio is selected. |
+| Parameter    | Type                 | Default      | Description                                |
+| ------------ | -------------------- | ------------ | ------------------------------------------ |
+| `value`      | `T`                  | **required** | The value this radio represents.           |
+| `groupValue` | `T?`                 | **required** | The currently selected value in the group. |
+| `onChanged`  | `bool Function(T?)?` | **required** | Called when this radio is selected.        |
 
 ### Notes
 
@@ -188,6 +194,7 @@ WiredRadio<String>(
 Combines `WiredRadio` with a list tile layout. Follows the `RadioListTile` API pattern.
 
 <!-- {=docsRadioListTileUsage} -->
+
 ```dart
 WiredRadioListTile<String>(
   title: Text('Option A'),
@@ -204,6 +211,7 @@ WiredRadioListTile<String>(
 A toggle switch with a hand-drawn rounded rectangle track and a circle thumb that animates between on and off positions.
 
 <!-- {=docsSwitchUsage} -->
+
 ```dart
 WiredSwitch(
   value: isEnabled,
@@ -215,13 +223,13 @@ WiredSwitch(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `value` | `bool` | **required** | Current on/off state. |
-| `onChanged` | `ValueChanged<bool>?` | `null` | Called when toggled. |
-| `activeColor` | `Color?` | `null` | Track color when on. Defaults to `theme.borderColor`. |
-| `inactiveColor` | `Color?` | `null` | Track color when off. Defaults to `theme.fillColor`. |
-| `semanticLabel` | `String?` | `null` | Accessibility label. |
+| Parameter       | Type                  | Default      | Description                                           |
+| --------------- | --------------------- | ------------ | ----------------------------------------------------- |
+| `value`         | `bool`                | **required** | Current on/off state.                                 |
+| `onChanged`     | `ValueChanged<bool>?` | `null`       | Called when toggled.                                  |
+| `activeColor`   | `Color?`              | `null`       | Track color when on. Defaults to `theme.borderColor`. |
+| `inactiveColor` | `Color?`              | `null`       | Track color when off. Defaults to `theme.fillColor`.  |
+| `semanticLabel` | `String?`             | `null`       | Accessibility label.                                  |
 
 ### Notes
 
@@ -237,6 +245,7 @@ WiredSwitch(
 Combines `WiredSwitch` with a list tile layout. Follows the `SwitchListTile` API pattern.
 
 <!-- {=docsSwitchListTileUsage} -->
+
 ```dart
 WiredSwitchListTile(
   title: Text('Dark mode'),
@@ -252,6 +261,7 @@ WiredSwitchListTile(
 A slider with a sketchy track line and a hand-drawn circle thumb. Supports divisions and labels.
 
 <!-- {=docsSliderUsage} -->
+
 ```dart
 WiredSlider(
   value: volume,
@@ -268,13 +278,13 @@ WiredSlider(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `value` | `double` | **required** | Current slider value. |
-| `divisions` | `int?` | `null` | Number of discrete steps. |
-| `label` | `String?` | `null` | Label displayed above the thumb. |
-| `min` | `double` | `0.0` | Minimum value. |
-| `max` | `double` | `1.0` | Maximum value. |
+| Parameter   | Type                     | Default      | Description                                            |
+| ----------- | ------------------------ | ------------ | ------------------------------------------------------ |
+| `value`     | `double`                 | **required** | Current slider value.                                  |
+| `divisions` | `int?`                   | `null`       | Number of discrete steps.                              |
+| `label`     | `String?`                | `null`       | Label displayed above the thumb.                       |
+| `min`       | `double`                 | `0.0`        | Minimum value.                                         |
+| `max`       | `double`                 | `1.0`        | Maximum value.                                         |
 | `onChanged` | `bool Function(double)?` | **required** | Called on drag. Return `true` to accept the new value. |
 
 ### Notes
@@ -290,6 +300,7 @@ WiredSlider(
 A dual-handle variant of `WiredSlider` for selecting a range of values. Follows the `RangeSlider` API.
 
 <!-- {=docsRangeSliderUsage} -->
+
 ```dart
 WiredRangeSlider(
   values: RangeValues(20, 80),
@@ -306,6 +317,7 @@ WiredRangeSlider(
 A simple on/off toggle with a hand-drawn rectangle track and an animated circle thumb. More minimal than `WiredSwitch`.
 
 <!-- {=docsToggleUsage} -->
+
 ```dart
 WiredToggle(
   value: isOn,
@@ -318,12 +330,12 @@ WiredToggle(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `value` | `bool` | **required** | Current toggle state. |
-| `onChange` | `bool Function(bool)?` | `null` | Called on tap. Return `true` to accept. |
-| `thumbRadius` | `double` | `24.0` | Radius of the thumb circle. |
-| `semanticLabel` | `String?` | `null` | Accessibility label. |
+| Parameter       | Type                   | Default      | Description                             |
+| --------------- | ---------------------- | ------------ | --------------------------------------- |
+| `value`         | `bool`                 | **required** | Current toggle state.                   |
+| `onChange`      | `bool Function(bool)?` | `null`       | Called on tap. Return `true` to accept. |
+| `thumbRadius`   | `double`               | `24.0`       | Radius of the thumb circle.             |
+| `semanticLabel` | `String?`              | `null`       | Accessibility label.                    |
 
 ### Notes
 
@@ -338,6 +350,7 @@ WiredToggle(
 A hand-drawn wrapper around Flutter's `Form` widget. Draws a sketchy rounded rectangle border around form content.
 
 <!-- {=docsFormUsage} -->
+
 ```dart
 final formKey = GlobalKey<FormState>();
 
@@ -359,14 +372,14 @@ WiredForm(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `child` | `Widget` | **required** | Form content. |
-| `formKey` | `GlobalKey<FormState>?` | `null` | Key for the underlying `Form`. |
-| `autovalidateMode` | `AutovalidateMode` | `AutovalidateMode.disabled` | When to auto-validate. |
-| `onChanged` | `VoidCallback?` | `null` | Called when any form field changes. |
-| `padding` | `EdgeInsetsGeometry` | `EdgeInsets.all(16)` | Padding around the form content. |
-| `borderRadius` | `BorderRadius` | `BorderRadius.circular(16)` | Corner radius of the border. |
+| Parameter          | Type                    | Default                     | Description                         |
+| ------------------ | ----------------------- | --------------------------- | ----------------------------------- |
+| `child`            | `Widget`                | **required**                | Form content.                       |
+| `formKey`          | `GlobalKey<FormState>?` | `null`                      | Key for the underlying `Form`.      |
+| `autovalidateMode` | `AutovalidateMode`      | `AutovalidateMode.disabled` | When to auto-validate.              |
+| `onChanged`        | `VoidCallback?`         | `null`                      | Called when any form field changes. |
+| `padding`          | `EdgeInsetsGeometry`    | `EdgeInsets.all(16)`        | Padding around the form content.    |
+| `borderRadius`     | `BorderRadius`          | `BorderRadius.circular(16)` | Corner radius of the border.        |
 
 ### Notes
 
@@ -380,6 +393,7 @@ WiredForm(
 A hand-drawn autocomplete field that displays suggestions in a sketchy dropdown as the user types. Wraps Flutter's `Autocomplete` widget.
 
 <!-- {=docsAutocompleteUsage} -->
+
 ```dart
 WiredAutocomplete<String>(
   optionsBuilder: (textEditingValue) {
@@ -398,6 +412,7 @@ WiredAutocomplete<String>(
 A Cupertino-styled text field with a hand-drawn rounded rectangle border. Mirrors the `CupertinoTextField` API.
 
 <!-- {=docsCupertinoTextFieldUsage} -->
+
 ```dart
 WiredCupertinoTextField(
   placeholder: 'Enter text',
@@ -412,6 +427,7 @@ WiredCupertinoTextField(
 A Cupertino-styled slider with a sketchy track and thumb. Mirrors the `CupertinoSlider` API.
 
 <!-- {=docsCupertinoSliderUsage} -->
+
 ```dart
 WiredCupertinoSlider(
   value: brightness,
@@ -428,6 +444,7 @@ WiredCupertinoSlider(
 A Cupertino-styled toggle switch with hand-drawn track and thumb. Mirrors the `CupertinoSwitch` API.
 
 <!-- {=docsCupertinoSwitchUsage} -->
+
 ```dart
 WiredCupertinoSwitch(
   value: isActive,

--- a/docs/site/content/widgets/layout.md
+++ b/docs/site/content/widgets/layout.md
@@ -14,6 +14,7 @@ Skribble provides layout and structural widgets that form the scaffolding of you
 A card with a hand-drawn rectangle border. Supports optional hachure fill for a more prominent appearance.
 
 <!-- {=docsCardUsage} -->
+
 ```dart
 WiredCard(
   child: Padding(
@@ -32,11 +33,11 @@ WiredCard(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `child` | `Widget?` | `null` | The card content. |
-| `fill` | `bool` | `false` | Whether to apply hachure fill to the card background. |
-| `height` | `double?` | `130.0` | Card height. Set to `null` for intrinsic sizing. |
+| Parameter | Type      | Default | Description                                           |
+| --------- | --------- | ------- | ----------------------------------------------------- |
+| `child`   | `Widget?` | `null`  | The card content.                                     |
+| `fill`    | `bool`    | `false` | Whether to apply hachure fill to the card background. |
+| `height`  | `double?` | `130.0` | Card height. Set to `null` for intrinsic sizing.      |
 
 ### Notes
 
@@ -52,6 +53,7 @@ WiredCard(
 A hand-drawn horizontal divider line. Renders a sketchy line spanning the full width of its parent.
 
 <!-- {=docsDividerUsage} -->
+
 ```dart
 Column(
   children: [
@@ -79,6 +81,7 @@ None. `WiredDivider` has no configurable parameters beyond the inherited `key`.
 A list tile with a hand-drawn separator line at the bottom. Supports leading, title, subtitle, and trailing widgets.
 
 <!-- {=docsListTileUsage} -->
+
 ```dart
 WiredListTile(
   leading: WiredAvatar(radius: 20, child: Text('A')),
@@ -91,14 +94,14 @@ WiredListTile(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `leading` | `Widget?` | `null` | Widget before the title (e.g., avatar or icon). |
-| `title` | `Widget?` | `null` | Primary text. Rendered at 16px with `theme.textColor`. |
-| `subtitle` | `Widget?` | `null` | Secondary text. Rendered at 14px with `theme.disabledTextColor`. |
-| `trailing` | `Widget?` | `null` | Widget at the trailing edge. |
-| `onTap` | `VoidCallback?` | `null` | Called when the tile is tapped. |
-| `showDivider` | `bool` | `true` | Whether to show the bottom divider line. |
+| Parameter     | Type            | Default | Description                                                      |
+| ------------- | --------------- | ------- | ---------------------------------------------------------------- |
+| `leading`     | `Widget?`       | `null`  | Widget before the title (e.g., avatar or icon).                  |
+| `title`       | `Widget?`       | `null`  | Primary text. Rendered at 16px with `theme.textColor`.           |
+| `subtitle`    | `Widget?`       | `null`  | Secondary text. Rendered at 14px with `theme.disabledTextColor`. |
+| `trailing`    | `Widget?`       | `null`  | Widget at the trailing edge.                                     |
+| `onTap`       | `VoidCallback?` | `null`  | Called when the tile is tapped.                                  |
+| `showDivider` | `bool`          | `true`  | Whether to show the bottom divider line.                         |
 
 ### Notes
 
@@ -113,6 +116,7 @@ WiredListTile(
 An expansion tile with a hand-drawn border that expands to reveal child content. The expand/collapse arrow animates on tap.
 
 <!-- {=docsExpansionTileUsage} -->
+
 ```dart
 WiredExpansionTile(
   title: Text('Advanced Settings'),
@@ -133,6 +137,7 @@ WiredExpansionTile(
 A data table with hand-drawn column headers and row borders. Each cell is separated by sketchy lines.
 
 <!-- {=docsDataTableUsage} -->
+
 ```dart
 WiredDataTable(
   columns: [
@@ -162,6 +167,7 @@ WiredDataTable(
 A step-by-step wizard with hand-drawn circles for step indicators and sketchy connecting lines.
 
 <!-- {=docsStepperUsage} -->
+
 ```dart
 WiredStepper(
   currentStep: currentStep,
@@ -182,6 +188,7 @@ WiredStepper(
 A standalone calendar widget with hand-drawn day cells and month navigation. Days are rendered within sketchy rectangle cells.
 
 <!-- {=docsCalendarUsage} -->
+
 ```dart
 WiredCalendar(
   selectedDate: selectedDate,
@@ -196,6 +203,7 @@ WiredCalendar(
 A scrollbar with a hand-drawn track and thumb. Wraps Flutter's `Scrollbar` with sketchy styling.
 
 <!-- {=docsScrollbarUsage} -->
+
 ```dart
 WiredScrollbar(
   child: ListView.builder(
@@ -214,6 +222,7 @@ WiredScrollbar(
 A Material `Scaffold` wrapper tuned for Skribble's paper-like palette. Provides the familiar scaffold API with hand-drawn theme integration.
 
 <!-- {=docsScaffoldUsage} -->
+
 ```dart
 WiredScaffold(
   appBar: WiredAppBar(title: Text('My App')),
@@ -241,26 +250,26 @@ WiredScaffold(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `appBar` | `PreferredSizeWidget?` | `null` | App bar (typically `WiredAppBar`). |
-| `body` | `Widget?` | `null` | Main body content. |
-| `backgroundColor` | `Color?` | `null` | Background. Defaults to `theme.paperBackgroundColor`. |
-| `bodyPadding` | `EdgeInsetsGeometry?` | `null` | Padding applied around the body. |
-| `applySafeArea` | `bool` | `false` | Wrap the body in a `SafeArea`. |
-| `floatingActionButton` | `Widget?` | `null` | FAB widget. |
-| `floatingActionButtonAnimator` | `FloatingActionButtonAnimator?` | `null` | FAB animation. |
-| `floatingActionButtonLocation` | `FloatingActionButtonLocation?` | `null` | FAB position. |
-| `drawer` | `Widget?` | `null` | Side drawer. |
-| `endDrawer` | `Widget?` | `null` | End drawer. |
-| `drawerScrimColor` | `Color?` | `null` | Scrim overlay color. Defaults to `theme.borderColor` at 12% opacity. |
-| `bottomNavigationBar` | `Widget?` | `null` | Bottom navigation bar. |
-| `bottomSheet` | `Widget?` | `null` | Persistent bottom sheet. |
-| `persistentFooterButtons` | `List<Widget>?` | `null` | Footer buttons. |
-| `resizeToAvoidBottomInset` | `bool?` | `null` | Whether body resizes for the keyboard. |
-| `extendBody` | `bool` | `false` | Extend body behind bottom navigation. |
-| `extendBodyBehindAppBar` | `bool` | `false` | Extend body behind app bar. |
-| `primary` | `bool` | `true` | Whether this is the primary scaffold. |
+| Parameter                      | Type                            | Default | Description                                                          |
+| ------------------------------ | ------------------------------- | ------- | -------------------------------------------------------------------- |
+| `appBar`                       | `PreferredSizeWidget?`          | `null`  | App bar (typically `WiredAppBar`).                                   |
+| `body`                         | `Widget?`                       | `null`  | Main body content.                                                   |
+| `backgroundColor`              | `Color?`                        | `null`  | Background. Defaults to `theme.paperBackgroundColor`.                |
+| `bodyPadding`                  | `EdgeInsetsGeometry?`           | `null`  | Padding applied around the body.                                     |
+| `applySafeArea`                | `bool`                          | `false` | Wrap the body in a `SafeArea`.                                       |
+| `floatingActionButton`         | `Widget?`                       | `null`  | FAB widget.                                                          |
+| `floatingActionButtonAnimator` | `FloatingActionButtonAnimator?` | `null`  | FAB animation.                                                       |
+| `floatingActionButtonLocation` | `FloatingActionButtonLocation?` | `null`  | FAB position.                                                        |
+| `drawer`                       | `Widget?`                       | `null`  | Side drawer.                                                         |
+| `endDrawer`                    | `Widget?`                       | `null`  | End drawer.                                                          |
+| `drawerScrimColor`             | `Color?`                        | `null`  | Scrim overlay color. Defaults to `theme.borderColor` at 12% opacity. |
+| `bottomNavigationBar`          | `Widget?`                       | `null`  | Bottom navigation bar.                                               |
+| `bottomSheet`                  | `Widget?`                       | `null`  | Persistent bottom sheet.                                             |
+| `persistentFooterButtons`      | `List<Widget>?`                 | `null`  | Footer buttons.                                                      |
+| `resizeToAvoidBottomInset`     | `bool?`                         | `null`  | Whether body resizes for the keyboard.                               |
+| `extendBody`                   | `bool`                          | `false` | Extend body behind bottom navigation.                                |
+| `extendBodyBehindAppBar`       | `bool`                          | `false` | Extend body behind app bar.                                          |
+| `primary`                      | `bool`                          | `true`  | Whether this is the primary scaffold.                                |
 
 ### Notes
 
@@ -275,6 +284,7 @@ WiredScaffold(
 A reorderable list with hand-drawn drag handles and separator lines. Items can be dragged to reorder.
 
 <!-- {=docsReorderableListViewUsage} -->
+
 ```dart
 WiredReorderableListView(
   onReorder: (oldIndex, newIndex) {
@@ -300,6 +310,7 @@ WiredReorderableListView(
 A dismissible wrapper with hand-drawn swipe-to-dismiss background. Shows a sketchy indicator as the user swipes.
 
 <!-- {=docsDismissibleUsage} -->
+
 ```dart
 WiredDismissible(
   key: ValueKey(item.id),
@@ -315,6 +326,7 @@ WiredDismissible(
 Selectable text rendered with Skribble's text color from the theme. Allows copy-paste of displayed text.
 
 <!-- {=docsSelectableTextUsage} -->
+
 ```dart
 WiredSelectableText('This text can be selected and copied.')
 ```
@@ -326,6 +338,7 @@ WiredSelectableText('This text can be selected and copied.')
 A drawer header area with a hand-drawn bottom border. Typically placed at the top of a `WiredDrawer`.
 
 <!-- {=docsDrawerHeaderUsage} -->
+
 ```dart
 WiredDrawerHeader(
   child: Column(
@@ -346,6 +359,7 @@ WiredDrawerHeader(
 A drawer header with account info: avatar, name, and email. Displays a hand-drawn border and themed background.
 
 <!-- {=docsUserAccountsDrawerHeaderUsage} -->
+
 ```dart
 WiredUserAccountsDrawerHeader(
   accountName: Text('Jane Doe'),
@@ -364,6 +378,7 @@ WiredUserAccountsDrawerHeader(
 A hand-drawn circular avatar. Displays an image, icon, or initials inside a sketchy circle border with optional hachure fill.
 
 <!-- {=docsAvatarUsage} -->
+
 ```dart
 // With initials
 WiredAvatar(
@@ -386,16 +401,16 @@ WiredAvatar(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `backgroundImage` | `ImageProvider?` | `null` | Background image, clipped to a circle. |
-| `foregroundImage` | `ImageProvider?` | `null` | Foreground image overlaid on top. |
-| `backgroundColor` | `Color?` | `null` | Background color. Defaults to `theme.borderColor` at 15% opacity. |
-| `foregroundColor` | `Color?` | `null` | Color for text/icons. Defaults to `theme.textColor`. |
-| `radius` | `double` | `20` | Radius of the avatar circle. |
-| `child` | `Widget?` | `null` | Content widget (initials text or icon). |
-| `minRadius` | `double?` | `null` | Minimum radius constraint. |
-| `maxRadius` | `double?` | `null` | Maximum radius constraint. |
+| Parameter         | Type             | Default | Description                                                       |
+| ----------------- | ---------------- | ------- | ----------------------------------------------------------------- |
+| `backgroundImage` | `ImageProvider?` | `null`  | Background image, clipped to a circle.                            |
+| `foregroundImage` | `ImageProvider?` | `null`  | Foreground image overlaid on top.                                 |
+| `backgroundColor` | `Color?`         | `null`  | Background color. Defaults to `theme.borderColor` at 15% opacity. |
+| `foregroundColor` | `Color?`         | `null`  | Color for text/icons. Defaults to `theme.textColor`.              |
+| `radius`          | `double`         | `20`    | Radius of the avatar circle.                                      |
+| `child`           | `Widget?`        | `null`  | Content widget (initials text or icon).                           |
+| `minRadius`       | `double?`        | `null`  | Minimum radius constraint.                                        |
+| `maxRadius`       | `double?`        | `null`  | Maximum radius constraint.                                        |
 
 ### Notes
 
@@ -411,6 +426,7 @@ WiredAvatar(
 A Cupertino page scaffold with hand-drawn navigation bar and paper-like background. Mirrors the `CupertinoPageScaffold` API.
 
 <!-- {=docsPageScaffoldUsage} -->
+
 ```dart
 WiredPageScaffold(
   navigationBar: WiredCupertinoNavigationBar(
@@ -427,6 +443,7 @@ WiredPageScaffold(
 A Cupertino tab scaffold with a hand-drawn tab bar and page switching. Mirrors the `CupertinoTabScaffold` API.
 
 <!-- {=docsTabScaffoldUsage} -->
+
 ```dart
 WiredTabScaffold(
   tabBar: WiredCupertinoTabBar(

--- a/docs/site/content/widgets/navigation.md
+++ b/docs/site/content/widgets/navigation.md
@@ -14,6 +14,7 @@ Skribble provides navigation chrome that replaces Material and Cupertino navigat
 An app bar with a hand-drawn bottom border line. Implements `PreferredSizeWidget` so it can be used directly in `WiredScaffold.appBar`.
 
 <!-- {=docsAppBarUsage} -->
+
 ```dart
 WiredAppBar(
   title: Text('My App'),
@@ -29,13 +30,13 @@ WiredAppBar(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `title` | `Widget?` | `null` | Title widget, rendered with bold 20px text. |
-| `leading` | `Widget?` | `null` | Widget before the title (e.g., menu button). |
-| `actions` | `List<Widget>?` | `null` | Action widgets at the trailing edge. |
-| `height` | `double` | `56.0` | App bar height. |
-| `backgroundColor` | `Color?` | `null` | Background color. Defaults to transparent. |
+| Parameter         | Type            | Default | Description                                  |
+| ----------------- | --------------- | ------- | -------------------------------------------- |
+| `title`           | `Widget?`       | `null`  | Title widget, rendered with bold 20px text.  |
+| `leading`         | `Widget?`       | `null`  | Widget before the title (e.g., menu button). |
+| `actions`         | `List<Widget>?` | `null`  | Action widgets at the trailing edge.         |
+| `height`          | `double`        | `56.0`  | App bar height.                              |
+| `backgroundColor` | `Color?`        | `null`  | Background color. Defaults to transparent.   |
 
 ### Notes
 
@@ -50,6 +51,7 @@ WiredAppBar(
 A bottom navigation bar with hand-drawn circle selection indicators around active icons.
 
 <!-- {=docsBottomNavUsage} -->
+
 ```dart
 WiredBottomNavigationBar(
   currentIndex: selectedTab,
@@ -64,18 +66,18 @@ WiredBottomNavigationBar(
 
 ### WiredBottomNavItem parameters
 
-| Parameter | Type | Description |
-|---|---|---|
-| `icon` | `IconData` | The icon for this tab. |
-| `label` | `String` | Text label below the icon. |
+| Parameter | Type       | Description                |
+| --------- | ---------- | -------------------------- |
+| `icon`    | `IconData` | The icon for this tab.     |
+| `label`   | `String`   | Text label below the icon. |
 
 ### WiredBottomNavigationBar parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `items` | `List<WiredBottomNavItem>` | **required** | Tab items. |
-| `currentIndex` | `int` | `0` | Currently selected index. |
-| `onTap` | `ValueChanged<int>?` | `null` | Called when a tab is tapped. |
+| Parameter      | Type                       | Default      | Description                  |
+| -------------- | -------------------------- | ------------ | ---------------------------- |
+| `items`        | `List<WiredBottomNavItem>` | **required** | Tab items.                   |
+| `currentIndex` | `int`                      | `0`          | Currently selected index.    |
+| `onTap`        | `ValueChanged<int>?`       | `null`       | Called when a tab is tapped. |
 
 ### Notes
 
@@ -90,6 +92,7 @@ WiredBottomNavigationBar(
 A Material 3 style navigation bar with hand-drawn rounded rectangle selection indicators and support for `selectedIcon`.
 
 <!-- {=docsNavigationBarUsage} -->
+
 ```dart
 WiredNavigationBar(
   selectedIndex: currentIndex,
@@ -104,19 +107,19 @@ WiredNavigationBar(
 
 ### WiredNavigationDestination parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `icon` | `IconData` | **required** | Default icon. |
-| `selectedIcon` | `IconData?` | `null` | Icon shown when selected. Falls back to `icon`. |
-| `label` | `String` | **required** | Text label below the icon. |
+| Parameter      | Type        | Default      | Description                                     |
+| -------------- | ----------- | ------------ | ----------------------------------------------- |
+| `icon`         | `IconData`  | **required** | Default icon.                                   |
+| `selectedIcon` | `IconData?` | `null`       | Icon shown when selected. Falls back to `icon`. |
+| `label`        | `String`    | **required** | Text label below the icon.                      |
 
 ### WiredNavigationBar parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `destinations` | `List<WiredNavigationDestination>` | **required** | Navigation destinations. |
-| `selectedIndex` | `int` | `0` | Currently selected destination index. |
-| `onDestinationSelected` | `ValueChanged<int>?` | `null` | Called when a destination is tapped. |
+| Parameter               | Type                               | Default      | Description                           |
+| ----------------------- | ---------------------------------- | ------------ | ------------------------------------- |
+| `destinations`          | `List<WiredNavigationDestination>` | **required** | Navigation destinations.              |
+| `selectedIndex`         | `int`                              | `0`          | Currently selected destination index. |
+| `onDestinationSelected` | `ValueChanged<int>?`               | `null`       | Called when a destination is tapped.  |
 
 ### Notes
 
@@ -131,6 +134,7 @@ WiredNavigationBar(
 A vertical navigation rail with hand-drawn rounded rectangle selection indicators. Best for desktop and tablet layouts.
 
 <!-- {=docsNavigationRailUsage} -->
+
 ```dart
 WiredNavigationRail(
   selectedIndex: currentIndex,
@@ -146,21 +150,21 @@ WiredNavigationRail(
 
 ### WiredNavigationRailDestination parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `icon` | `IconData` | **required** | Default icon. |
-| `selectedIcon` | `IconData?` | `null` | Icon when selected. Falls back to `icon`. |
-| `label` | `String` | **required** | Text label below the icon. |
+| Parameter      | Type        | Default      | Description                               |
+| -------------- | ----------- | ------------ | ----------------------------------------- |
+| `icon`         | `IconData`  | **required** | Default icon.                             |
+| `selectedIcon` | `IconData?` | `null`       | Icon when selected. Falls back to `icon`. |
+| `label`        | `String`    | **required** | Text label below the icon.                |
 
 ### WiredNavigationRail parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `destinations` | `List<WiredNavigationRailDestination>` | **required** | Rail destinations. |
-| `selectedIndex` | `int` | `0` | Currently selected destination index. |
-| `onDestinationSelected` | `ValueChanged<int>?` | `null` | Called when a destination is tapped. |
-| `leading` | `Widget?` | `null` | Widget above the destinations (e.g., FAB). |
-| `trailing` | `Widget?` | `null` | Widget below the destinations, pushed to the bottom. |
+| Parameter               | Type                                   | Default      | Description                                          |
+| ----------------------- | -------------------------------------- | ------------ | ---------------------------------------------------- |
+| `destinations`          | `List<WiredNavigationRailDestination>` | **required** | Rail destinations.                                   |
+| `selectedIndex`         | `int`                                  | `0`          | Currently selected destination index.                |
+| `onDestinationSelected` | `ValueChanged<int>?`                   | `null`       | Called when a destination is tapped.                 |
+| `leading`               | `Widget?`                              | `null`       | Widget above the destinations (e.g., FAB).           |
+| `trailing`              | `Widget?`                              | `null`       | Widget below the destinations, pushed to the bottom. |
 
 ### Notes
 
@@ -175,6 +179,7 @@ WiredNavigationRail(
 A side navigation drawer with a hand-drawn border. Displays a list of navigation destinations with sketchy selection indicators.
 
 <!-- {=docsNavigationDrawerUsage} -->
+
 ```dart
 WiredNavigationDrawer(
   selectedIndex: currentIndex,
@@ -198,6 +203,7 @@ WiredNavigationDrawer(
 A tab bar with hand-drawn underline indicators. Each tab label gets a sketchy line beneath it when selected.
 
 <!-- {=docsTabBarUsage} -->
+
 ```dart
 WiredTabBar(
   controller: tabController,
@@ -222,6 +228,7 @@ WiredTabBar(
 A hand-drawn drawer panel with a sketchy border, suitable for side menus.
 
 <!-- {=docsDrawerUsage} -->
+
 ```dart
 WiredScaffold(
   drawer: WiredDrawer(
@@ -244,6 +251,7 @@ WiredScaffold(
 A popup menu triggered by a button press. Menu items appear in a hand-drawn bordered overlay.
 
 <!-- {=docsPopupMenuUsage} -->
+
 ```dart
 WiredPopupMenuButton<String>(
   onSelected: (value) => print(value),
@@ -261,6 +269,7 @@ WiredPopupMenuButton<String>(
 A horizontal menu bar with hand-drawn borders, suitable for desktop-style navigation.
 
 <!-- {=docsMenuBarUsage} -->
+
 ```dart
 WiredMenuBar(
   children: [
@@ -283,6 +292,7 @@ WiredMenuBar(
 A bottom app bar with a hand-drawn top border. Can contain actions and an optional notch for a FAB.
 
 <!-- {=docsBottomAppBarUsage} -->
+
 ```dart
 WiredScaffold(
   bottomNavigationBar: WiredBottomAppBar(
@@ -306,6 +316,7 @@ WiredScaffold(
 A sliver app bar with hand-drawn borders for use in `CustomScrollView`. Supports expanding/collapsing behavior.
 
 <!-- {=docsSliverAppBarUsage} -->
+
 ```dart
 CustomScrollView(
   slivers: [
@@ -326,6 +337,7 @@ CustomScrollView(
 A Cupertino-style navigation bar with hand-drawn borders. Mirrors the `CupertinoNavigationBar` API with sketchy styling.
 
 <!-- {=docsCupertinoNavBarUsage} -->
+
 ```dart
 WiredCupertinoNavigationBar(
   middle: Text('Page Title'),
@@ -343,6 +355,7 @@ WiredCupertinoNavigationBar(
 A Cupertino-style tab bar with hand-drawn selection indicators. Mirrors the `CupertinoTabBar` API.
 
 <!-- {=docsCupertinoTabBarUsage} -->
+
 ```dart
 WiredCupertinoTabBar(
   currentIndex: selectedTab,

--- a/docs/site/content/widgets/selection.md
+++ b/docs/site/content/widgets/selection.md
@@ -14,6 +14,7 @@ Skribble provides selection widgets for choices, filtering, date/time picking, a
 A chip with a hand-drawn pill-shaped border (16px radius). Supports an optional avatar and delete action.
 
 <!-- {=docsChipUsage} -->
+
 ```dart
 WiredChip(
   label: Text('Flutter'),
@@ -24,11 +25,11 @@ WiredChip(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `label` | `Widget` | **required** | The chip label. |
-| `avatar` | `Widget?` | `null` | Widget displayed before the label. |
-| `onDeleted` | `VoidCallback?` | `null` | Called when the delete icon is tapped. Adds a close icon when set. |
+| Parameter   | Type            | Default      | Description                                                        |
+| ----------- | --------------- | ------------ | ------------------------------------------------------------------ |
+| `label`     | `Widget`        | **required** | The chip label.                                                    |
+| `avatar`    | `Widget?`       | `null`       | Widget displayed before the label.                                 |
+| `onDeleted` | `VoidCallback?` | `null`       | Called when the delete icon is tapped. Adds a close icon when set. |
 
 ### Notes
 
@@ -44,6 +45,7 @@ WiredChip(
 A selectable chip that toggles between selected and unselected states. When selected, it receives a hachure fill.
 
 <!-- {=docsChoiceChipUsage} -->
+
 ```dart
 WiredChoiceChip(
   label: Text('Small'),
@@ -66,6 +68,7 @@ WiredChoiceChip(
 A chip with a checkmark indicator that can be toggled on and off for filtering. Shows a hand-drawn checkmark when selected.
 
 <!-- {=docsFilterChipUsage} -->
+
 ```dart
 WiredFilterChip(
   label: Text('Vegetarian'),
@@ -85,6 +88,7 @@ WiredFilterChip(
 A chip representing a piece of user input (e.g., a tag or email address). Supports avatar, delete, and tap actions.
 
 <!-- {=docsInputChipUsage} -->
+
 ```dart
 WiredInputChip(
   label: Text('user@example.com'),
@@ -101,6 +105,7 @@ WiredInputChip(
 A chip that triggers an action when tapped. Has a hand-drawn border but no selected state.
 
 <!-- {=docsActionChipUsage} -->
+
 ```dart
 WiredActionChip(
   label: Text('Share'),
@@ -116,6 +121,7 @@ WiredActionChip(
 A hand-drawn dropdown selector wrapping Flutter's `DropdownButton`. Displays a sketchy inverted triangle indicator and draws a hand-drawn rectangle around each dropdown item.
 
 <!-- {=docsComboUsage} -->
+
 ```dart
 WiredCombo<String>(
   value: selectedFruit,
@@ -133,11 +139,11 @@ WiredCombo<String>(
 
 ### Constructor parameters
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `value` | `T?` | `null` | Currently selected value. |
-| `items` | `List<DropdownMenuItem<T>>` | **required** | Dropdown items. |
-| `onChanged` | `bool? Function(T?)?` | `null` | Called on selection. Return `true` to indicate external state management. |
+| Parameter   | Type                        | Default      | Description                                                               |
+| ----------- | --------------------------- | ------------ | ------------------------------------------------------------------------- |
+| `value`     | `T?`                        | `null`       | Currently selected value.                                                 |
+| `items`     | `List<DropdownMenuItem<T>>` | **required** | Dropdown items.                                                           |
+| `onChanged` | `bool? Function(T?)?`       | `null`       | Called on selection. Return `true` to indicate external state management. |
 
 ### Notes
 
@@ -153,6 +159,7 @@ WiredCombo<String>(
 A date picker dialog with hand-drawn calendar grid and navigation. Renders month headers and day cells with sketchy borders.
 
 <!-- {=docsDatePickerUsage} -->
+
 ```dart
 final date = await showDatePicker(
   context: context,
@@ -170,6 +177,7 @@ final date = await showDatePicker(
 A time picker with hand-drawn clock face and input mode. Replaces the standard Material time picker overlay.
 
 <!-- {=docsTimePickerUsage} -->
+
 ```dart
 final time = await showTimePicker(
   context: context,
@@ -185,6 +193,7 @@ final time = await showTimePicker(
 An inline calendar date picker widget (not a dialog) with hand-drawn day cells and month navigation arrows.
 
 <!-- {=docsCalendarDatePickerUsage} -->
+
 ```dart
 WiredCalendarDatePicker(
   initialDate: DateTime.now(),
@@ -201,6 +210,7 @@ WiredCalendarDatePicker(
 A color picker with a hand-drawn grid of color swatches. Each swatch is a sketchy circle that fills with hachure when selected.
 
 <!-- {=docsColorPickerUsage} -->
+
 ```dart
 WiredColorPicker(
   selectedColor: currentColor,
@@ -215,6 +225,7 @@ WiredColorPicker(
 A Cupertino-style scrolling picker wheel with hand-drawn selection highlight. Mirrors the `CupertinoPicker` API.
 
 <!-- {=docsCupertinoPickerUsage} -->
+
 ```dart
 WiredCupertinoPicker(
   itemExtent: 32,
@@ -234,6 +245,7 @@ WiredCupertinoPicker(
 A Cupertino-style date picker with hand-drawn wheel columns. Mirrors the `CupertinoDatePicker` API.
 
 <!-- {=docsCupertinoDatePickerUsage} -->
+
 ```dart
 WiredCupertinoDatePicker(
   mode: CupertinoDatePickerMode.date,
@@ -249,6 +261,7 @@ WiredCupertinoDatePicker(
 A Cupertino-style segmented control with hand-drawn segment borders and hachure selection fill.
 
 <!-- {=docsCupertinoSegmentedControlUsage} -->
+
 ```dart
 WiredCupertinoSegmentedControl<int>(
   groupValue: selectedSegment,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ workspace:
   - packages/skribble_icons_custom
   - packages/skribble_lints
   - apps/skribble_storybook
+  - apps/skribble_example
 
 dev_dependencies:
   melos: ^7.4.0


### PR DESCRIPTION
## Summary

A complete hand-drawn notes app ("Sketch Notes") demonstrating the Skribble design system used end-to-end. Every visible element uses Wired* widgets — no Material widgets leak through.

## Screens

### Home Page
- `WiredScaffold` + `WiredAppBar` + `WiredSearchBar` for filtering
- Note list using `WiredCard` + `WiredListTile` with color indicators
- `WiredDismissible` for swipe-to-delete with undo snackbar
- `WiredFloatingActionButton` to create notes
- `WiredBadge` on recently-updated notes
- Navigation `WiredDrawer` with `WiredDrawerHeader` and `WiredAvatar`

### Edit Page
- `WiredInput` for title, `WiredTextArea` for content
- 5 `WiredChip` color labels for categorization
- `WiredButton` to save

### Settings Page
- `WiredSwitchListTile` for Dark Mode
- `WiredSlider` for Roughness adjustment
- `showWiredAboutDialog` integration
- `WiredDivider` + `WiredListTile` layout

## Widgets demonstrated

`WiredMaterialApp`, `WiredScaffold`, `WiredAppBar`, `WiredDrawer`, `WiredDrawerHeader`, `WiredAvatar`, `WiredSearchBar`, `WiredCard`, `WiredListTile`, `WiredDismissible`, `WiredFloatingActionButton`, `WiredBadge`, `WiredDivider`, `WiredInput`, `WiredTextArea`, `WiredChip`, `WiredButton`, `WiredSwitchListTile`, `WiredSlider`, `WiredSnackBarContent`

## Test plan

- [x] 8 widget tests pass (app rendering, navigation, model logic)
- [x] `dart analyze --fatal-infos .` passes
- [x] Zero raw Material widgets in the UI

Closes #104