### PR TITLE
feat: add PrecomputedEmoji for fast emoji rendering

### DIFF
--- a/.changeset/emoji-precomputed.md
+++ b/.changeset/emoji-precomputed.md
@@ -1,0 +1,7 @@
+---
+skribble: patch
+---
+
+Add `PrecomputedEmoji` widget for fast emoji rendering without the rough engine.
+Same API as `WiredEmoji` (fromName, fromUnicode, placeholder fallback) but draws
+SVG paths directly via canvas.drawPath for performance-critical screens.

--- a/packages/skribble_emoji/lib/skribble_emoji.dart
+++ b/packages/skribble_emoji/lib/skribble_emoji.dart
@@ -17,6 +17,8 @@ export 'package:skribble_emoji/src/generated/skribble_emoji.g.dart'
     show kSkribbleEmoji;
 export 'package:skribble_emoji/src/generated/skribble_emoji_codepoints.g.dart'
     show kSkribbleEmojiCodePoints;
+export 'package:skribble_emoji/src/precomputed_emoji.dart'
+    show PrecomputedEmoji;
 export 'package:skribble_emoji/src/wired_emoji.dart' show WiredEmoji;
 export 'package:skribble_emoji/src/wired_svg_icon_data.dart'
     show

--- a/packages/skribble_emoji/lib/src/precomputed_emoji.dart
+++ b/packages/skribble_emoji/lib/src/precomputed_emoji.dart
@@ -1,0 +1,209 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:skribble_emoji/skribble_emoji.dart';
+
+/// Renders emoji by drawing pre-parsed SVG paths directly — no rough engine.
+///
+/// This is the fast rendering path for performance-critical screens. For
+/// runtime roughening with the Skribble rough engine, use [WiredEmoji] instead.
+///
+/// ```dart
+/// PrecomputedEmoji(data: kSkribbleEmoji[0x1f600]!)
+/// PrecomputedEmoji.fromName('grinning_face')
+/// PrecomputedEmoji.fromUnicode(0x1f600)
+/// ```
+class PrecomputedEmoji extends HookWidget {
+  /// Creates a [PrecomputedEmoji] from explicit [data].
+  ///
+  /// If [data] is `null`, a placeholder is shown.
+  const PrecomputedEmoji({
+    super.key,
+    this.data,
+    this.size = 24.0,
+    this.color,
+    this.semanticLabel,
+  });
+
+  /// Creates a [PrecomputedEmoji] by looking up the emoji [name].
+  PrecomputedEmoji.fromName(
+    String name, {
+    super.key,
+    this.size = 24.0,
+    this.color,
+    this.semanticLabel,
+  }) : data = lookupSkribbleEmojiByName(name);
+
+  /// Creates a [PrecomputedEmoji] by looking up the Unicode [codePoint].
+  PrecomputedEmoji.fromUnicode(
+    int codePoint, {
+    super.key,
+    this.size = 24.0,
+    this.color,
+    this.semanticLabel,
+  }) : data = lookupSkribbleEmojiByUnicode(codePoint);
+
+  /// The emoji data to render, or `null` to show a placeholder.
+  final WiredSvgIconData? data;
+
+  /// The logical size of the emoji. Defaults to 24.0.
+  final double size;
+
+  /// Emoji color. Falls back to [IconThemeData.color] or grey.
+  final Color? color;
+
+  /// Semantic label for accessibility.
+  final String? semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveData = data;
+    final effectiveColor =
+        color ?? IconTheme.of(context).color ?? Colors.grey.shade700;
+
+    if (effectiveData == null) {
+      return _buildPlaceholder(context, effectiveColor);
+    }
+
+    final primitives = useMemoized(
+      () => _preparePrimitives(data: effectiveData, emojiSize: size),
+      <Object?>[effectiveData, size],
+    );
+
+    Widget child = RepaintBoundary(
+      child: SizedBox.square(
+        dimension: size,
+        child: CustomPaint(
+          painter: _PrecomputedEmojiPainter(
+            primitives: primitives,
+            color: effectiveColor,
+            size: size,
+          ),
+        ),
+      ),
+    );
+
+    if (semanticLabel != null && semanticLabel!.isNotEmpty) {
+      child = Semantics(label: semanticLabel, image: true, child: child);
+    }
+
+    return child;
+  }
+
+  Widget _buildPlaceholder(BuildContext context, Color color) {
+    return SizedBox.square(
+      dimension: size,
+      child: CustomPaint(
+        painter: _PlaceholderCirclePainter(color: color),
+        child: Center(
+          child: Text(
+            '?',
+            style: TextStyle(
+              fontSize: size * 0.5,
+              fontWeight: FontWeight.bold,
+              color: color,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+List<_PreparedPrimitive> _preparePrimitives({
+  required WiredSvgIconData data,
+  required double emojiSize,
+}) {
+  final scale = math.min(emojiSize / data.width, emojiSize / data.height);
+  final translatedWidth = data.width * scale;
+  final translatedHeight = data.height * scale;
+  final dx = (emojiSize - translatedWidth) / 2;
+  final dy = (emojiSize - translatedHeight) / 2;
+
+  final transform = Float64List.fromList(<double>[
+    scale, 0, 0, 0, //
+    0, scale, 0, 0,
+    0, 0, 1, 0,
+    dx, dy, 0, 1,
+  ]);
+
+  return data.primitives
+      .map(
+        (primitive) =>
+            _PreparedPrimitive(path: primitive.buildPath().transform(transform)),
+      )
+      .toList(growable: false);
+}
+
+final class _PreparedPrimitive {
+  const _PreparedPrimitive({required this.path});
+
+  final Path path;
+}
+
+final class _PrecomputedEmojiPainter extends CustomPainter {
+  const _PrecomputedEmojiPainter({
+    required this.primitives,
+    required this.color,
+    required this.size,
+  });
+
+  final List<_PreparedPrimitive> primitives;
+  final Color color;
+  final double size;
+
+  @override
+  void paint(Canvas canvas, Size canvasSize) {
+    final fillPaint = Paint()
+      ..color = color
+      ..style = PaintingStyle.fill
+      ..isAntiAlias = true;
+
+    final outlinePaint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = math.max(0.5, size / 48)
+      ..strokeCap = StrokeCap.round
+      ..isAntiAlias = true;
+
+    for (final primitive in primitives) {
+      canvas
+        ..drawPath(primitive.path, fillPaint)
+        ..drawPath(primitive.path, outlinePaint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_PrecomputedEmojiPainter oldDelegate) {
+    return oldDelegate.primitives != primitives ||
+        oldDelegate.color != color ||
+        oldDelegate.size != size;
+  }
+}
+
+class _PlaceholderCirclePainter extends CustomPainter {
+  const _PlaceholderCirclePainter({required this.color});
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.5
+      ..strokeCap = StrokeCap.round
+      ..isAntiAlias = true;
+
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = (size.shortestSide / 2) - 1.5;
+    canvas.drawCircle(center, radius, paint);
+  }
+
+  @override
+  bool shouldRepaint(_PlaceholderCirclePainter oldDelegate) {
+    return oldDelegate.color != color;
+  }
+}

--- a/packages/skribble_emoji/test/skribble_emoji_test.dart
+++ b/packages/skribble_emoji/test/skribble_emoji_test.dart
@@ -267,4 +267,118 @@ void main() {
       expect(find.byType(WiredSvgIcon), findsOneWidget);
     });
   });
+
+  group('PrecomputedEmoji widget', () {
+    testWidgets('renders without error with valid data', (tester) async {
+      final data = lookupSkribbleEmojiByName('grinning_face');
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(child: PrecomputedEmoji(data: data)),
+          ),
+        ),
+      );
+
+      expect(find.byType(PrecomputedEmoji), findsOneWidget);
+      expect(find.byType(CustomPaint), findsWidgets);
+      expect(find.text('?'), findsNothing);
+    });
+
+    testWidgets('fromName renders known emoji', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: PrecomputedEmoji.fromName('thumbs_up', size: 48),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(PrecomputedEmoji), findsOneWidget);
+      expect(find.text('?'), findsNothing);
+    });
+
+    testWidgets('fromName shows placeholder for unknown name', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: PrecomputedEmoji.fromName('nonexistent_xyz'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(PrecomputedEmoji), findsOneWidget);
+      expect(find.text('?'), findsOneWidget);
+    });
+
+    testWidgets('fromUnicode renders known emoji', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: PrecomputedEmoji.fromUnicode(0x1f525, size: 36),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(PrecomputedEmoji), findsOneWidget);
+      expect(find.text('?'), findsNothing);
+    });
+
+    testWidgets('respects custom size', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: PrecomputedEmoji.fromName('fire', size: 64),
+            ),
+          ),
+        ),
+      );
+
+      final sizedBox = tester.widget<SizedBox>(
+        find.descendant(
+          of: find.byType(PrecomputedEmoji),
+          matching: find.byType(SizedBox),
+        ),
+      );
+      expect(sizedBox.width, 64);
+      expect(sizedBox.height, 64);
+    });
+
+    testWidgets('does not use WiredSvgIcon (no rough engine)', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: PrecomputedEmoji.fromName('grinning_face'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(WiredSvgIcon), findsNothing);
+    });
+
+    testWidgets('adds semantics label when provided', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: PrecomputedEmoji(
+                data: lookupSkribbleEmojiByName('star'),
+                semanticLabel: 'star emoji',
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.bySemanticsLabel('star emoji'), findsOneWidget);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Adds `PrecomputedEmoji` widget that draws emoji SVG paths directly via `canvas.drawPath` — no rough engine computation. Same API as `WiredEmoji` for easy switching.

## Rendering options

| Widget            | Rendering | Performance | Use case                          |
| ----------------- | --------- | ----------- | --------------------------------- |
| `WiredEmoji`      | Runtime   | Baseline    | Dynamic roughness, fill control   |
| `PrecomputedEmoji`| Direct    | Fast        | Emoji grids, chat, perf-critical  |

## API

```dart
// Fast (direct path drawing):
PrecomputedEmoji.fromName('grinning_face', size: 32)
PrecomputedEmoji.fromUnicode(0x1f600, size: 32)

// Dynamic (rough engine):
WiredEmoji.fromName('grinning_face', size: 32)
```

## Test plan

- [x] 28 tests pass (7 new PrecomputedEmoji tests)
- [x] `dart analyze --fatal-infos .` passes
- [x] Verified WiredSvgIcon is NOT used (no rough engine)
- [x] Placeholder behavior matches WiredEmoji