### PR TITLE
feat: wire icons/emoji into storybook and update documentation

### DIFF
--- a/.changeset/storybook-docs-icons-emoji.md
+++ b/.changeset/storybook-docs-icons-emoji.md
@@ -1,0 +1,7 @@
+---
+skribble: patch
+---
+
+Wire `skribble_icons` and `skribble_emoji` into the storybook with dedicated
+pages, update docs with icon/emoji/font documentation, and add companion
+package installation instructions.

--- a/apps/skribble_storybook/lib/app.dart
+++ b/apps/skribble_storybook/lib/app.dart
@@ -4,6 +4,7 @@ import 'package:skribble/skribble.dart';
 
 import 'package:skribble_storybook/pages/buttons_page.dart';
 import 'package:skribble_storybook/pages/data_display_page.dart';
+import 'package:skribble_storybook/pages/emoji_page.dart';
 import 'package:skribble_storybook/pages/feedback_page.dart';
 import 'package:skribble_storybook/pages/home_page.dart';
 import 'package:skribble_storybook/pages/inputs_page.dart';
@@ -11,6 +12,7 @@ import 'package:skribble_storybook/pages/layout_page.dart';
 import 'package:skribble_storybook/pages/navigation_page.dart';
 import 'package:skribble_storybook/pages/rough_icons_page.dart';
 import 'package:skribble_storybook/pages/selection_page.dart';
+import 'package:skribble_storybook/pages/skribble_icons_page.dart';
 
 class SkribbleStorybookApp extends HookWidget {
   const SkribbleStorybookApp({super.key});
@@ -39,6 +41,8 @@ class SkribbleStorybookApp extends HookWidget {
         '/layout': (context) => const LayoutPage(),
         '/data-display': (context) => const DataDisplayPage(),
         '/rough-icons': (context) => const RoughIconsPage(),
+        '/skribble-icons': (context) => const SkribbleIconsPage(),
+        '/emoji': (context) => const EmojiPage(),
       },
     );
   }

--- a/apps/skribble_storybook/lib/pages/emoji_page.dart
+++ b/apps/skribble_storybook/lib/pages/emoji_page.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:skribble/skribble.dart';
+import 'package:skribble_emoji/skribble_emoji.dart';
+
+class EmojiPage extends HookWidget {
+  const EmojiPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final sortedNames = useMemoized(() {
+      final names = kSkribbleEmojiCodePoints.keys.toList()..sort();
+      return names;
+    });
+
+    final emojiCount = kSkribbleEmoji.length;
+
+    return WiredScaffold(
+      appBar: WiredAppBar(
+        leading: const BackButton(),
+        title: const Text('Emoji'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Hand-drawn emoji set',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '$emojiCount emoji from OpenMoji',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Emoji are rendered as hand-drawn SVG icons using the '
+              'WiredEmoji widget. Look up emoji by name with '
+              'lookupSkribbleEmojiByName() or by Unicode codepoint '
+              'with lookupSkribbleEmojiByUnicode().',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 24),
+            if (sortedNames.isEmpty)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 32),
+                child: Center(
+                  child: Column(
+                    children: [
+                      const WiredEmoji(size: 48),
+                      const SizedBox(height: 12),
+                      Text(
+                        'No emoji generated yet.\n'
+                        'Run the rough icon pipeline against the emoji '
+                        'manifest to populate this gallery.',
+                        style: Theme.of(context).textTheme.bodyMedium,
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                  ),
+                ),
+              )
+            else
+              Wrap(
+                spacing: 12,
+                runSpacing: 16,
+                children: [
+                  for (final name in sortedNames)
+                    SizedBox(
+                      width: 72,
+                      child: Column(
+                        children: [
+                          WiredEmoji.fromName(name, size: 32),
+                          const SizedBox(height: 4),
+                          Text(
+                            name,
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodySmall
+                                ?.copyWith(fontSize: 9),
+                            textAlign: TextAlign.center,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
+                      ),
+                    ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/skribble_storybook/lib/pages/home_page.dart
+++ b/apps/skribble_storybook/lib/pages/home_page.dart
@@ -143,4 +143,16 @@ const _categories = [
     route: '/rough-icons',
     icon: Icons.draw_outlined,
   ),
+  _Category(
+    title: 'Skribble Icons',
+    description: 'Curated hand-drawn custom icon set with unified lookup',
+    route: '/skribble-icons',
+    icon: Icons.auto_awesome_outlined,
+  ),
+  _Category(
+    title: 'Emoji',
+    description: 'Hand-drawn emoji from OpenMoji rendered as SVG icons',
+    route: '/emoji',
+    icon: Icons.emoji_emotions_outlined,
+  ),
 ];

--- a/apps/skribble_storybook/lib/pages/skribble_icons_page.dart
+++ b/apps/skribble_storybook/lib/pages/skribble_icons_page.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:skribble/skribble.dart';
+import 'package:skribble_icons/skribble_icons.dart';
+
+class SkribbleIconsPage extends HookWidget {
+  const SkribbleIconsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final sortedIdentifiers = useMemoized(() {
+      final identifiers = kSkribbleCustomIconsCodePoints.keys.toList()..sort();
+      return identifiers;
+    });
+
+    final materialCount = useMemoized(() => materialRoughIconCodePoints.length);
+    final customCount = kSkribbleCustomIcons.length;
+    final totalCount = customCount + materialCount;
+
+    return WiredScaffold(
+      appBar: WiredAppBar(
+        leading: const BackButton(),
+        title: const Text('Skribble Icons'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Curated hand-drawn icon set',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '$customCount custom icons + $materialCount Material icons = '
+              '$totalCount total',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'All icons are accessible through a unified lookup API. '
+              'Use lookupSkribbleIconByIdentifier() to find any custom icon '
+              'by name, or use WiredIcon for Material icons.',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'Custom Icons',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 12,
+              runSpacing: 16,
+              children: [
+                for (final identifier in sortedIdentifiers)
+                  SizedBox(
+                    width: 72,
+                    child: Column(
+                      children: [
+                        WiredSvgIcon(
+                          data: lookupSkribbleIconByIdentifier(identifier)!,
+                          size: 32,
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          identifier,
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodySmall
+                              ?.copyWith(fontSize: 9),
+                          textAlign: TextAlign.center,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/skribble_storybook/pubspec.yaml
+++ b/apps/skribble_storybook/pubspec.yaml
@@ -16,6 +16,10 @@ dependencies:
   flutter_hooks: ^0.21.3
   skribble:
     path: ../../packages/skribble
+  skribble_emoji:
+    path: ../../packages/skribble_emoji
+  skribble_icons:
+    path: ../../packages/skribble_icons
 
 dev_dependencies:
   flutter_test:

--- a/apps/skribble_storybook/test/pages/home_page_test.dart
+++ b/apps/skribble_storybook/test/pages/home_page_test.dart
@@ -19,7 +19,7 @@ void main() {
       expect(find.text('Hand-drawn UI components for Flutter'), findsOneWidget);
     });
 
-    testWidgets('renders all eight category cards', (tester) async {
+    testWidgets('renders all ten category cards', (tester) async {
       await tester.pumpWidget(const SkribbleStorybookApp());
       await tester.pumpAndSettle();
 
@@ -28,15 +28,35 @@ void main() {
       expect(find.text('Inputs'), findsOneWidget);
       expect(find.text('Navigation'), findsOneWidget);
 
-      // Scroll down to find remaining categories.
+      // Scroll down to find middle categories.
+      await tester.scrollUntilVisible(find.text('Selection'), 200);
+      await tester.pumpAndSettle();
+      expect(find.text('Selection'), findsOneWidget);
+
+      await tester.scrollUntilVisible(find.text('Feedback'), 200);
+      await tester.pumpAndSettle();
+      expect(find.text('Feedback'), findsOneWidget);
+
+      await tester.scrollUntilVisible(find.text('Layout'), 200);
+      await tester.pumpAndSettle();
+      expect(find.text('Layout'), findsOneWidget);
+
+      await tester.scrollUntilVisible(find.text('Data Display'), 200);
+      await tester.pumpAndSettle();
+      expect(find.text('Data Display'), findsOneWidget);
+
       await tester.scrollUntilVisible(find.text('Rough Icons'), 200);
       await tester.pumpAndSettle();
-
-      expect(find.text('Selection'), findsOneWidget);
-      expect(find.text('Feedback'), findsOneWidget);
-      expect(find.text('Layout'), findsOneWidget);
-      expect(find.text('Data Display'), findsOneWidget);
       expect(find.text('Rough Icons'), findsOneWidget);
+
+      // Scroll down to find the new categories.
+      await tester.scrollUntilVisible(find.text('Skribble Icons'), 200);
+      await tester.pumpAndSettle();
+      expect(find.text('Skribble Icons'), findsOneWidget);
+
+      await tester.scrollUntilVisible(find.text('Emoji'), 200);
+      await tester.pumpAndSettle();
+      expect(find.text('Emoji'), findsOneWidget);
     });
 
     testWidgets('uses WiredAppBar', (tester) async {

--- a/docs/site/content/getting-started/installation.md
+++ b/docs/site/content/getting-started/installation.md
@@ -38,6 +38,33 @@ import 'package:skribble/skribble.dart';
 
 That single import gives you access to every Wired widget, the theming system, the rough-drawing engine, and the icon set. No additional setup is required -- just start using Wired widgets in your widget tree.
 
+### Optional companion packages
+
+For curated custom icons and hand-drawn emoji, add the companion packages:
+
+```bash
+dart pub add skribble_icons
+dart pub add skribble_emoji
+```
+
+Or add them manually to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  skribble: ^0.1.0
+  skribble_icons: ^0.1.0
+  skribble_emoji: ^0.1.0
+```
+
+Import them separately:
+
+```dart
+import 'package:skribble_icons/skribble_icons.dart';
+import 'package:skribble_emoji/skribble_emoji.dart';
+```
+
+`skribble_icons` provides 30 curated hand-drawn custom icons with a unified lookup API. `skribble_emoji` provides hand-drawn emoji from OpenMoji with the `WiredEmoji` widget.
+
 <!-- {/docsInstallSection} -->
 
 ## Workspace contribution setup

--- a/docs/site/content/reference/api-overview.md
+++ b/docs/site/content/reference/api-overview.md
@@ -222,8 +222,39 @@ The main library depends on:
 
 | Package                 | Purpose                                            |
 | ----------------------- | -------------------------------------------------- |
+| `skribble_icons`        | 30 curated hand-drawn custom icons + unified API   |
+| `skribble_emoji`        | Hand-drawn emoji from OpenMoji + WiredEmoji widget |
 | `skribble_lints`        | Shared lint rules (extends `very_good_analysis`)   |
 | `skribble_icons_custom` | Example custom icon set with SVG-manifest pipeline |
+
+### skribble_icons
+
+```dart
+import 'package:skribble_icons/skribble_icons.dart';
+```
+
+| Export                             | Type                         | Purpose                                           |
+| ---------------------------------- | ---------------------------- | ------------------------------------------------- |
+| `kSkribbleIcons`                   | `Map<int, WiredSvgIconData>` | All custom icons keyed by codepoint               |
+| `kSkribbleIconsCodePoints`         | `Map<String, int>`           | Icon identifier to codepoint mapping              |
+| `lookupSkribbleIconByIdentifier()` | function                     | Look up custom icon data by name                  |
+| `WiredSvgIconData`                 | class                        | SVG icon data (re-exported from `skribble`)       |
+| `WiredSvgPrimitive`                | class                        | SVG primitive types (re-exported from `skribble`) |
+
+### skribble_emoji
+
+```dart
+import 'package:skribble_emoji/skribble_emoji.dart';
+```
+
+| Export                           | Type                         | Purpose                                     |
+| -------------------------------- | ---------------------------- | ------------------------------------------- |
+| `kSkribbleEmoji`                 | `Map<int, WiredSvgIconData>` | All emoji keyed by Unicode codepoint        |
+| `kSkribbleEmojiCodePoints`       | `Map<String, int>`           | Emoji name to Unicode codepoint mapping     |
+| `lookupSkribbleEmojiByName()`    | function                     | Look up emoji data by name                  |
+| `lookupSkribbleEmojiByUnicode()` | function                     | Look up emoji data by Unicode codepoint     |
+| `WiredEmoji`                     | widget                       | HookWidget for rendering hand-drawn emoji   |
+| `WiredSvgIconData`               | class                        | SVG icon data (re-exported from `skribble`) |
 
 ## API documentation
 

--- a/docs/site/content/widgets/emoji.md
+++ b/docs/site/content/widgets/emoji.md
@@ -1,0 +1,122 @@
+---
+title: Emoji
+description: Hand-drawn emoji from OpenMoji, rendered as rough SVG icons with the WiredEmoji widget.
+---
+
+# Emoji
+
+The `skribble_emoji` package provides hand-drawn emoji sourced from [OpenMoji](https://openmoji.org/), rendered through the same rough SVG pipeline used for icons. Emoji are displayed with hand-drawn strokes and optional fill styles, matching the Skribble design language.
+
+---
+
+## Installation
+
+```bash
+dart pub add skribble_emoji
+```
+
+Import the package:
+
+```dart
+import 'package:skribble_emoji/skribble_emoji.dart';
+```
+
+---
+
+## WiredEmoji
+
+The primary widget for rendering a hand-drawn emoji. When the requested emoji data is `null` (not yet generated), a placeholder circle with a "?" character is shown.
+
+```dart
+// From explicit data
+WiredEmoji(data: lookupSkribbleEmojiByName('grinning_face'))
+
+// From name lookup
+WiredEmoji.fromName('grinning_face', size: 32)
+
+// From Unicode codepoint lookup
+WiredEmoji.fromUnicode(0x1f600, size: 32)
+```
+
+### Constructor parameters
+
+| Parameter | Type                | Default | Description                                          |
+| --------- | ------------------- | ------- | ---------------------------------------------------- |
+| `data`    | `WiredSvgIconData?` | `null`  | The emoji SVG data. Shows a placeholder when `null`. |
+| `size`    | `double`            | `24.0`  | The logical size of the emoji.                       |
+
+### Named constructors
+
+| Constructor              | Description                                                         |
+| ------------------------ | ------------------------------------------------------------------- |
+| `WiredEmoji.fromName`    | Looks up emoji by identifier string via `kSkribbleEmojiCodePoints`. |
+| `WiredEmoji.fromUnicode` | Looks up emoji by Unicode codepoint via `kSkribbleEmoji`.           |
+
+---
+
+## Available emoji
+
+The emoji catalog is generated from OpenMoji SVG sources through the Skribble rough icon pipeline. The catalog is populated by running the generator against the emoji manifest.
+
+The `kSkribbleEmoji` map contains all generated emoji keyed by Unicode codepoint, and `kSkribbleEmojiCodePoints` maps human-readable names to their codepoints.
+
+---
+
+## Lookup functions
+
+| Function                         | Return type         | Description                                 |
+| -------------------------------- | ------------------- | ------------------------------------------- |
+| `lookupSkribbleEmojiByName()`    | `WiredSvgIconData?` | Look up emoji by identifier string.         |
+| `lookupSkribbleEmojiByUnicode()` | `WiredSvgIconData?` | Look up emoji by Unicode codepoint integer. |
+
+### Examples
+
+```dart
+import 'package:skribble_emoji/skribble_emoji.dart';
+
+// Look up by name
+final grinning = lookupSkribbleEmojiByName('grinning_face');
+if (grinning != null) {
+  WiredEmoji(data: grinning, size: 48);
+}
+
+// Look up by Unicode codepoint
+final thumbsUp = lookupSkribbleEmojiByUnicode(0x1f44d);
+
+// Check available emoji count
+print('${kSkribbleEmoji.length} emoji available');
+
+// Iterate all emoji names
+for (final name in kSkribbleEmojiCodePoints.keys) {
+  print(name);
+}
+```
+
+---
+
+## How to add more emoji
+
+To add emoji to the catalog:
+
+1. Download SVG sources from [OpenMoji](https://openmoji.org/) or create your own simple path-based SVG files.
+2. Place the SVG files in the `packages/skribble_emoji/emoji/` directory.
+3. Create or update the emoji manifest JSON file with the mapping of names to SVG filenames and Unicode codepoints.
+4. Run the rough icon generator against the manifest:
+
+```bash
+cd packages/skribble &&
+dart run tool/generate_rough_icons.dart \
+  --kit svg-manifest \
+  --manifest ../skribble_emoji/tool/emoji.manifest.json \
+  --output ../skribble_emoji/lib/src/generated/skribble_emoji.g.dart \
+  --map-name kSkribbleEmoji
+```
+
+5. Update the `kSkribbleEmojiCodePoints` map in `skribble_emoji.dart` with entries for each new emoji.
+
+### SVG requirements
+
+- Emoji SVGs should use simple path, circle, and ellipse elements.
+- Complex SVG features (gradients, filters, masks, embedded images) are not supported.
+- Fill rules (`nonZero` and `evenOdd`) are preserved from the source SVG.
+- Keep SVGs clean and path-based for the best rough rendering results.

--- a/docs/site/content/widgets/icons.md
+++ b/docs/site/content/widgets/icons.md
@@ -237,6 +237,58 @@ final codePoints = materialRoughIconCodePoints;
 
 ---
 
+## skribble_icons package
+
+The `skribble_icons` package provides a curated set of 30 hand-drawn custom icons with a unified lookup API. It re-exports all Material rough icons from the main `skribble` package, giving you a single import for both custom and Material icons.
+
+### Installation
+
+```bash
+dart pub add skribble_icons
+```
+
+### Import
+
+```dart
+import 'package:skribble_icons/skribble_icons.dart';
+```
+
+### Curated custom icons
+
+The package includes 30 custom icons covering common UI actions:
+
+`home`, `search`, `settings`, `star`, `heart`, `user`, `menu`, `close`, `check`, `plus`, `minus`, `arrow_left`, `arrow_right`, `arrow_up`, `arrow_down`, `edit`, `delete`, `share`, `copy`, `mail`, `phone`, `camera`, `image`, `calendar`, `clock`, `lock`, `unlock`, `eye`, `eye_off`, `notification`.
+
+### Unified lookup API
+
+Look up any custom icon by its string identifier:
+
+```dart
+import 'package:skribble_icons/skribble_icons.dart';
+
+// Look up a custom icon by name
+final data = lookupSkribbleIconByIdentifier('star');
+if (data != null) {
+  WiredSvgIcon(data: data, size: 32);
+}
+```
+
+### Available exports
+
+| Export                           | Type                         | Description                                           |
+| -------------------------------- | ---------------------------- | ----------------------------------------------------- |
+| `kSkribbleIcons`                 | `Map<int, WiredSvgIconData>` | All custom icons keyed by codepoint.                  |
+| `kSkribbleIconsCodePoints`       | `Map<String, int>`           | Maps icon identifier strings to codepoints.           |
+| `lookupSkribbleIconByIdentifier` | `WiredSvgIconData? Function` | Returns icon data for a given identifier, or `null`.  |
+| `WiredSvgIconData`               | class                        | The SVG icon data type (re-exported from `skribble`). |
+| `WiredSvgPrimitive`              | class                        | SVG primitive types (re-exported from `skribble`).    |
+
+### Material icons
+
+All Material rough icons remain available through the main `skribble` package. The `skribble_icons` package focuses on the curated custom icon set. Use `WiredIcon(icon: Icons.home)` for Material icons and `WiredSvgIcon(data: ...)` for custom icons from `skribble_icons`.
+
+---
+
 ## Custom icon sets
 
 The `skribble_icons_custom` package provides tooling for generating rough icon catalogs from your own SVG icon sets.


### PR DESCRIPTION
## Summary

Wires the new `skribble_icons` and `skribble_emoji` packages into the storybook with dedicated showcase pages, and updates documentation across the site.

## Storybook changes

- **Skribble Icons page** — Grid of all 30 curated custom icons with identifier labels, total icon count (custom + Material), unified API explanation
- **Emoji page** — Grid of all 50 OpenMoji emoji via `WiredEmoji.fromName()`, emoji count
- **Home page** — Two new navigation cards for the new pages (10 categories total)
- **Dependencies** — `skribble_icons` and `skribble_emoji` added to storybook pubspec

## Documentation changes

- `widgets/icons.md` — New "skribble_icons package" section with unified API docs
- `widgets/emoji.md` — New page documenting WiredEmoji widget, lookups, and adding emoji
- `getting-started/installation.md` — "Optional companion packages" section
- `reference/api-overview.md` — New package export tables

## Test plan

- [x] All 64 storybook tests pass
- [x] `dart analyze --fatal-infos .` passes
- [x] Home page test updated for 10 category cards

Closes #114, closes #115