### PR TITLE
feat: wire pre-computed SkribbleIcon into storybook

### DIFF
--- a/apps/skribble_storybook/lib/pages/skribble_icons_page.dart
+++ b/apps/skribble_storybook/lib/pages/skribble_icons_page.dart
@@ -59,7 +59,7 @@ class SkribbleIconsPage extends HookWidget {
                     width: 72,
                     child: Column(
                       children: [
-                        WiredSvgIcon(
+                        SkribbleIcon(
                           data: lookupSkribbleIconByIdentifier(identifier)!,
                           size: 32,
                         ),


### PR DESCRIPTION
## Summary

Replace `WiredSvgIcon` with the pre-computed `SkribbleIcon` widget on the storybook's Skribble Icons page. This uses the 10-18x faster pre-computed rendering path for the icon grid.

The example app uses `Icons.*` (Material icons) via `WiredIcon` — no change needed there since those go through the Material rough icon lookup path.

## Test plan

- [x] All 64 storybook tests pass
- [x] All 41 example app tests pass
- [x] `dart analyze --fatal-infos .` passes