### PR TITLE
feat: make all 8,600+ Flutter Material icons available through skribble_icons

### DIFF
--- a/.changeset/skribble-icons-comprehensive.md
+++ b/.changeset/skribble-icons-comprehensive.md
@@ -1,0 +1,9 @@
+---
+skribble: patch
+---
+
+Make all 8,600+ Flutter Material icons available through `skribble_icons` via
+unified lookup API. Re-exports Material rough icons from `skribble` package,
+keeps 30 curated custom icons, and provides `lookupSkribbleIconByIdentifier()`
+that searches custom first then falls back to Material. Adds
+`rough-icons-skribble` melos script for custom icon regeneration.

--- a/packages/skribble_icons/README.md
+++ b/packages/skribble_icons/README.md
@@ -1,8 +1,71 @@
 # skribble_icons
 
-Hand-drawn icon set for the Skribble design system. This package provides 30 curated SVG icons that are processed through the Skribble rough icon pipeline to produce hand-drawn variants.
+Comprehensive hand-drawn icon library for the [Skribble](https://github.com/openbudgetfun/skribble) design system.
 
-## Icons
+Provides unified access to **all 8,600+ roughened Flutter Material icons** plus 30 curated custom icons through a single API. Every icon is rendered with the Skribble hand-drawn aesthetic.
+
+## Installation
+
+```yaml
+dependencies:
+  skribble: ^0.3.4
+  skribble_icons: ^0.1.0
+```
+
+## Usage
+
+### Unified lookup (recommended)
+
+Search custom icons first, then fall back to the full Material set:
+
+```dart
+import 'package:skribble/skribble.dart';
+import 'package:skribble_icons/skribble_icons.dart';
+
+// Any Material icon identifier works:
+final alarm = lookupSkribbleIconByIdentifier('access_alarm');
+final home = lookupSkribbleIconByIdentifier('home');
+
+// Render it:
+if (alarm != null) {
+  WiredIcon.custom(data: alarm);
+}
+```
+
+### Custom icons only
+
+Access just the 30 curated custom icons:
+
+```dart
+final star = lookupSkribbleCustomIconByIdentifier('star');
+```
+
+### Material icons directly
+
+Access the full Material rough icon set:
+
+```dart
+// By identifier
+final icon = lookupMaterialRoughIconByIdentifier('favorite');
+
+// By codepoint
+final icon = kMaterialRoughIcons[0xe87d];
+
+// All available identifiers
+final names = materialRoughIconIdentifiers; // 8,600+ names
+```
+
+### Icon count
+
+```dart
+print(skribbleIconCount); // custom + Material total
+print(kSkribbleCustomIcons.length); // 30 curated icons
+print(kMaterialRoughIcons.length); // 8,600+ Material icons
+```
+
+## Custom icons
+
+The 30 curated custom icons cover common app patterns:
 
 | Identifier     | Codepoint | Description                    |
 | -------------- | --------- | ------------------------------ |
@@ -37,48 +100,37 @@ Hand-drawn icon set for the Skribble design system. This package provides 30 cur
 | `eye_off`      | `0xf01d`  | Eye with line through          |
 | `notification` | `0xf01e`  | Bell                           |
 
-## Usage
+## Regenerating custom icons
 
-Add the dependency to your `pubspec.yaml`:
-
-```yaml
-dependencies:
-  skribble_icons: ^0.1.0
-```
-
-Import and use the icons:
-
-```dart
-import 'package:skribble_icons/skribble_icons.dart';
-
-// Access the full icon map by codepoint.
-final homeIcon = kSkribbleIcons[0xf001];
-
-// Look up an icon by its string identifier.
-final starIcon = lookupSkribbleIconByIdentifier('star');
-
-// Iterate over all available codepoints.
-for (final entry in kSkribbleIconsCodePoints.entries) {
-  print('${entry.key}: 0x${entry.value.toRadixString(16)}');
-}
-```
-
-## Regeneration
-
-The generated Dart file at `lib/src/generated/skribble_icons.g.dart` is produced by the Skribble rough icon pipeline. To regenerate it, run from the workspace root:
+The curated icons are generated from SVG sources via the rough icon pipeline:
 
 ```bash
-cd packages/skribble && dart run tool/generate_rough_icons.dart \
+# From the workspace root:
+melos run rough-icons-skribble
+
+# Or directly:
+cd packages/skribble
+dart run tool/generate_rough_icons.dart \
   --kit svg-manifest \
   --manifest ../skribble_icons/tool/skribble_icons.manifest.json \
   --output ../skribble_icons/lib/src/generated/skribble_icons.g.dart \
-  --map-name kSkribbleIcons
+  --map-name kSkribbleCustomIcons
 ```
 
-## Adding new icons
+## Adding custom icons
 
-1. Create a 24x24 SVG file in the `icons/` directory.
-2. Add an entry to `tool/skribble_icons.manifest.json` with a unique `identifier`, the next available `codePoint`, and the relative `svgPath`.
-3. Add the identifier and codepoint to `kSkribbleIconsCodePoints` in `lib/skribble_icons.dart`.
-4. Run the regeneration command above.
-5. Update the test expectations in `test/skribble_icon_catalog_test.dart`.
+1. Add a 24x24 SVG file to `icons/`.
+2. Add an entry to `tool/skribble_icons.manifest.json`:
+   ```json
+   {
+     "identifier": "my_icon",
+     "codePoint": "0xf01f",
+     "svgPath": "../icons/my_icon.svg"
+   }
+   ```
+3. Run `melos run rough-icons-skribble`.
+4. Update the `kSkribbleCustomIconsCodePoints` map in `lib/skribble_icons.dart`.
+
+## License
+
+Same as the root Skribble repository — see [LICENSE](../../LICENSE) for details.

--- a/packages/skribble_icons/lib/skribble_icons.dart
+++ b/packages/skribble_icons/lib/skribble_icons.dart
@@ -1,31 +1,51 @@
-/// Hand-drawn icon set for Skribble.
+/// Comprehensive hand-drawn icon library for Skribble.
 ///
-/// Provides [kSkribbleIcons], a compile-time map from codepoint to
-/// [WiredSvgIconData], and [lookupSkribbleIconByIdentifier] for
-/// name-based access.
+/// Provides unified access to **all** roughened Flutter Material icons (8,600+)
+/// plus 30 curated custom icons through a single API.
 ///
+/// ## Quick start
+///
+/// ```dart
+/// import 'package:skribble_icons/skribble_icons.dart';
+///
+/// // Look up any Material icon by its Flutter identifier:
+/// final searchIcon = lookupSkribbleIconByIdentifier('search');
+///
+/// // Or use the curated custom icons:
+/// final homeIcon = lookupSkribbleCustomIconByIdentifier('home');
+/// ```
 library;
 
+import 'package:skribble/skribble.dart';
 import 'package:skribble_icons/src/generated/skribble_icons.g.dart';
-import 'package:skribble_icons/src/wired_svg_icon_data.dart';
 
-export 'package:skribble_icons/src/generated/skribble_icons.g.dart'
-    show kSkribbleIcons;
-export 'package:skribble_icons/src/wired_svg_icon_data.dart'
+// Re-export core icon types and Material rough icon accessors from skribble.
+export 'package:skribble/skribble.dart'
     show
         WiredSvgCirclePrimitive,
         WiredSvgEllipsePrimitive,
         WiredSvgFillRule,
         WiredSvgIconData,
         WiredSvgPathPrimitive,
-        WiredSvgPrimitive;
+        WiredSvgPrimitive,
+        lookupMaterialRoughIcon,
+        lookupMaterialRoughIconByIdentifier,
+        materialRoughFontCodePoints,
+        materialRoughFontFamily,
+        materialRoughIconCodePoints,
+        materialRoughIconIdentifiers;
+
+// Export the curated custom icon set.
+export 'package:skribble_icons/src/generated/skribble_icons.g.dart'
+    show kSkribbleCustomIcons;
 
 // ---------------------------------------------------------------------------
-// Lookup helpers
+// Custom icon codepoint map
 // ---------------------------------------------------------------------------
 
-/// Maps each icon identifier string to its codepoint in [kSkribbleIcons].
-const Map<String, int> kSkribbleIconsCodePoints = <String, int>{
+/// Maps each curated custom icon identifier to its codepoint in
+/// [kSkribbleCustomIcons].
+const Map<String, int> kSkribbleCustomIconsCodePoints = <String, int>{
   'home': 0xf001,
   'search': 0xf002,
   'settings': 0xf003,
@@ -58,13 +78,44 @@ const Map<String, int> kSkribbleIconsCodePoints = <String, int>{
   'notification': 0xf01e,
 };
 
-/// Returns the [WiredSvgIconData] for [identifier], or `null` if not found.
+// ---------------------------------------------------------------------------
+// Unified lookup helpers
+// ---------------------------------------------------------------------------
+
+/// Returns [WiredSvgIconData] for [identifier], searching custom icons first,
+/// then falling back to the full Material rough icon set.
+///
+/// This is the primary lookup function — it covers all 8,600+ Material icons
+/// plus the 30 curated custom icons.
 ///
 /// ```dart
-/// final data = lookupSkribbleIconByIdentifier('star');
+/// // Custom icon:
+/// lookupSkribbleIconByIdentifier('heart'); // curated custom icon
+///
+/// // Material icon (any Flutter Icons identifier):
+/// lookupSkribbleIconByIdentifier('access_alarm'); // Material rough icon
 /// ```
 WiredSvgIconData? lookupSkribbleIconByIdentifier(String identifier) {
-  final codePoint = kSkribbleIconsCodePoints[identifier];
-  if (codePoint == null) return null;
-  return kSkribbleIcons[codePoint];
+  // Try custom icons first (they take precedence for shared identifiers).
+  final customCodePoint = kSkribbleCustomIconsCodePoints[identifier];
+  if (customCodePoint != null) {
+    final data = kSkribbleCustomIcons[customCodePoint];
+    if (data != null) return data;
+  }
+  // Fall back to the full Material rough icon set.
+  return lookupMaterialRoughIconByIdentifier(identifier);
 }
+
+/// Returns [WiredSvgIconData] for [identifier] from the curated custom set
+/// only. Returns `null` if not found.
+WiredSvgIconData? lookupSkribbleCustomIconByIdentifier(String identifier) {
+  final codePoint = kSkribbleCustomIconsCodePoints[identifier];
+  if (codePoint == null) return null;
+  return kSkribbleCustomIcons[codePoint];
+}
+
+/// Total number of curated custom icons.
+int get skribbleCustomIconCount => kSkribbleCustomIcons.length;
+
+/// Total number of Material rough icons available.
+int get skribbleMaterialIconCount => materialRoughIconCodePoints.length;

--- a/packages/skribble_icons/lib/src/generated/skribble_icons.g.dart
+++ b/packages/skribble_icons/lib/src/generated/skribble_icons.g.dart
@@ -3,7 +3,7 @@
 
 import '../wired_svg_icon_data.dart';
 
-const Map<int, WiredSvgIconData> kSkribbleIcons = <int, WiredSvgIconData>{
+const Map<int, WiredSvgIconData> kSkribbleCustomIcons = <int, WiredSvgIconData>{
   // home
   0xf001: WiredSvgIconData(
     width: 24.0,

--- a/packages/skribble_icons/test/skribble_icon_catalog_test.dart
+++ b/packages/skribble_icons/test/skribble_icon_catalog_test.dart
@@ -2,17 +2,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:skribble_icons/skribble_icons.dart';
 
 void main() {
-  group('kSkribbleIcons map', () {
+  group('kSkribbleCustomIcons (curated 30)', () {
     test('is non-empty', () {
-      expect(kSkribbleIcons, isNotEmpty);
+      expect(kSkribbleCustomIcons, isNotEmpty);
     });
 
     test('contains exactly 30 icons', () {
-      expect(kSkribbleIcons.length, 30);
+      expect(kSkribbleCustomIcons.length, 30);
     });
 
     test('every entry has a non-empty primitives list', () {
-      for (final entry in kSkribbleIcons.entries) {
+      for (final entry in kSkribbleCustomIcons.entries) {
         expect(
           entry.value.primitives,
           isNotEmpty,
@@ -22,7 +22,7 @@ void main() {
     });
 
     test('every entry has positive dimensions', () {
-      for (final entry in kSkribbleIcons.entries) {
+      for (final entry in kSkribbleCustomIcons.entries) {
         expect(
           entry.value.width,
           greaterThan(0),
@@ -37,10 +37,49 @@ void main() {
     });
   });
 
-  group('kSkribbleIconsCodePoints map', () {
-    test('contains all expected identifiers', () {
+  group('Material rough icons (full set via re-export)', () {
+    test('materialRoughIconIdentifiers is non-empty', () {
+      expect(materialRoughIconIdentifiers, isNotEmpty);
+    });
+
+    test('contains thousands of icons', () {
+      expect(materialRoughIconIdentifiers.length, greaterThan(5000));
+    });
+
+    test('common Material icons are present', () {
+      for (final identifier in <String>[
+        'search',
+        'home',
+        'settings',
+        'favorite',
+        'add',
+        'delete',
+        'edit',
+        'share',
+        'menu',
+        'close',
+        'check',
+        'arrow_back',
+        'arrow_forward',
+        'person',
+        'email',
+        'phone',
+        'camera_alt',
+      ]) {
+        final data = lookupMaterialRoughIconByIdentifier(identifier);
+        expect(
+          data,
+          isNotNull,
+          reason: 'Material icon "$identifier" should be available',
+        );
+      }
+    });
+  });
+
+  group('kSkribbleCustomIconsCodePoints', () {
+    test('contains all 30 custom identifiers', () {
       expect(
-        kSkribbleIconsCodePoints.keys,
+        kSkribbleCustomIconsCodePoints.keys,
         containsAll(<String>[
           'home',
           'search',
@@ -76,77 +115,76 @@ void main() {
       );
     });
 
-    test('every identifier resolves to a codepoint present in the icon map',
-        () {
-      for (final entry in kSkribbleIconsCodePoints.entries) {
+    test('every identifier resolves to a codepoint in the custom map', () {
+      for (final entry in kSkribbleCustomIconsCodePoints.entries) {
         expect(
-          kSkribbleIcons,
+          kSkribbleCustomIcons,
           contains(entry.value),
-          reason: 'Identifier "${entry.key}" codepoint '
+          reason: '"${entry.key}" codepoint '
               '0x${entry.value.toRadixString(16)} missing from map',
         );
       }
     });
   });
 
-  group('lookupSkribbleIconByIdentifier', () {
-    test('returns icon data for known identifiers', () {
-      for (final name in <String>[
-        'home',
-        'search',
-        'settings',
-        'star',
-        'heart',
-        'user',
-        'menu',
-        'close',
-        'check',
-        'plus',
-        'minus',
-        'arrow_left',
-        'arrow_right',
-        'arrow_up',
-        'arrow_down',
-        'edit',
-        'delete',
-        'share',
-        'copy',
-        'mail',
-        'phone',
-        'camera',
-        'image',
-        'calendar',
-        'clock',
-        'lock',
-        'unlock',
-        'eye',
-        'eye_off',
-        'notification',
-      ]) {
-        final result = lookupSkribbleIconByIdentifier(name);
+  group('lookupSkribbleIconByIdentifier (unified)', () {
+    test('returns custom icon for custom identifier', () {
+      final result = lookupSkribbleIconByIdentifier('heart');
+      expect(result, isA<WiredSvgIconData>());
+    });
+
+    test('returns Material icon for Material-only identifier', () {
+      final result = lookupSkribbleIconByIdentifier('access_alarm');
+      expect(result, isA<WiredSvgIconData>());
+    });
+
+    test('returns null for unknown identifier', () {
+      expect(lookupSkribbleIconByIdentifier('does_not_exist_xyz'), isNull);
+    });
+
+    test('custom icons take precedence over Material for shared names', () {
+      final unified = lookupSkribbleIconByIdentifier('home');
+      final custom = lookupSkribbleCustomIconByIdentifier('home');
+      expect(unified, isNotNull);
+      expect(custom, isNotNull);
+      expect(identical(unified, custom), isTrue);
+    });
+  });
+
+  group('lookupSkribbleCustomIconByIdentifier', () {
+    test('returns data for all 30 custom icons', () {
+      for (final name in kSkribbleCustomIconsCodePoints.keys) {
+        final result = lookupSkribbleCustomIconByIdentifier(name);
         expect(result, isA<WiredSvgIconData>(), reason: '"$name" not found');
       }
     });
 
-    test('returns null for unknown identifier', () {
-      expect(lookupSkribbleIconByIdentifier('does_not_exist'), isNull);
+    test('returns null for Material-only identifier', () {
+      expect(lookupSkribbleCustomIconByIdentifier('access_alarm'), isNull);
+    });
+  });
+
+  group('icon counts', () {
+    test('skribbleCustomIconCount equals 30', () {
+      expect(skribbleCustomIconCount, 30);
     });
 
-    test('home icon has expected codepoint 0xf001', () {
-      expect(kSkribbleIconsCodePoints['home'], 0xf001);
+    test('skribbleMaterialIconCount is over 5000', () {
+      expect(skribbleMaterialIconCount, greaterThan(5000));
     });
   });
 
   group('WiredSvgIconData structure', () {
-    test('home icon has a path primitive', () {
-      final home = lookupSkribbleIconByIdentifier('home')!;
+    test('custom home icon has a path primitive', () {
+      final home = lookupSkribbleCustomIconByIdentifier('home')!;
       expect(home.primitives.first, isA<WiredSvgPathPrimitive>());
     });
 
-    test('search icon SVG path is non-empty', () {
-      final search = lookupSkribbleIconByIdentifier('search')!;
-      final path = search.primitives.first as WiredSvgPathPrimitive;
-      expect(path.data, isNotEmpty);
+    test('Material search icon has valid primitives', () {
+      final search = lookupMaterialRoughIconByIdentifier('search')!;
+      expect(search.primitives, isNotEmpty);
+      expect(search.width, greaterThan(0));
+      expect(search.height, greaterThan(0));
     });
   });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -96,6 +96,16 @@ melos:
         --output ../skribble_icons_custom/lib/src/generated/custom_rough_icons.g.dart
         --map-name kCustomRoughIcons
 
+    rough-icons-skribble:
+      description: Generate rough custom icon artifacts for the skribble_icons package.
+      run: >-
+        cd packages/skribble &&
+        dart run tool/generate_rough_icons.dart
+        --kit svg-manifest
+        --manifest ../skribble_icons/tool/skribble_icons.manifest.json
+        --output ../skribble_icons/lib/src/generated/skribble_icons.g.dart
+        --map-name kSkribbleCustomIcons
+
     rough-icons-ci-check:
       description: Run the same rough icon regression/sync checks enforced by CI.
       run: ./scripts/check_rough_icons_ci.sh all


### PR DESCRIPTION
## Summary

Transforms `skribble_icons` into the comprehensive icon entry point for Skribble. Instead of duplicating the 70K+ lines of generated Material rough icons, it re-exports them from the `skribble` package and provides a unified lookup API.

## What's available now

- **8,622 Material rough icons** — every Flutter `Icons.*` identifier accessible via `lookupSkribbleIconByIdentifier()` or `lookupMaterialRoughIconByIdentifier()`
- **30 curated custom icons** — common app icons with clean SVG sources (home, search, settings, star, heart, user, menu, close, check, plus, minus, arrows, edit, delete, share, copy, mail, phone, camera, image, calendar, clock, lock, unlock, eye, eye_off, notification)
- **Unified lookup** — `lookupSkribbleIconByIdentifier()` searches custom first, then Material

## API

| Symbol | Description |
| --- | --- |
| `lookupSkribbleIconByIdentifier()` | Unified lookup: custom → Material fallback |
| `lookupSkribbleCustomIconByIdentifier()` | Custom icons only |
| `lookupMaterialRoughIconByIdentifier()` | Material icons only (re-exported) |
| `kSkribbleCustomIcons` | `Map<int, WiredSvgIconData>` — 30 custom icons |
| `materialRoughIconIdentifiers` | All 8,600+ Material identifier strings |
| `skribbleCustomIconCount` / `skribbleMaterialIconCount` | Icon counts |

## New melos script

`melos run rough-icons-skribble` — regenerates the 30 custom icons through the rough pipeline.

## Test plan

- [x] 19 tests pass (custom icons, Material re-exports, unified lookup, precedence, counts)
- [x] `dart analyze --fatal-infos .` passes
- [x] Custom icons take precedence over Material for shared identifiers

Closes #111